### PR TITLE
Prefetched pretoken-cache encode pipeline + single-pass allocation fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,6 +1112,7 @@ dependencies = [
  "icu_codepointtrie_builder",
  "indicatif",
  "itertools 0.15.0",
+ "libc",
  "memchr",
  "memmap2",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ flate2 = "1.1"
 zstd = "0.13"
 spm_precompiled = "0.1.4"
 
+# madvise(MADV_HUGEPAGE) for the pretoken-cache table (already in the tree
+# transitively via memmap2/pyo3).
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [profile.release]
 lto = "fat"
 

--- a/benches/encode_doc.rs
+++ b/benches/encode_doc.rs
@@ -2,9 +2,9 @@
 //! `BPETokenizer.encode_files` on a single plain-text file: the entire input
 //! is ONE document handed to the library's parallel encode path
 //! (`encode_docs_ragged`), which splits it at pretoken-safe boundaries
-//! (token-identical to a serial pass), encodes with a persistent worker
-//! pool, and gathers one flat id buffer. Five rounds, so warm rounds show
-//! the retained worker caches.
+//! (token-identical to a serial pass), encodes with a pooled worker per
+//! thread, and gathers one flat id buffer. Five rounds, each with a fresh
+//! worker pool so every round is a cold-cache sample.
 //!
 //! Run with: cargo bench --bench encode_doc              (2 GB default)
 //!           ENCODE_MB=500 cargo bench --bench encode_doc
@@ -31,10 +31,13 @@ fn main() {
     let size_mb = input.len() as f64 / 1e6;
     eprintln!("1 document, {} threads\n", rayon::current_num_threads());
 
-    // Persistent worker pool, retained across rounds like the binding's —
-    // pretoken caches stay warm after round 0.
-    let workers = WorkerPool::new();
     for round in 0..5 {
+        // Fresh worker pool every round: the pool retains one forked
+        // tokenizer (and its pretoken caches) per rayon thread, so reusing
+        // it would measure warm-cache reruns of the same input rather than
+        // realistic first-pass encoding. Each round is an independent
+        // cold-cache sample.
+        let workers = WorkerPool::new();
         let t0 = Instant::now();
         let (flat, lens) = encode_docs_ragged(&workers, &tokenizer, &[&input]);
         black_box((&flat, lens));

--- a/benches/encode_doc.rs
+++ b/benches/encode_doc.rs
@@ -2,9 +2,15 @@
 //! `BPETokenizer.encode_files` on a single plain-text file: the entire input
 //! is ONE document handed to the library's parallel encode path
 //! (`encode_docs_ragged`), which splits it at pretoken-safe boundaries
-//! (token-identical to a serial pass), encodes with a pooled worker per
-//! thread, and gathers one flat id buffer. Five rounds, each with a fresh
-//! worker pool so every round is a cold-cache sample.
+//! (token-identical to a serial pass), encodes with a persistent worker
+//! pool, and gathers one flat id buffer.
+//!
+//! One round per process by default: a first pass over a fresh dataset is
+//! the workload that matters, and everything a second in-process round
+//! reuses — worker pretoken caches, allocator arenas, faulted pages, grown
+//! buffer capacities — makes later rounds unrealistically fast. Restart the
+//! binary to collect independent samples; ENCODE_ROUNDS>1 remains available
+//! for cache-behavior experiments.
 //!
 //! Run with: cargo bench --bench encode_doc              (2 GB default)
 //!           ENCODE_MB=500 cargo bench --bench encode_doc
@@ -21,6 +27,13 @@ mod common;
 const DEFAULT_MB: usize = 2000;
 
 fn main() {
+    // Some session managers launch children with PR_SET_THP_DISABLE, which
+    // silently vetoes MADV_HUGEPAGE; clear it so the bench measures the
+    // tokenizer, not the launcher's memory policy (same as encode_st).
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::prctl(libc::PR_SET_THP_DISABLE, 0, 0, 0, 0);
+    }
     let tokenizer_json = std::env::var("TOKENIZER_JSON")
         .unwrap_or_else(|_| "data/olmo3_tokenizer.json".to_string());
     let tokenizer_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(&tokenizer_json);
@@ -31,12 +44,14 @@ fn main() {
     let size_mb = input.len() as f64 / 1e6;
     eprintln!("1 document, {} threads\n", rayon::current_num_threads());
 
-    for round in 0..5 {
-        // Fresh worker pool every round: the pool retains one forked
-        // tokenizer (and its pretoken caches) per rayon thread, so reusing
-        // it would measure warm-cache reruns of the same input rather than
-        // realistic first-pass encoding. Each round is an independent
-        // cold-cache sample.
+    let rounds: usize = std::env::var("ENCODE_ROUNDS")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(1);
+    for round in 0..rounds {
+        // Fresh worker pool per round so extra rounds at least start with
+        // cold pretoken caches (the pool retains one forked tokenizer per
+        // rayon thread).
         let workers = WorkerPool::new();
         let t0 = Instant::now();
         let (flat, lens) = encode_docs_ragged(&workers, &tokenizer, &[&input]);

--- a/benches/encode_st.rs
+++ b/benches/encode_st.rs
@@ -5,10 +5,25 @@ use std::time::Instant;
 
 mod common;
 fn main() {
-    let tokenizer_path =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/gpt2_tokenizer.json");
-    eprintln!("Loading GPT-2 tokenizer from {tokenizer_path:?}...");
-    let mut tokenizer = load_hf_bpe(&tokenizer_path).expect("Could not load GPT-2 tokenizer");
+    // The pretoken cache madvises its table to 2 MiB pages (the table far
+    // exceeds 4 KiB dTLB coverage, and Zen drops software prefetches that
+    // miss the TLB). Some session managers launch children with
+    // PR_SET_THP_DISABLE, which silently vetoes MADV_HUGEPAGE; clear it so
+    // the bench measures the tokenizer, not the launcher's memory policy.
+    #[cfg(target_os = "linux")]
+    unsafe {
+        libc::prctl(libc::PR_SET_THP_DISABLE, 0, 0, 0, 0);
+    }
+    // ENCODE_TOKENIZER overrides the tokenizer.json (e.g.
+    // data/qwen3_tokenizer.json to bench the qwen2-scheme encode path);
+    // encoding then runs through the scheme dispatch instead of the
+    // hardcoded r50k pretokenizer.
+    let tokenizer_override = std::env::var("ENCODE_TOKENIZER").ok().map(PathBuf::from);
+    let tokenizer_path = tokenizer_override.clone().unwrap_or_else(|| {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/gpt2_tokenizer.json")
+    });
+    eprintln!("Loading tokenizer from {tokenizer_path:?}...");
+    let mut tokenizer = load_hf_bpe(&tokenizer_path).expect("Could not load tokenizer");
 
     let input = common::load_owt_input(None);
     let size_gb = input.len() as f64 / 1e9;
@@ -16,17 +31,36 @@ fn main() {
     // handles newlines itself, so pre-splitting into lines is unnecessary).
     let buf: &[u8] = &input;
 
+    // ENCODE_PASSES=N re-encodes the same buffer N times; passes after the
+    // first run with a fully warm pretoken cache, isolating the hit path.
+    let passes: usize = std::env::var("ENCODE_PASSES")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(1);
     eprintln!("Encoding (single-threaded)...");
-    let start = Instant::now();
-    let mut total_tokens: usize = 0;
-    tokenizer.memoized_encode(FastR50kPretokenizer::new(buf), |tokens| {
-        total_tokens += tokens.len();
-    });
-    let elapsed = start.elapsed().as_secs_f64();
-    let throughput_gb = size_gb / elapsed;
+    for pass in 0..passes {
+        let start = Instant::now();
+        let mut total_tokens: usize = 0;
+        if tokenizer_override.is_some() {
+            let pretokens = tokenizer.pretokenizer_type().pretokenize(buf);
+            tokenizer.memoized_encode(pretokens, |tokens| {
+                total_tokens += tokens.len();
+            });
+        } else {
+            tokenizer.memoized_encode(FastR50kPretokenizer::new(buf), |tokens| {
+                total_tokens += tokens.len();
+            });
+        }
+        let elapsed = start.elapsed().as_secs_f64();
+        let throughput_gb = size_gb / elapsed;
 
+        eprintln!(
+            "pass {pass}: {total_tokens} tokens in {elapsed:.2}s — {throughput_gb:.2} GB/s ({:.0} MB/s)",
+            throughput_gb * 1000.0
+        );
+    }
+    let (sl, sc, ll, lc, lkb, al, ac) = tokenizer.cache_mem_stats();
     eprintln!(
-        "{total_tokens} tokens in {elapsed:.2}s — {throughput_gb:.2} GB/s ({:.0} MB/s)",
-        throughput_gb * 1000.0
+        "cache: short {sl} entries (cap {sc}), long {ll} (cap {lc}, {lkb} key bytes), arena {al} tokens (cap {ac})"
     );
 }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -28,9 +28,7 @@ pub(crate) fn chunk_target_bytes(total_bytes: usize) -> usize {
 pub(crate) fn encode_into(tokenizer: &mut Tokenizer, doc: &[u8], ids: &mut Vec<u32>, lens: &mut Vec<i64>) {
     let before = ids.len();
     tokenizer.encode_with_added_tokens(doc, |tokens| {
-        for &e in tokens {
-            ids.push(e.into())
-        }
+        ids.extend(tokens.iter().map(|&t| u32::from(t)))
     });
     lens.push((ids.len() - before) as i64);
 }
@@ -96,7 +94,15 @@ pub(crate) struct ChunkTokens {
 }
 
 fn encode_chunk(tokenizer: &mut Tokenizer, chunk: &EncodeChunk) -> ChunkTokens {
-    let mut ids = Vec::new();
+    // Reserve the output once, from a bytes-per-token estimate on the low
+    // side of natural language (~4.4 on OWT/GPT-2). Growing from empty
+    // instead re-copies roughly the final size in doublings — per chunk,
+    // on every chunk of a first pass.
+    let byte_len = match chunk {
+        EncodeChunk::Docs(docs) => docs.iter().map(|d| d.len()).sum::<usize>(),
+        EncodeChunk::Region { bytes, .. } | EncodeChunk::Fragment { bytes, .. } => bytes.len(),
+    };
+    let mut ids = Vec::with_capacity(byte_len / 4 + 16);
     let mut lens = Vec::new();
     let mut continues = false;
     match chunk {
@@ -207,6 +213,21 @@ pub(crate) fn assemble_ragged(chunks: Vec<ChunkTokens>) -> (Vec<u32>, Vec<i64>) 
     }
     let total: usize = chunks.iter().map(|c| c.ids.len()).sum();
     let mut flat = vec![0u32; total];
+    // Ask for 2 MiB pages before first touch: the parallel copy below
+    // faults in the whole (multi-GB) buffer, and huge pages cut the fault
+    // count ~500x. No-op where THP is unavailable.
+    #[cfg(target_os = "linux")]
+    if total > 0 {
+        // SAFETY: the range is exactly this allocation; MADV_HUGEPAGE only
+        // hints page sizing.
+        unsafe {
+            libc::madvise(
+                flat.as_mut_ptr() as *mut libc::c_void,
+                total * std::mem::size_of::<u32>(),
+                libc::MADV_HUGEPAGE,
+            );
+        }
+    }
     let mut rest: &mut [u32] = &mut flat;
     let mut slices = Vec::with_capacity(chunks.len());
     for chunk in &chunks {

--- a/src/bpe/mod.rs
+++ b/src/bpe/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod pretoken_cache;
 pub mod sentencepiece;
 pub mod tiktoken;
 
@@ -108,6 +109,10 @@ pub fn bpe_merge_symbols<S: std::hash::BuildHasher>(
 /// Like [`bpe_merge_symbols`], but reuses caller-provided scratch buffers so
 /// repeated calls (one per cache-missing pretoken) do not allocate. Merges
 /// `symbols` in place.
+// Out of line: this only runs on pretoken-cache misses (~0.7% of
+// pretokens on OWT), and inlining its bulk into the encode loop costs
+// more in I-cache and register pressure there than a call costs here.
+#[inline(never)]
 pub fn bpe_merge_symbols_with_scratch<S: std::hash::BuildHasher>(
     merges: &HashMap<(TokenId, TokenId), TokenId, S>,
     symbols: &mut Vec<TokenId>,

--- a/src/bpe/pretoken_cache.rs
+++ b/src/bpe/pretoken_cache.rs
@@ -1,0 +1,215 @@
+//! Open-addressing cache for short (≤ 15 byte) pretoken encodings, replacing
+//! the `HashMap<u128, (u32, u32)>` it grew out of. Three properties of the
+//! encode loop drive the design (measured on 1 GB OWT, Zen 2):
+//!
+//! - The table holds ~1.3M unique pretokens (~99.4% hit rate), far beyond
+//!   L2/L3, so a lookup in the Zipf tail is a random DRAM access. hashbrown
+//!   spends two cache lines per probe (control bytes + entry); this table's
+//!   32-byte entries are self-contained, so a probe touches exactly one
+//!   line, and [`Self::prefetch`] lets the encode loop request that line a
+//!   chunk ahead of the probe, hiding the miss latency behind other work
+//!   instead of stalling on it.
+//! - 228M output tokens / 208M pretokens: ~90% of pretokens encode to ONE
+//!   token and ~98% to at most two. The value is a single packed `u64`
+//!   (see `tiktoken::pack_fast_val_inline`) holding those tokens inline —
+//!   one dependent load, and no second random access into the token arena.
+//! - At ~64 MB the table also blows the dTLB through 4 KiB pages, so the
+//!   backing memory is 2 MiB-aligned and `MADV_HUGEPAGE`d — with THP
+//!   available the whole table sits in a few dozen dTLB entries. (Note:
+//!   processes launched under `PR_SET_THP_DISABLE` — some sandboxes and
+//!   session managers do this — silently get 4 KiB pages anyway.)
+//!
+//! Linear probing; growth doubles at 3/4 load. Key 0 marks empty slots: a
+//! real key always has its nonzero length in the top byte
+//! (`pack_pretoken_key` tags length; empty pretokens pack to key 0, which
+//! the encode loop routes to the long map, never here).
+
+use std::alloc::{Layout, alloc_zeroed, dealloc, handle_alloc_error};
+use std::ptr::NonNull;
+
+/// One slot: the packed pretoken key plus its packed encoding.
+/// 24 data bytes pad to 32 with `u128` alignment: two slots per cache
+/// line, never straddling one.
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct Entry {
+    key: u128,
+    val: u64,
+}
+
+const EMPTY_KEY: u128 = 0;
+
+/// The table's slot array: a manually managed, zeroed (== all-empty,
+/// since `EMPTY_KEY` is 0), 2 MiB-aligned allocation marked
+/// `MADV_HUGEPAGE`. A plain `Box<[Entry]>` can neither over-align nor
+/// keep dealloc's layout in sync with an over-aligned alloc.
+struct Slots {
+    ptr: NonNull<Entry>,
+    cap: usize,
+}
+
+impl Slots {
+    const HUGE_PAGE: usize = 2 * 1024 * 1024;
+
+    fn new_zeroed(cap: usize) -> Self {
+        let layout = Self::layout(cap);
+        // SAFETY: layout has nonzero size (cap >= 1).
+        let raw = unsafe { alloc_zeroed(layout) };
+        let Some(ptr) = NonNull::new(raw as *mut Entry) else {
+            handle_alloc_error(layout)
+        };
+        #[cfg(target_os = "linux")]
+        // SAFETY: the range is exactly this fresh allocation, 2 MiB-aligned;
+        // MADV_HUGEPAGE only hints page sizing and cannot invalidate it.
+        unsafe {
+            libc::madvise(raw as *mut libc::c_void, layout.size(), libc::MADV_HUGEPAGE);
+        }
+        Self { ptr, cap }
+    }
+
+    fn layout(cap: usize) -> Layout {
+        let size = cap * std::mem::size_of::<Entry>();
+        // Huge-page alignment only once the table outgrows one huge page;
+        // small tables (fresh tokenizers encoding little text) stay modest.
+        let align = Self::HUGE_PAGE
+            .min(size.next_power_of_two())
+            .max(std::mem::align_of::<Entry>());
+        Layout::from_size_align(size, align).expect("table layout overflow")
+    }
+
+    #[inline(always)]
+    unsafe fn get(&self, idx: usize) -> &Entry {
+        debug_assert!(idx < self.cap);
+        // SAFETY: caller guarantees idx < cap.
+        unsafe { &*self.ptr.as_ptr().add(idx) }
+    }
+
+    #[inline(always)]
+    unsafe fn get_mut(&mut self, idx: usize) -> &mut Entry {
+        debug_assert!(idx < self.cap);
+        // SAFETY: caller guarantees idx < cap.
+        unsafe { &mut *self.ptr.as_ptr().add(idx) }
+    }
+}
+
+impl Drop for Slots {
+    fn drop(&mut self) {
+        // SAFETY: allocated in `new_zeroed` with this exact layout.
+        unsafe { dealloc(self.ptr.as_ptr() as *mut u8, Self::layout(self.cap)) };
+    }
+}
+
+// SAFETY: Slots owns its allocation exclusively, like Box<[Entry]>.
+unsafe impl Send for Slots {}
+unsafe impl Sync for Slots {}
+
+pub(crate) struct ShortPretokenCache {
+    slots: Slots,
+    /// `cap - 1` (capacity is a power of two).
+    mask: usize,
+    len: usize,
+}
+
+impl ShortPretokenCache {
+    pub(crate) fn new() -> Self {
+        Self::with_pow2_capacity(1 << 16)
+    }
+
+    fn with_pow2_capacity(cap: usize) -> Self {
+        debug_assert!(cap.is_power_of_two());
+        Self { slots: Slots::new_zeroed(cap), mask: cap - 1, len: 0 }
+    }
+
+    /// Request the probe's cache line ahead of [`Self::get`]. The encode
+    /// loop calls this a chunk of pretokens early; by probe time the line
+    /// is (usually) in L1 regardless of where it started.
+    #[inline(always)]
+    pub(crate) fn prefetch(&self, h: u64) {
+        let idx = (h as usize) & self.mask;
+        // SAFETY: idx <= mask < cap.
+        let p = unsafe { self.slots.ptr.as_ptr().add(idx) };
+        #[cfg(target_arch = "x86_64")]
+        // SAFETY: prefetch has no memory effects; any address is allowed.
+        unsafe {
+            core::arch::x86_64::_mm_prefetch(p as *const i8, core::arch::x86_64::_MM_HINT_T0);
+        }
+        #[cfg(target_arch = "aarch64")]
+        // SAFETY: prefetch has no memory effects; any address is allowed.
+        unsafe {
+            core::arch::asm!(
+                "prfm pldl1keep, [{p}]",
+                p = in(reg) p,
+                options(nostack, preserves_flags, readonly)
+            );
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        let _ = p;
+    }
+
+    /// Look up `key`, returning its packed value.
+    #[inline(always)]
+    pub(crate) fn get(&self, key: u128, h: u64) -> Option<u64> {
+        let mut idx = (h as usize) & self.mask;
+        loop {
+            // SAFETY: idx is masked to the table.
+            let e = unsafe { self.slots.get(idx) };
+            if e.key == key {
+                return Some(e.val);
+            }
+            if e.key == EMPTY_KEY {
+                return None;
+            }
+            idx = (idx + 1) & self.mask;
+        }
+    }
+
+    /// Insert a key known to be absent (the encode loop only inserts after
+    /// a [`Self::get`] miss).
+    pub(crate) fn insert(&mut self, key: u128, h: u64, val: u64) {
+        debug_assert_ne!(key, EMPTY_KEY);
+        if (self.len + 1) * 4 > self.slots.cap * 3 {
+            self.grow();
+        }
+        let mut idx = (h as usize) & self.mask;
+        // SAFETY: idx is masked; load < 1 guarantees an empty slot exists.
+        unsafe {
+            while self.slots.get(idx).key != EMPTY_KEY {
+                idx = (idx + 1) & self.mask;
+            }
+            *self.slots.get_mut(idx) = Entry { key, val };
+        }
+        self.len += 1;
+    }
+
+    #[cold]
+    fn grow(&mut self) {
+        let new_cap = self.slots.cap * 2;
+        let old = std::mem::replace(&mut self.slots, Slots::new_zeroed(new_cap));
+        self.mask = new_cap - 1;
+        for i in 0..old.cap {
+            // SAFETY: i < old.cap.
+            let e = *unsafe { old.get(i) };
+            if e.key == EMPTY_KEY {
+                continue;
+            }
+            // Must be the same hash the inserts' `h` came from.
+            let mut idx =
+                (crate::pretokenize::pretoken_key_hash(e.key) as usize) & self.mask;
+            // SAFETY: idx is masked; the doubled table has empty slots.
+            unsafe {
+                while self.slots.get(idx).key != EMPTY_KEY {
+                    idx = (idx + 1) & self.mask;
+                }
+                *self.slots.get_mut(idx) = e;
+            }
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn capacity(&self) -> usize {
+        self.slots.cap
+    }
+}

--- a/src/bpe/sentencepiece.rs
+++ b/src/bpe/sentencepiece.rs
@@ -1,5 +1,5 @@
 use crate::bpe::bpe_merge_symbols_ranked;
-use crate::bpe::tiktoken::pack_pretoken_key;
+use crate::pretokenize::pack_pretoken_key;
 use crate::token::TokenId;
 use rustc_hash::FxBuildHasher;
 use std::borrow::Cow;

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1,8 +1,9 @@
+use crate::bpe::pretoken_cache::ShortPretokenCache;
 use crate::bpe::{ByteRemapping, MergeScratch, bpe_merge_symbols_with_scratch, simple_bpe_merge};
 use crate::pretokenize::{
     FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastOlmo3Pretokenizer,
-    FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer, Pretoken,
-    PretokenizerType,
+    FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer, PRETOKEN_CHUNK,
+    Pretoken, PretokenSpans, PretokenizerType,
 };
 use crate::token::TokenId;
 use eyre::Result;
@@ -20,21 +21,18 @@ pub struct Tokenizer {
     pub(crate) vocab: Vec<Arc<[u8]>>,
     pub(crate) vocab_inv: HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
     pub(crate) byte_remapping: Option<ByteRemapping>,
-    /// Append-only arena of encoded token IDs. Cache entries store
-    /// `(offset, len)` slices into this vector, avoiding per-entry
-    /// `Arc` allocations and atomic refcount bumps on every cache hit.
+    /// Append-only arena of encoded token IDs. Cache entries for encodings
+    /// of 3+ tokens store `(offset, len)` slices into this vector; shorter
+    /// encodings (~98% of hit occurrences) live inline in the cache entry
+    /// and never touch it.
     token_arena: Vec<TokenId>,
-    /// Pretoken cache for the common case (≤ 15 bytes, ~99.9% of pretokens).
-    /// The key packs the bytes into the low 15 bytes and the length into the
-    /// top byte of a `u128`, so lookups are a single inlined 128-bit compare
-    /// instead of a `memcmp` call, and hashing is two multiply-mixes instead of
-    /// a byte loop. Keys are `Copy`, so cache misses no longer allocate.
-    pretoken_cache: HashMap<u128, (u32, u32), rustc_hash::FxBuildHasher>,
-    /// Direct-mapped front cache for packed pretokens. Natural-language
-    /// pretokens are heavily Zipf-distributed, so most hits avoid probing the
-    /// much larger SwissTable. Each entry keeps its key and arena range
-    /// together so a hit usually requires one cache-line fetch.
-    pretoken_front: Vec<PretokenFrontEntry>,
+    /// Pretoken cache for the common case (≤ 15 bytes, ~99.9% of
+    /// pretokens). The key packs the bytes into the low 15 bytes and the
+    /// length into the top byte of a `u128`, so lookups are a single
+    /// inlined 128-bit compare instead of a `memcmp` call. See
+    /// `pretoken_cache.rs` for why this is a custom prefetchable table
+    /// rather than a `HashMap`.
+    pretoken_cache: ShortPretokenCache,
     /// Fallback cache for pretokens longer than 15 bytes.
     pretoken_cache_long: HashMap<Box<[u8]>, (u32, u32), rustc_hash::FxBuildHasher>,
     /// Scratch buffers reused across cache-missing pretokens so the merge loop
@@ -56,32 +54,6 @@ pub struct Tokenizer {
     /// Apply NFC normalization to non-added-token segments before
     /// pretokenization, like HuggingFace's `NFC` normalizer (e.g. Qwen2).
     normalize_nfc: bool,
-}
-
-/// A 24-byte front-cache entry. Splitting the `u128` key into two words avoids
-/// the 16-byte alignment padding that would otherwise make this 32 bytes.
-#[derive(Clone, Copy, Default)]
-struct PretokenFrontEntry {
-    key_lo: u64,
-    key_hi: u64,
-    value: u64,
-}
-
-impl PretokenFrontEntry {
-    #[inline(always)]
-    fn new(key: u128, offset: u32, len: u32) -> Self {
-        Self {
-            key_lo: key as u64,
-            key_hi: (key >> 64) as u64,
-            value: offset as u64 | ((len as u64) << 32),
-        }
-    }
-
-    #[inline(always)]
-    fn get(self, key: u128) -> Option<(u32, u32)> {
-        (self.key_lo == key as u64 && self.key_hi == (key >> 64) as u64)
-            .then_some((self.value as u32, (self.value >> 32) as u32))
-    }
 }
 
 /// NFC-normalize a segment if needed, using `buf` as scratch on the slow path.
@@ -106,73 +78,22 @@ fn nfc_segment<'a>(seg: &'a [u8], buf: &'a mut String) -> &'a [u8] {
     buf.as_bytes()
 }
 
-/// Pack a pretoken of ≤ 15 bytes into a `u128`: bytes in the low 15 lanes,
-/// length in the top byte. Returns `None` for longer pretokens, which use the
-/// `Box<[u8]>` fallback map. Encoding the length means two pretokens of
-/// different length can never collide.
-///
-/// The common path is a single unaligned 16-byte load followed by a mask, which
-/// avoids both the variable-length `copy_from_slice` (a `memcpy` libc call) and
-/// any per-byte branching. The load is only taken when it cannot cross a page
-/// boundary, so it can never touch an unmapped page; the rare near-boundary case
-/// falls back to a plain copy. Both paths produce the identical key.
-/// Per-length `(mask, length-tag)` pairs for [`pack_pretoken_key`]: one 512-byte
-/// L1-resident table lookup replaces a 128-bit variable shift + sub + tag shift
-/// (u128 shifts lower to a multi-instruction sequence on aarch64).
-const PACK_MASK_TAG: [(u128, u128); 16] = {
-    let mut t = [(0u128, 0u128); 16];
-    let mut n = 0;
-    while n < 16 {
-        let mask = if n == 0 { 0 } else { u128::MAX >> (8 * (16 - n)) };
-        t[n] = (mask, (n as u128) << 120);
-        n += 1;
-    }
-    t
-};
-
-/// Log2 of the direct-mapped packed-pretoken front cache size. 2^18 entries use
-/// 6 MiB per tokenizer and retain the broad working set while the authoritative
-/// HashMap keeps every key.
-const PRETOKEN_FRONT_BITS: u32 = 18;
+/// Cache-value packing (shared by the short-pretoken table and decode in
+/// the encode loop). Low byte: token count in bits 0-6 plus a "spilled"
+/// flag in bit 7. Inline values (1-2 tokens, each ID < 2^24 — true of
+/// every real vocab) carry the IDs in bits 8-31 and 32-55; spilled values
+/// carry the token-arena offset in the high 32 bits.
+const VAL_SPILL: u64 = 0x80;
 
 #[inline(always)]
-fn pretoken_cache_hash(key: u128) -> u64 {
-    let folded = (key as u64) ^ ((key >> 64) as u64);
-    folded.wrapping_mul(0x9E37_79B9_7F4A_7C15)
-}
-
-#[inline(always)]
-fn pretoken_front_index(hash: u64) -> usize {
-    (hash >> (64 - PRETOKEN_FRONT_BITS)) as usize
-}
-
-#[inline(always)]
-pub(crate) fn pack_pretoken_key(bytes: &[u8]) -> Option<u128> {
-    let n = bytes.len();
-    if n > 15 {
-        return None;
+fn pack_val_inline(symbols: &[TokenId]) -> Option<u64> {
+    match *symbols {
+        [a] if a.0 < (1 << 24) => Some(1 | ((a.0 as u64) << 8)),
+        [a, b] if a.0 < (1 << 24) && b.0 < (1 << 24) => {
+            Some(2 | ((a.0 as u64) << 8) | ((b.0 as u64) << 32))
+        }
+        _ => None,
     }
-    if n == 0 {
-        return Some(0);
-    }
-    let p = bytes.as_ptr();
-    // Keep the low `n` bytes, zero the rest; lane 15 stays zero, ready for the
-    // length tag.
-    let (mask, tag) = PACK_MASK_TAG[n];
-    let low = if (p as usize) & 4095 <= 4096 - 16 {
-        // SAFETY: the offset within the (≥ 4096-byte) page is ≤ 4096 - 16, so a
-        // 16-byte read stays inside the page holding `p`, which is mapped
-        // because `p` points to at least one valid byte.
-        let v = unsafe { (p as *const u128).read_unaligned() };
-        v & mask
-    } else {
-        // Rare: `p` is within 16 bytes of a page boundary. Gather with a plain
-        // copy (≤ 15 bytes) — correctness over speed on this cold path.
-        let mut lanes = [0u8; 16];
-        lanes[..n].copy_from_slice(bytes);
-        u128::from_le_bytes(lanes) & mask
-    };
-    Some(low | tag)
 }
 
 impl Tokenizer {
@@ -193,8 +114,7 @@ impl Tokenizer {
             vocab,
             byte_remapping,
             token_arena: Vec::new(),
-            pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
-            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
+            pretoken_cache: ShortPretokenCache::new(),
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -241,8 +161,7 @@ impl Tokenizer {
             vocab,
             vocab_inv,
             token_arena: Vec::new(),
-            pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
-            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
+            pretoken_cache: ShortPretokenCache::new(),
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -262,8 +181,7 @@ impl Tokenizer {
             vocab_inv: self.vocab_inv.clone(),
             byte_remapping: self.byte_remapping.clone(),
             token_arena: Vec::new(),
-            pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
-            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
+            pretoken_cache: ShortPretokenCache::new(),
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -424,79 +342,132 @@ impl Tokenizer {
     /// For each pretoken in the input iterator, looks up the string in the
     /// cache, and if not found, encodes it and inserts it into the cache.
     /// Calls `f` with the encoded token slice for each pretoken.
+    ///
+    /// Runs in chunks of `CHUNK` pretokens through three phases — pull
+    /// spans from the pretokenizer, then key/hash/prefetch every span,
+    /// then probe and emit. The phase split serves two purposes:
+    /// - every cache probe was prefetched a phase earlier (hundreds of
+    ///   cycles: the ~1.3M-entry table on 1 GB OWT is far beyond L3, and
+    ///   unpipelined tail lookups were ~60-cycle stalls dominating encode);
+    /// - each phase is a tight loop over plain arrays, keeping the
+    ///   pretokenizer's state hot in one and letting the key/hash math
+    ///   schedule with high ILP in another instead of interleaving with
+    ///   the branchy probe/emit code.
     pub fn memoized_encode<'i>(
         &mut self,
-        pretoken_iter: impl Iterator<Item = Pretoken<'i>>,
+        mut pretokens: impl PretokenSpans<'i>,
         mut f: impl FnMut(&[TokenId]),
     ) {
-        for pretoken in pretoken_iter {
-            let bytes = pretoken.as_ref();
-            // Look up the cached encoding. Short pretokens (the overwhelming
-            // majority) use the packed `u128` map; the rare long ones fall back
-            // to the slice-keyed map. The key is computed once and reused on the
-            // miss path's insert.
-            let key = pack_pretoken_key(bytes);
-            // Packed key zero represents an empty pretoken and is reserved as
-            // the front cache's empty sentinel. Real pretokenizers never yield
-            // empty slices, but keep the public iterator API correct for one.
-            let front_key = key.filter(|&key| key != 0);
-            let mut front_idx = 0;
-            if let Some(key) = front_key {
-                let hash = pretoken_cache_hash(key);
-                front_idx = pretoken_front_index(hash);
-                // SAFETY: pretoken_front_index returns PRETOKEN_FRONT_BITS bits
-                // and the array has exactly 2^PRETOKEN_FRONT_BITS entries.
-                if let Some((offset, len)) =
-                    unsafe { *self.pretoken_front.get_unchecked(front_idx) }.get(key)
-                {
-                    let start = offset as usize;
-                    // SAFETY: front entries are copied from authoritative cache
-                    // entries, whose arena ranges remain valid forever.
-                    f(unsafe { self.token_arena.get_unchecked(start..start + len as usize) });
-                    continue;
+        let mut spans: [&[u8]; PRETOKEN_CHUNK] = [&[]; PRETOKEN_CHUNK];
+        // Packed key (0 = long pretoken, routed to the slice-keyed map;
+        // real keys are never 0 since the length tag is nonzero) and hash.
+        let mut keys = [0u128; PRETOKEN_CHUNK];
+        let mut hashes = [0u64; PRETOKEN_CHUNK];
+        loop {
+            // Pull phase: a chunk of pretoken spans with keys and hashes
+            // derived and their probe lines prefetched on the way out (out
+            // of line, fused with the span walker — see PretokenSpans).
+            // Probes happen a phase later — hundreds of cycles, enough to
+            // cover DRAM — so the probe phase finds its lines in L1.
+            let cache = &self.pretoken_cache;
+            let n = pretokens.fill_spans_keyed(&mut spans, &mut keys, &mut hashes, &|h| {
+                cache.prefetch(h)
+            });
+            if n == 0 {
+                break;
+            }
+            // Probe phase: probe and emit. ~90% of pretokens encode to one
+            // token and ~98% to at most two (228M tokens / 208M pretokens
+            // on OWT); inline values avoid the dependent random load into
+            // `token_arena`.
+            for i in 0..n {
+                let (key, h) = (keys[i], hashes[i]);
+                if key != 0 {
+                    match self.pretoken_cache.get(key, h) {
+                        Some(val) => {
+                            let len = (val & 0x7F) as usize;
+                            if val & VAL_SPILL == 0 {
+                                let pair = [
+                                    TokenId((val >> 8) as u32 & 0xFF_FFFF),
+                                    TokenId((val >> 32) as u32),
+                                ];
+                                f(&pair[..len]);
+                            } else {
+                                let start = (val >> 32) as usize;
+                                // SAFETY: recorded right after appending
+                                // `len` tokens at `start`; the arena never
+                                // shrinks.
+                                f(unsafe { self.token_arena.get_unchecked(start..start + len) });
+                            }
+                        }
+                        None => self.encode_pretoken_miss(spans[i], key, h, &mut f),
+                    }
+                } else {
+                    // Long pretokens (> 15 bytes, rare) always spill to the
+                    // arena; their token counts can exceed the packed-value
+                    // range, so they bypass it entirely.
+                    match self.pretoken_cache_long.get(spans[i]) {
+                        Some(&(offset, len)) => {
+                            let start = offset as usize;
+                            // SAFETY: as above.
+                            f(unsafe {
+                                self.token_arena.get_unchecked(start..start + len as usize)
+                            })
+                        }
+                        None => self.encode_pretoken_miss(spans[i], 0, 0, &mut f),
+                    }
                 }
             }
-            let cached = match key {
-                Some(key) => self.pretoken_cache.get(&key).copied(),
-                None => self.pretoken_cache_long.get(bytes).copied(),
-            };
-            if let Some((offset, len)) = cached {
-                if let Some(key) = front_key {
-                    self.pretoken_front[front_idx] = PretokenFrontEntry::new(key, offset, len);
-                }
-                let start = offset as usize;
-                // SAFETY: every cached (offset, len) was recorded right after
-                // appending those `len` tokens at `offset`, and `token_arena`
-                // never shrinks, so the range is always in bounds.
-                f(unsafe { self.token_arena.get_unchecked(start..start + len as usize) });
-            } else {
-                // Encode into reusable scratch and append straight to the
-                // arena: no intermediate `Vec`, no `Cow` remap allocation.
-                let symbols = &mut self.symbol_scratch;
-                symbols.clear();
-                match self.byte_remapping.as_ref() {
-                    Some(br) => symbols.extend(bytes.iter().map(|&b| br.mapping[b as usize])),
-                    None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
-                }
-                bpe_merge_symbols_with_scratch(&self.merges, symbols, &mut self.merge_scratch);
-                let offset = self.token_arena.len() as u32;
-                let len = symbols.len() as u32;
-                self.token_arena.extend_from_slice(symbols);
-                match key {
-                    Some(key) => {
-                        self.pretoken_cache.insert(key, (offset, len));
-                        if let Some(key) = front_key {
-                            self.pretoken_front[front_idx] =
-                                PretokenFrontEntry::new(key, offset, len);
-                        }
-                    }
-                    None => {
-                        self.pretoken_cache_long.insert(bytes.into(), (offset, len));
-                    }
-                }
-                f(&self.token_arena[offset as usize..offset as usize + len as usize]);
+            if n < PRETOKEN_CHUNK {
+                break;
             }
         }
+    }
+
+    /// Cache-miss path of [`Self::memoized_encode`]: BPE-encode `bytes` and
+    /// record it in the table `key` routes to (the short-pretoken table,
+    /// or the long map when `key == 0`). Out of line to keep the hit
+    /// loop's code compact.
+    #[inline(never)]
+    fn encode_pretoken_miss(
+        &mut self,
+        bytes: &[u8],
+        key: u128,
+        h: u64,
+        f: &mut impl FnMut(&[TokenId]),
+    ) {
+        // Encode into reusable scratch; only encodings too long to inline
+        // go to the arena. A pretoken that is a complete vocab entry
+        // (very common: most frequent words are vocab words) skips the
+        // merge loop entirely via one reverse-vocab probe.
+        let symbols = &mut self.symbol_scratch;
+        symbols.clear();
+        if let Some(&tid) = self.vocab_inv.get(bytes) {
+            symbols.push(tid);
+        } else {
+            match self.byte_remapping.as_ref() {
+                Some(br) => symbols.extend(bytes.iter().map(|&b| br.mapping[b as usize])),
+                None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
+            }
+            bpe_merge_symbols_with_scratch(&self.merges, symbols, &mut self.merge_scratch);
+        }
+        let len = symbols.len() as u32;
+        if key != 0 {
+            let val = match pack_val_inline(symbols) {
+                Some(val) => val,
+                None => {
+                    let offset = self.token_arena.len() as u64;
+                    self.token_arena.extend_from_slice(symbols);
+                    VAL_SPILL | len as u64 | (offset << 32)
+                }
+            };
+            self.pretoken_cache.insert(key, h, val);
+        } else {
+            let offset = self.token_arena.len() as u32;
+            self.token_arena.extend_from_slice(symbols);
+            self.pretoken_cache_long.insert(bytes.into(), (offset, len));
+        }
+        f(symbols);
     }
 
     pub fn decode(&self, v: &[TokenId]) -> impl Iterator<Item = u8> {
@@ -507,7 +478,6 @@ impl Tokenizer {
 
     /// Detailed cache stats for memory accounting (see examples/cache_memory.rs):
     /// (short_len, short_cap, long_len, long_cap, long_key_bytes, arena_len, arena_cap).
-    /// The fixed-size 6 MiB front cache is not represented in the tuple.
     pub fn cache_mem_stats(&self) -> (usize, usize, usize, usize, usize, usize, usize) {
         let long_key_bytes: usize = self.pretoken_cache_long.keys().map(|k| k.len()).sum();
         (
@@ -538,38 +508,93 @@ mod tests {
     use crate::load_tokenizer::tiktoken::load_tiktoken;
     use std::io::Read;
 
+    /// Token-for-token differential of the cached encode path
+    /// (`memoized_encode`: packed keys, open-addressing table, inline
+    /// values, prefetch pipeline) against the uncached reference
+    /// (`encode_pretoken`, plain BPE merge per pretoken) on real OWT.
     #[test]
-    fn packed_front_cache_serves_repeated_pretokens() {
+    #[ignore]
+    fn memoized_encode_matches_reference_owt() {
+        use crate::load_tokenizer::hf::load_hf_bpe;
+        let tokenizer_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("data/gpt2_tokenizer.json");
+        let mut tokenizer = load_hf_bpe(&tokenizer_path).expect("load GPT-2 tokenizer");
+
+        let data_dir = std::env::home_dir().unwrap().join("data");
+        let all = std::fs::read(data_dir.join("owt_train.txt")).expect("read OWT");
+        let mut end = 50_000_000.min(all.len());
+        while end > 0 && std::str::from_utf8(&all[..end]).is_err() {
+            end -= 1;
+        }
+        let input = &all[..end];
+
+        let mut cached: Vec<TokenId> = Vec::new();
+        tokenizer
+            .memoized_encode(crate::pretokenize::pretokenize_as_iter(input), |tokens| {
+                cached.extend_from_slice(tokens)
+            });
+
+        // Uncached reference: remap bytes and run the plain merge loop.
+        let encode_reference = |pretoken: Pretoken| -> Vec<TokenId> {
+            let mut symbols: Vec<TokenId> = match tokenizer.byte_remapping.as_ref() {
+                Some(br) => pretoken.iter().map(|&b| br.mapping[b as usize]).collect(),
+                None => pretoken.iter().map(|&b| TokenId::from(b as u32)).collect(),
+            };
+            crate::bpe::bpe_merge_symbols(&tokenizer.merges, &mut symbols);
+            symbols
+        };
+        let mut idx = 0usize;
+        for (pi, pretoken) in crate::pretokenize::pretokenize_as_iter(input).enumerate() {
+            let reference = encode_reference(pretoken);
+            assert!(
+                cached[idx..(idx + reference.len()).min(cached.len())] == reference[..],
+                "pretoken {pi} ({:?}) diverged: cached {:?} vs reference {:?}",
+                String::from_utf8_lossy(pretoken.0),
+                &cached[idx..(idx + reference.len()).min(cached.len())],
+                reference,
+            );
+            idx += reference.len();
+        }
+        assert_eq!(idx, cached.len(), "cached encode produced extra tokens");
+        eprintln!("all {idx} tokens match on {} MB", input.len() / 1_000_000);
+    }
+
+    #[test]
+    fn short_pretoken_cache_serves_repeated_pretokens() {
+        use crate::pretokenize::{SpanIter, pack_pretoken_key, pretoken_key_hash};
+
         let merges = HashMap::with_hasher(rustc_hash::FxBuildHasher {});
         let vocab = (0..=u8::MAX).map(|byte| vec![byte]).collect();
         let mut tokenizer = Tokenizer::new(merges, vocab, None);
         let bytes = b"hello";
 
         let mut first = Vec::new();
-        tokenizer.memoized_encode([Pretoken(bytes)].into_iter(), |tokens| {
+        tokenizer.memoized_encode(SpanIter([Pretoken(bytes)].into_iter()), |tokens| {
             first.extend(tokens.iter().map(|token| token.0));
         });
         let expected: Vec<u32> = bytes.iter().map(|&byte| byte as u32).collect();
         assert_eq!(first, expected);
 
+        // The 5-token encoding is too long to inline, so it spilled to the
+        // arena, but the cache entry serves it either way.
         let key = pack_pretoken_key(bytes).unwrap();
-        let front_idx = pretoken_front_index(pretoken_cache_hash(key));
-        assert!(tokenizer.pretoken_front[front_idx].get(key).is_some());
-        assert!(tokenizer.pretoken_cache.remove(&key).is_some());
+        let h = pretoken_key_hash(key);
+        assert!(tokenizer.pretoken_cache.get(key, h).is_some());
 
         let mut repeated = Vec::new();
-        tokenizer.memoized_encode([Pretoken(bytes)].into_iter(), |tokens| {
+        tokenizer.memoized_encode(SpanIter([Pretoken(bytes)].into_iter()), |tokens| {
             repeated.extend(tokens.iter().map(|token| token.0));
         });
         assert_eq!(repeated, first);
-        assert!(tokenizer.pretoken_cache.is_empty());
+        assert_eq!(tokenizer.pretoken_cache.len(), 1);
 
-        // The zero key is the front-cache sentinel, so an empty pretoken must
-        // still take the authoritative map path.
-        tokenizer.memoized_encode([Pretoken(b"")].into_iter(), |tokens| {
+        // The zero key marks empty slots in the short table, so an empty
+        // pretoken (possible through the public API) must take the long-map
+        // path.
+        tokenizer.memoized_encode(SpanIter([Pretoken(b"")].into_iter()), |tokens| {
             assert!(tokens.is_empty());
         });
-        assert!(tokenizer.pretoken_cache.contains_key(&0));
+        assert!(tokenizer.pretoken_cache_long.contains_key(&b""[..]));
     }
 
     #[test]

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -3,7 +3,7 @@ use crate::bpe::{ByteRemapping, MergeScratch, bpe_merge_symbols_with_scratch, si
 use crate::pretokenize::{
     FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastOlmo3Pretokenizer,
     FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer, PRETOKEN_CHUNK,
-    Pretoken, PretokenSpans, PretokenizerType,
+    Pretoken, PretokenSpans, PretokenizerType, SpanBatch,
 };
 use crate::token::TokenId;
 use eyre::Result;
@@ -358,11 +358,7 @@ impl Tokenizer {
         mut pretokens: impl PretokenSpans<'i>,
         mut f: impl FnMut(&[TokenId]),
     ) {
-        let mut spans: [&[u8]; PRETOKEN_CHUNK] = [&[]; PRETOKEN_CHUNK];
-        // Packed key (0 = long pretoken, routed to the slice-keyed map;
-        // real keys are never 0 since the length tag is nonzero) and hash.
-        let mut keys = [0u128; PRETOKEN_CHUNK];
-        let mut hashes = [0u64; PRETOKEN_CHUNK];
+        let mut batch = SpanBatch::new();
         loop {
             // Pull phase: a chunk of pretoken spans with keys and hashes
             // derived and their probe lines prefetched on the way out (out
@@ -370,9 +366,7 @@ impl Tokenizer {
             // Probes happen a phase later — hundreds of cycles, enough to
             // cover DRAM — so the probe phase finds its lines in L1.
             let cache = &self.pretoken_cache;
-            let n = pretokens.fill_spans_keyed(&mut spans, &mut keys, &mut hashes, &|h| {
-                cache.prefetch(h)
-            });
+            let n = pretokens.fill_spans_keyed(&mut batch, &|h| cache.prefetch(h));
             if n == 0 {
                 break;
             }
@@ -381,7 +375,7 @@ impl Tokenizer {
             // on OWT); inline values avoid the dependent random load into
             // `token_arena`.
             for i in 0..n {
-                let (key, h) = (keys[i], hashes[i]);
+                let (key, h) = (batch.keys[i], batch.hashes[i]);
                 if key != 0 {
                     match self.pretoken_cache.get(key, h) {
                         Some(val) => {
@@ -400,13 +394,13 @@ impl Tokenizer {
                                 f(unsafe { self.token_arena.get_unchecked(start..start + len) });
                             }
                         }
-                        None => self.encode_pretoken_miss(spans[i], key, h, &mut f),
+                        None => self.encode_pretoken_miss(batch.spans[i], key, h, &mut f),
                     }
                 } else {
                     // Long pretokens (> 15 bytes, rare) always spill to the
                     // arena; their token counts can exceed the packed-value
                     // range, so they bypass it entirely.
-                    match self.pretoken_cache_long.get(spans[i]) {
+                    match self.pretoken_cache_long.get(batch.spans[i]) {
                         Some(&(offset, len)) => {
                             let start = offset as usize;
                             // SAFETY: as above.
@@ -414,7 +408,7 @@ impl Tokenizer {
                                 self.token_arena.get_unchecked(start..start + len as usize)
                             })
                         }
-                        None => self.encode_pretoken_miss(spans[i], 0, 0, &mut f),
+                        None => self.encode_pretoken_miss(batch.spans[i], 0, 0, &mut f),
                     }
                 }
             }

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1,5 +1,9 @@
 use crate::bpe::{ByteRemapping, MergeScratch, bpe_merge_symbols_with_scratch, simple_bpe_merge};
-use crate::pretokenize::{Pretoken, PretokenizerType};
+use crate::pretokenize::{
+    FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastOlmo3Pretokenizer,
+    FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer, Pretoken,
+    PretokenizerType,
+};
 use crate::token::TokenId;
 use eyre::Result;
 use std::collections::HashMap;
@@ -26,6 +30,11 @@ pub struct Tokenizer {
     /// instead of a `memcmp` call, and hashing is two multiply-mixes instead of
     /// a byte loop. Keys are `Copy`, so cache misses no longer allocate.
     pretoken_cache: HashMap<u128, (u32, u32), rustc_hash::FxBuildHasher>,
+    /// Direct-mapped front cache for packed pretokens. Natural-language
+    /// pretokens are heavily Zipf-distributed, so most hits avoid probing the
+    /// much larger SwissTable. Each entry keeps its key and arena range
+    /// together so a hit usually requires one cache-line fetch.
+    pretoken_front: Vec<PretokenFrontEntry>,
     /// Fallback cache for pretokens longer than 15 bytes.
     pretoken_cache_long: HashMap<Box<[u8]>, (u32, u32), rustc_hash::FxBuildHasher>,
     /// Scratch buffers reused across cache-missing pretokens so the merge loop
@@ -47,6 +56,32 @@ pub struct Tokenizer {
     /// Apply NFC normalization to non-added-token segments before
     /// pretokenization, like HuggingFace's `NFC` normalizer (e.g. Qwen2).
     normalize_nfc: bool,
+}
+
+/// A 24-byte front-cache entry. Splitting the `u128` key into two words avoids
+/// the 16-byte alignment padding that would otherwise make this 32 bytes.
+#[derive(Clone, Copy, Default)]
+struct PretokenFrontEntry {
+    key_lo: u64,
+    key_hi: u64,
+    value: u64,
+}
+
+impl PretokenFrontEntry {
+    #[inline(always)]
+    fn new(key: u128, offset: u32, len: u32) -> Self {
+        Self {
+            key_lo: key as u64,
+            key_hi: (key >> 64) as u64,
+            value: offset as u64 | ((len as u64) << 32),
+        }
+    }
+
+    #[inline(always)]
+    fn get(self, key: u128) -> Option<(u32, u32)> {
+        (self.key_lo == key as u64 && self.key_hi == (key >> 64) as u64)
+            .then_some((self.value as u32, (self.value >> 32) as u32))
+    }
 }
 
 /// NFC-normalize a segment if needed, using `buf` as scratch on the slow path.
@@ -95,11 +130,30 @@ const PACK_MASK_TAG: [(u128, u128); 16] = {
     t
 };
 
+/// Log2 of the direct-mapped packed-pretoken front cache size. 2^18 entries use
+/// 6 MiB per tokenizer and retain the broad working set while the authoritative
+/// HashMap keeps every key.
+const PRETOKEN_FRONT_BITS: u32 = 18;
+
+#[inline(always)]
+fn pretoken_cache_hash(key: u128) -> u64 {
+    let folded = (key as u64) ^ ((key >> 64) as u64);
+    folded.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+}
+
+#[inline(always)]
+fn pretoken_front_index(hash: u64) -> usize {
+    (hash >> (64 - PRETOKEN_FRONT_BITS)) as usize
+}
+
 #[inline(always)]
 pub(crate) fn pack_pretoken_key(bytes: &[u8]) -> Option<u128> {
     let n = bytes.len();
     if n > 15 {
         return None;
+    }
+    if n == 0 {
+        return Some(0);
     }
     let p = bytes.as_ptr();
     // Keep the low `n` bytes, zero the rest; lane 15 stays zero, ready for the
@@ -140,6 +194,7 @@ impl Tokenizer {
             byte_remapping,
             token_arena: Vec::new(),
             pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
+            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -187,6 +242,7 @@ impl Tokenizer {
             vocab_inv,
             token_arena: Vec::new(),
             pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
+            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -207,6 +263,7 @@ impl Tokenizer {
             byte_remapping: self.byte_remapping.clone(),
             token_arena: Vec::new(),
             pretoken_cache: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
+            pretoken_front: vec![PretokenFrontEntry::default(); 1 << PRETOKEN_FRONT_BITS],
             pretoken_cache_long: HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
             merge_scratch: MergeScratch::default(),
             symbol_scratch: Vec::new(),
@@ -334,7 +391,26 @@ impl Tokenizer {
             } else {
                 &bytes[pos..seg_end]
             };
-            self.memoized_encode(pretokenizer_type.pretokenize(segment), &mut f);
+            match pretokenizer_type {
+                PretokenizerType::GPT2 => {
+                    self.memoized_encode(FastR50kPretokenizer::new(segment), &mut f)
+                }
+                PretokenizerType::GPT4 => {
+                    self.memoized_encode(FastCl100kPretokenizer::new(segment), &mut f)
+                }
+                PretokenizerType::Qwen2 => {
+                    self.memoized_encode(FastQwen2Pretokenizer::new(segment), &mut f)
+                }
+                PretokenizerType::Qwen35 => {
+                    self.memoized_encode(FastQwen35Pretokenizer::new(segment), &mut f)
+                }
+                PretokenizerType::Olmo3 => {
+                    self.memoized_encode(FastOlmo3Pretokenizer::new(segment), &mut f)
+                }
+                PretokenizerType::DeepSeekV3 => {
+                    self.memoized_encode(FastDeepSeekV3Pretokenizer::new(segment), &mut f)
+                }
+            }
             match added {
                 Some((end, id)) => {
                     f(&[id]);
@@ -360,11 +436,34 @@ impl Tokenizer {
             // to the slice-keyed map. The key is computed once and reused on the
             // miss path's insert.
             let key = pack_pretoken_key(bytes);
+            // Packed key zero represents an empty pretoken and is reserved as
+            // the front cache's empty sentinel. Real pretokenizers never yield
+            // empty slices, but keep the public iterator API correct for one.
+            let front_key = key.filter(|&key| key != 0);
+            let mut front_idx = 0;
+            if let Some(key) = front_key {
+                let hash = pretoken_cache_hash(key);
+                front_idx = pretoken_front_index(hash);
+                // SAFETY: pretoken_front_index returns PRETOKEN_FRONT_BITS bits
+                // and the array has exactly 2^PRETOKEN_FRONT_BITS entries.
+                if let Some((offset, len)) =
+                    unsafe { *self.pretoken_front.get_unchecked(front_idx) }.get(key)
+                {
+                    let start = offset as usize;
+                    // SAFETY: front entries are copied from authoritative cache
+                    // entries, whose arena ranges remain valid forever.
+                    f(unsafe { self.token_arena.get_unchecked(start..start + len as usize) });
+                    continue;
+                }
+            }
             let cached = match key {
                 Some(key) => self.pretoken_cache.get(&key).copied(),
                 None => self.pretoken_cache_long.get(bytes).copied(),
             };
             if let Some((offset, len)) = cached {
+                if let Some(key) = front_key {
+                    self.pretoken_front[front_idx] = PretokenFrontEntry::new(key, offset, len);
+                }
                 let start = offset as usize;
                 // SAFETY: every cached (offset, len) was recorded right after
                 // appending those `len` tokens at `offset`, and `token_arena`
@@ -386,6 +485,10 @@ impl Tokenizer {
                 match key {
                     Some(key) => {
                         self.pretoken_cache.insert(key, (offset, len));
+                        if let Some(key) = front_key {
+                            self.pretoken_front[front_idx] =
+                                PretokenFrontEntry::new(key, offset, len);
+                        }
                     }
                     None => {
                         self.pretoken_cache_long.insert(bytes.into(), (offset, len));
@@ -404,6 +507,7 @@ impl Tokenizer {
 
     /// Detailed cache stats for memory accounting (see examples/cache_memory.rs):
     /// (short_len, short_cap, long_len, long_cap, long_key_bytes, arena_len, arena_cap).
+    /// The fixed-size 6 MiB front cache is not represented in the tuple.
     pub fn cache_mem_stats(&self) -> (usize, usize, usize, usize, usize, usize, usize) {
         let long_key_bytes: usize = self.pretoken_cache_long.keys().map(|k| k.len()).sum();
         (
@@ -433,6 +537,75 @@ mod tests {
     use super::*;
     use crate::load_tokenizer::tiktoken::load_tiktoken;
     use std::io::Read;
+
+    #[test]
+    fn packed_front_cache_serves_repeated_pretokens() {
+        let merges = HashMap::with_hasher(rustc_hash::FxBuildHasher {});
+        let vocab = (0..=u8::MAX).map(|byte| vec![byte]).collect();
+        let mut tokenizer = Tokenizer::new(merges, vocab, None);
+        let bytes = b"hello";
+
+        let mut first = Vec::new();
+        tokenizer.memoized_encode([Pretoken(bytes)].into_iter(), |tokens| {
+            first.extend(tokens.iter().map(|token| token.0));
+        });
+        let expected: Vec<u32> = bytes.iter().map(|&byte| byte as u32).collect();
+        assert_eq!(first, expected);
+
+        let key = pack_pretoken_key(bytes).unwrap();
+        let front_idx = pretoken_front_index(pretoken_cache_hash(key));
+        assert!(tokenizer.pretoken_front[front_idx].get(key).is_some());
+        assert!(tokenizer.pretoken_cache.remove(&key).is_some());
+
+        let mut repeated = Vec::new();
+        tokenizer.memoized_encode([Pretoken(bytes)].into_iter(), |tokens| {
+            repeated.extend(tokens.iter().map(|token| token.0));
+        });
+        assert_eq!(repeated, first);
+        assert!(tokenizer.pretoken_cache.is_empty());
+
+        // The zero key is the front-cache sentinel, so an empty pretoken must
+        // still take the authoritative map path.
+        tokenizer.memoized_encode([Pretoken(b"")].into_iter(), |tokens| {
+            assert!(tokens.is_empty());
+        });
+        assert!(tokenizer.pretoken_cache.contains_key(&0));
+    }
+
+    #[test]
+    fn concrete_pretokenizer_dispatch_matches_enum_dispatch() {
+        let schemes = [
+            PretokenizerType::GPT2,
+            PretokenizerType::GPT4,
+            PretokenizerType::Qwen2,
+            PretokenizerType::Qwen35,
+            PretokenizerType::Olmo3,
+            PretokenizerType::DeepSeekV3,
+        ];
+        let input = "Hello, 世界! café 12345\r\ncan't  stop".as_bytes();
+
+        for scheme in schemes {
+            let make_tokenizer = || {
+                let merges = HashMap::with_hasher(rustc_hash::FxBuildHasher {});
+                let vocab = (0..=u8::MAX).map(|byte| vec![byte]).collect();
+                Tokenizer::new(merges, vocab, None)
+            };
+
+            let mut reference = make_tokenizer();
+            let mut expected = Vec::new();
+            reference.memoized_encode(scheme.pretokenize(input), |tokens| {
+                expected.extend_from_slice(tokens);
+            });
+
+            let mut concrete = make_tokenizer();
+            concrete.set_pretokenizer_type(scheme);
+            let mut actual = Vec::new();
+            concrete.encode_with_added_tokens(input, |tokens| {
+                actual.extend_from_slice(tokens);
+            });
+            assert_eq!(actual, expected, "dispatch differs for {scheme:?}");
+        }
+    }
 
     #[test]
     fn test_merges_from_vocab() {

--- a/src/pretokenize/fast/cl100k.rs
+++ b/src/pretokenize/fast/cl100k.rs
@@ -76,20 +76,7 @@ impl<'a> Iterator for FastCl100kPretokenizer<'a> {
     }
 }
 
-impl<'a> crate::pretokenize::PretokenSpans<'a> for FastCl100kPretokenizer<'a> {
-    #[inline]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        super::fill_spans_keyed_mask::<Cl100kScheme>(
-            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
-        )
-    }
-}
+super::impl_mask_pretoken_spans!(FastCl100kPretokenizer, Cl100kScheme);
 
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s++$` | `\s*[\r\n]` | `\s+(?!\S)` | `\s+`, in that priority.

--- a/src/pretokenize/fast/cl100k.rs
+++ b/src/pretokenize/fast/cl100k.rs
@@ -76,6 +76,21 @@ impl<'a> Iterator for FastCl100kPretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastCl100kPretokenizer<'a> {
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        super::fill_spans_keyed_mask::<Cl100kScheme>(
+            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
+        )
+    }
+}
+
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s++$` | `\s*[\r\n]` | `\s+(?!\S)` | `\s+`, in that priority.
 /// Precondition: the letter-prefix (`[^\r\n\p{L}\p{N}]?+\p{L}++`) and

--- a/src/pretokenize/fast/deepseek_v3.rs
+++ b/src/pretokenize/fast/deepseek_v3.rs
@@ -66,6 +66,42 @@ impl<'a> Iterator for FastDeepSeekV3Pretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastDeepSeekV3Pretokenizer<'a> {
+    /// Chunked pull with the cursor in a local across the whole chunk (the
+    /// per-`next` store-load of `self.pos` costs real time in the encode
+    /// loop's register-starved surroundings); key/hash/prefetch ride along
+    /// as in the mask-scanner schemes' shared fill.
+    #[inline(never)]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        let len = self.bytes.len();
+        let mut pos = self.pos;
+        let mut n = 0;
+        while n < crate::pretokenize::PRETOKEN_CHUNK && pos < len {
+            let start = pos;
+            pos = advance_pos(self.bytes, start);
+            // SAFETY: advance_pos returns an in-bounds end > start.
+            let span = unsafe { self.bytes.get_unchecked(start..pos) };
+            let (key, h) = match crate::pretokenize::pack_pretoken_key(span) {
+                Some(key) => (key, crate::pretokenize::pretoken_key_hash(key)),
+                None => (0, 0),
+            };
+            prefetch(h);
+            spans[n] = span;
+            keys[n] = key;
+            hashes[n] = h;
+            n += 1;
+        }
+        self.pos = pos;
+        n
+    }
+}
+
 /// If the char at `pos` is `\p{L}` or `\p{M}` within the region, return the
 /// offset just past it.
 #[inline(always)]

--- a/src/pretokenize/fast/deepseek_v3.rs
+++ b/src/pretokenize/fast/deepseek_v3.rs
@@ -69,34 +69,28 @@ impl<'a> Iterator for FastDeepSeekV3Pretokenizer<'a> {
 impl<'a> crate::pretokenize::PretokenSpans<'a> for FastDeepSeekV3Pretokenizer<'a> {
     /// Chunked pull with the cursor in a local across the whole chunk (the
     /// per-`next` store-load of `self.pos` costs real time in the encode
-    /// loop's register-starved surroundings); key/hash/prefetch ride along
-    /// as in the mask-scanner schemes' shared fill.
+    /// loop's register-starved surroundings).
     #[inline(never)]
     fn fill_spans_keyed(
         &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        batch: &mut crate::pretokenize::SpanBatch<'a>,
         prefetch: &impl Fn(u64),
     ) -> usize {
-        let len = self.bytes.len();
+        let (bytes, len) = (self.bytes, self.bytes.len());
         let mut pos = self.pos;
-        let mut n = 0;
-        while n < crate::pretokenize::PRETOKEN_CHUNK && pos < len {
-            let start = pos;
-            pos = advance_pos(self.bytes, start);
-            // SAFETY: advance_pos returns an in-bounds end > start.
-            let span = unsafe { self.bytes.get_unchecked(start..pos) };
-            let (key, h) = match crate::pretokenize::pack_pretoken_key(span) {
-                Some(key) => (key, crate::pretokenize::pretoken_key_hash(key)),
-                None => (0, 0),
-            };
-            prefetch(h);
-            spans[n] = span;
-            keys[n] = key;
-            hashes[n] = h;
-            n += 1;
-        }
+        let n = crate::pretokenize::fill_spans_keyed_with(
+            || {
+                if pos >= len {
+                    return None;
+                }
+                let start = pos;
+                pos = advance_pos(bytes, start);
+                // SAFETY: advance_pos returns an in-bounds end > start.
+                Some(unsafe { bytes.get_unchecked(start..pos) })
+            },
+            batch,
+            prefetch,
+        );
         self.pos = pos;
         n
     }

--- a/src/pretokenize/fast/mod.rs
+++ b/src/pretokenize/fast/mod.rs
@@ -24,6 +24,50 @@ pub use qwen3_5::FastQwen35Pretokenizer;
 pub use r50k::FastR50kPretokenizer;
 
 use crate::pretokenize::unicode;
+use crate::pretokenize::{PRETOKEN_CHUNK, pack_pretoken_key, pretoken_key_hash};
+
+// -----------------------------------------------------------------------
+// Shared chunked span pull for the mask-scanner pretokenizers
+// -----------------------------------------------------------------------
+
+/// The `PretokenSpans::fill_spans_keyed` body shared by every mask-scanner
+/// pretokenizer (all of them wrap a `(bytes, MaskState)` pair): pull spans
+/// directly over `next_span` — fusing its `#[inline(always)]` walker body
+/// into this one tight loop so the `MaskState` fields stay in registers
+/// across the whole chunk — and derive each span's cache key, hash, and
+/// prefetch on the way out, riding in the walker chain's idle issue slots.
+/// `#[inline(never)]`: each monomorphization is its own out-of-line loop,
+/// keeping its register allocation away from the (register-hungry) encode
+/// loop that calls it. Routing this through `Iterator::next` instead
+/// measured ~23% of warm encode time in un-inlined call overhead.
+#[inline(never)]
+pub(crate) fn fill_spans_keyed_mask<'a, S: mask::MaskScheme>(
+    bytes: &'a [u8],
+    state: &mut mask::MaskState,
+    spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
+    keys: &mut [u128; PRETOKEN_CHUNK],
+    hashes: &mut [u64; PRETOKEN_CHUNK],
+    prefetch: &impl Fn(u64),
+) -> usize {
+    let mut n = 0;
+    while n < PRETOKEN_CHUNK {
+        let Some((start, end)) = state.next_span::<S>(bytes) else {
+            break;
+        };
+        // SAFETY: next_span returns in-bounds span boundaries.
+        let span = unsafe { bytes.get_unchecked(start..end) };
+        let (key, h) = match pack_pretoken_key(span) {
+            Some(key) => (key, pretoken_key_hash(key)),
+            None => (0, 0),
+        };
+        prefetch(h);
+        spans[n] = span;
+        keys[n] = key;
+        hashes[n] = h;
+        n += 1;
+    }
+    n
+}
 
 // -----------------------------------------------------------------------
 // Branchless byte predicates

--- a/src/pretokenize/fast/mod.rs
+++ b/src/pretokenize/fast/mod.rs
@@ -23,8 +23,8 @@ pub use qwen2::FastQwen2Pretokenizer;
 pub use qwen3_5::FastQwen35Pretokenizer;
 pub use r50k::FastR50kPretokenizer;
 
+use crate::pretokenize::SpanBatch;
 use crate::pretokenize::unicode;
-use crate::pretokenize::{PRETOKEN_CHUNK, pack_pretoken_key, pretoken_key_hash};
 
 // -----------------------------------------------------------------------
 // Shared chunked span pull for the mask-scanner pretokenizers
@@ -32,42 +32,54 @@ use crate::pretokenize::{PRETOKEN_CHUNK, pack_pretoken_key, pretoken_key_hash};
 
 /// The `PretokenSpans::fill_spans_keyed` body shared by every mask-scanner
 /// pretokenizer (all of them wrap a `(bytes, MaskState)` pair): pull spans
-/// directly over `next_span` — fusing its `#[inline(always)]` walker body
-/// into this one tight loop so the `MaskState` fields stay in registers
-/// across the whole chunk — and derive each span's cache key, hash, and
-/// prefetch on the way out, riding in the walker chain's idle issue slots.
-/// `#[inline(never)]`: each monomorphization is its own out-of-line loop,
-/// keeping its register allocation away from the (register-hungry) encode
-/// loop that calls it. Routing this through `Iterator::next` instead
-/// measured ~23% of warm encode time in un-inlined call overhead.
+/// directly over `next_span`, fusing its `#[inline(always)]` walker body
+/// into one tight loop so the `MaskState` fields stay in registers across
+/// the whole chunk. `#[inline(never)]`: each monomorphization is its own
+/// out-of-line loop, keeping its register allocation away from the
+/// (register-hungry) encode loop that calls it. Routing this through
+/// `Iterator::next` instead measured ~23% of warm encode time in
+/// un-inlined call overhead.
 #[inline(never)]
 pub(crate) fn fill_spans_keyed_mask<'a, S: mask::MaskScheme>(
     bytes: &'a [u8],
     state: &mut mask::MaskState,
-    spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
-    keys: &mut [u128; PRETOKEN_CHUNK],
-    hashes: &mut [u64; PRETOKEN_CHUNK],
+    batch: &mut SpanBatch<'a>,
     prefetch: &impl Fn(u64),
 ) -> usize {
-    let mut n = 0;
-    while n < PRETOKEN_CHUNK {
-        let Some((start, end)) = state.next_span::<S>(bytes) else {
-            break;
-        };
-        // SAFETY: next_span returns in-bounds span boundaries.
-        let span = unsafe { bytes.get_unchecked(start..end) };
-        let (key, h) = match pack_pretoken_key(span) {
-            Some(key) => (key, pretoken_key_hash(key)),
-            None => (0, 0),
-        };
-        prefetch(h);
-        spans[n] = span;
-        keys[n] = key;
-        hashes[n] = h;
-        n += 1;
-    }
-    n
+    crate::pretokenize::fill_spans_keyed_with(
+        || {
+            let (start, end) = state.next_span::<S>(bytes)?;
+            // SAFETY: next_span returns in-bounds span boundaries.
+            Some(unsafe { bytes.get_unchecked(start..end) })
+        },
+        batch,
+        prefetch,
+    )
 }
+
+/// Implement [`crate::pretokenize::PretokenSpans`] for a mask-scanner
+/// pretokenizer (any `{ bytes, state: MaskState }` struct) by delegating
+/// to its scheme's [`fill_spans_keyed_mask`] monomorphization.
+macro_rules! impl_mask_pretoken_spans {
+    ($pretokenizer:ident, $scheme:ty) => {
+        impl<'a> crate::pretokenize::PretokenSpans<'a> for $pretokenizer<'a> {
+            #[inline]
+            fn fill_spans_keyed(
+                &mut self,
+                batch: &mut crate::pretokenize::SpanBatch<'a>,
+                prefetch: &impl Fn(u64),
+            ) -> usize {
+                crate::pretokenize::fast::fill_spans_keyed_mask::<$scheme>(
+                    self.bytes,
+                    &mut self.state,
+                    batch,
+                    prefetch,
+                )
+            }
+        }
+    };
+}
+pub(crate) use impl_mask_pretoken_spans;
 
 // -----------------------------------------------------------------------
 // Branchless byte predicates

--- a/src/pretokenize/fast/olmo3.rs
+++ b/src/pretokenize/fast/olmo3.rs
@@ -72,20 +72,7 @@ impl<'a> Iterator for FastOlmo3Pretokenizer<'a> {
     }
 }
 
-impl<'a> crate::pretokenize::PretokenSpans<'a> for FastOlmo3Pretokenizer<'a> {
-    #[inline]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        super::fill_spans_keyed_mask::<Olmo3Scheme>(
-            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
-        )
-    }
-}
+super::impl_mask_pretoken_spans!(FastOlmo3Pretokenizer, Olmo3Scheme);
 
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s*[\r\n]+` | `\s+(?!\S)` | `\s+`, in that priority.

--- a/src/pretokenize/fast/olmo3.rs
+++ b/src/pretokenize/fast/olmo3.rs
@@ -72,6 +72,21 @@ impl<'a> Iterator for FastOlmo3Pretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastOlmo3Pretokenizer<'a> {
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        super::fill_spans_keyed_mask::<Olmo3Scheme>(
+            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
+        )
+    }
+}
+
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s*[\r\n]+` | `\s+(?!\S)` | `\s+`, in that priority.
 /// Precondition: the letter-prefix (`[^\r\n\p{L}\p{N}]?\p{L}+`) and

--- a/src/pretokenize/fast/qwen2.rs
+++ b/src/pretokenize/fast/qwen2.rs
@@ -74,6 +74,21 @@ impl<'a> Iterator for FastQwen2Pretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastQwen2Pretokenizer<'a> {
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        super::fill_spans_keyed_mask::<Qwen2Scheme>(
+            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
+        )
+    }
+}
+
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s*[\r\n]+` | `\s+(?!\S)` | `\s+`, in that priority.
 /// Precondition: the letter-prefix (`[^\r\n\p{L}\p{N}]?\p{L}+`) and

--- a/src/pretokenize/fast/qwen2.rs
+++ b/src/pretokenize/fast/qwen2.rs
@@ -74,20 +74,7 @@ impl<'a> Iterator for FastQwen2Pretokenizer<'a> {
     }
 }
 
-impl<'a> crate::pretokenize::PretokenSpans<'a> for FastQwen2Pretokenizer<'a> {
-    #[inline]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        super::fill_spans_keyed_mask::<Qwen2Scheme>(
-            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
-        )
-    }
-}
+super::impl_mask_pretoken_spans!(FastQwen2Pretokenizer, Qwen2Scheme);
 
 /// Whitespace-led token starting at `start`, i.e. the alternatives
 /// `\s*[\r\n]+` | `\s+(?!\S)` | `\s+`, in that priority.

--- a/src/pretokenize/fast/qwen3_5.rs
+++ b/src/pretokenize/fast/qwen3_5.rs
@@ -75,20 +75,7 @@ impl<'a> Iterator for FastQwen35Pretokenizer<'a> {
     }
 }
 
-impl<'a> crate::pretokenize::PretokenSpans<'a> for FastQwen35Pretokenizer<'a> {
-    #[inline]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        super::fill_spans_keyed_mask::<Qwen35Scheme>(
-            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
-        )
-    }
-}
+super::impl_mask_pretoken_spans!(FastQwen35Pretokenizer, Qwen35Scheme);
 
 /// If the char at `pos` is `\p{L}` or `\p{M}`, return the offset just past it.
 #[inline(always)]

--- a/src/pretokenize/fast/qwen3_5.rs
+++ b/src/pretokenize/fast/qwen3_5.rs
@@ -75,6 +75,21 @@ impl<'a> Iterator for FastQwen35Pretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastQwen35Pretokenizer<'a> {
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        super::fill_spans_keyed_mask::<Qwen35Scheme>(
+            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
+        )
+    }
+}
+
 /// If the char at `pos` is `\p{L}` or `\p{M}`, return the offset just past it.
 #[inline(always)]
 fn lm_end_at(bytes: &[u8], pos: usize) -> Option<usize> {

--- a/src/pretokenize/fast/r50k.rs
+++ b/src/pretokenize/fast/r50k.rs
@@ -492,20 +492,7 @@ impl<'a> Iterator for FastR50kPretokenizer<'a> {
     }
 }
 
-impl<'a> crate::pretokenize::PretokenSpans<'a> for FastR50kPretokenizer<'a> {
-    #[inline]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        super::fill_spans_keyed_mask::<R50kScheme>(
-            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
-        )
-    }
-}
+super::impl_mask_pretoken_spans!(FastR50kPretokenizer, R50kScheme);
 
 /// Advance past one token starting at `start`; returns the token's end.
 /// `start` must be < `bytes.len()` and a valid token start.

--- a/src/pretokenize/fast/r50k.rs
+++ b/src/pretokenize/fast/r50k.rs
@@ -492,6 +492,21 @@ impl<'a> Iterator for FastR50kPretokenizer<'a> {
     }
 }
 
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastR50kPretokenizer<'a> {
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        super::fill_spans_keyed_mask::<R50kScheme>(
+            self.bytes, &mut self.state, spans, keys, hashes, prefetch,
+        )
+    }
+}
+
 /// Advance past one token starting at `start`; returns the token's end.
 /// `start` must be < `bytes.len()` and a valid token start.
 /// Uses direct comparison chains instead of LUT + jump table to avoid

--- a/src/pretokenize/mod.rs
+++ b/src/pretokenize/mod.rs
@@ -123,6 +123,31 @@ pub(crate) fn pretoken_key_hash(key: u128) -> u64 {
     h
 }
 
+/// One chunk of pretoken spans with their packed cache keys (0 = longer
+/// than 15 bytes, routed to the slice-keyed fallback map) and key hashes,
+/// filled by [`PretokenSpans::fill_spans_keyed`].
+pub struct SpanBatch<'a> {
+    pub spans: [&'a [u8]; PRETOKEN_CHUNK],
+    pub keys: [u128; PRETOKEN_CHUNK],
+    pub hashes: [u64; PRETOKEN_CHUNK],
+}
+
+impl<'a> SpanBatch<'a> {
+    pub fn new() -> Self {
+        SpanBatch {
+            spans: [&[]; PRETOKEN_CHUNK],
+            keys: [0; PRETOKEN_CHUNK],
+            hashes: [0; PRETOKEN_CHUNK],
+        }
+    }
+}
+
+impl Default for SpanBatch<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A source of pretoken spans, pulled a chunk at a time with their cache
 /// keys derived on the way out.
 ///
@@ -136,88 +161,54 @@ pub(crate) fn pretoken_key_hash(key: u128) -> u64 {
 /// ~1.7 standalone): the independent per-span key math fills its idle
 /// issue slots nearly for free, where a separate pass paid for it in full.
 pub trait PretokenSpans<'a> {
-    /// Fill the arrays from the front with the next pretoken spans, their
-    /// packed keys (0 for pretokens longer than 15 bytes) and key hashes,
-    /// calling `prefetch(hash)` for each. Returns how many were written; a
-    /// short count (including 0) means the input is exhausted.
-    /// (Recomputing the hash at the consumer instead of storing it here
-    /// measured 4% slower end to end: the extra multiply sits on the probe
-    /// loop's critical path, while this loop has store slots to spare.)
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
-        keys: &mut [u128; PRETOKEN_CHUNK],
-        hashes: &mut [u64; PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize;
+    /// Fill `batch` from the front with the next pretoken spans, calling
+    /// `prefetch(hash)` for each. Returns how many were written; a short
+    /// count (including 0) means the input is exhausted. (Recomputing the
+    /// hash at the consumer instead of storing it here measured 4% slower
+    /// end to end: the extra multiply sits on the probe loop's critical
+    /// path, while this loop has store slots to spare.)
+    fn fill_spans_keyed(&mut self, batch: &mut SpanBatch<'a>, prefetch: &impl Fn(u64)) -> usize;
 }
 
-macro_rules! impl_pretoken_spans {
-    ($ty:ty) => {
-        impl<'a> PretokenSpans<'a> for $ty {
-            // Out of line on purpose — see the trait docs.
-            #[inline(never)]
-            fn fill_spans_keyed(
-                &mut self,
-                spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
-                keys: &mut [u128; PRETOKEN_CHUNK],
-                hashes: &mut [u64; PRETOKEN_CHUNK],
-                prefetch: &impl Fn(u64),
-            ) -> usize {
-                let mut n = 0;
-                while n < PRETOKEN_CHUNK {
-                    let Some(pretoken) = self.next() else { break };
-                    let (key, h) = match pack_pretoken_key(pretoken.0) {
-                        Some(key) => (key, pretoken_key_hash(key)),
-                        None => (0, 0),
-                    };
-                    prefetch(h);
-                    spans[n] = pretoken.0;
-                    keys[n] = key;
-                    hashes[n] = h;
-                    n += 1;
-                }
-                n
-            }
-        }
-    };
+/// Shared body of every [`PretokenSpans`] implementation: pull spans from
+/// `next` and derive each one's key, hash, and prefetch on the way out.
+/// `#[inline(always)]` so each `#[inline(never)]` implementation fuses it
+/// with its span walker into a single out-of-line loop (see the trait
+/// docs for why that fusion matters).
+#[inline(always)]
+pub(crate) fn fill_spans_keyed_with<'a>(
+    mut next: impl FnMut() -> Option<&'a [u8]>,
+    batch: &mut SpanBatch<'a>,
+    prefetch: &impl Fn(u64),
+) -> usize {
+    let mut n = 0;
+    while n < PRETOKEN_CHUNK {
+        let Some(span) = next() else { break };
+        let (key, h) = match pack_pretoken_key(span) {
+            Some(key) => (key, pretoken_key_hash(key)),
+            None => (0, 0),
+        };
+        prefetch(h);
+        batch.spans[n] = span;
+        batch.keys[n] = key;
+        batch.hashes[n] = h;
+        n += 1;
+    }
+    n
 }
 
-// The Fast* pretokenizers and the dispatch enum implement PretokenSpans
-// directly over their walker state in their own modules (see
-// `fast::fill_spans_keyed_mask`) — routing through `Iterator::next` here
-// left the (large, `#[inline(always)]`) `next_span` un-inlined behind a
-// real call, costing ~23% of warm encode time. Only the reference
-// state-machine iterator takes the generic adapter path.
-impl_pretoken_spans!(PretokenizerIter<'a>);
-
-/// Adapter giving any pretoken iterator (tests, custom sources) the
-/// [`PretokenSpans`] interface.
+/// Adapter giving any pretoken iterator (reference pretokenizers, tests,
+/// custom sources) the [`PretokenSpans`] interface. The `Fast*`
+/// pretokenizers implement the trait directly over their walker state
+/// instead (see `fast::fill_spans_keyed_mask`): routing them through
+/// `Iterator::next` left the (large, `#[inline(always)]`) `next_span`
+/// un-inlined behind a real call, costing ~23% of warm encode time.
 pub struct SpanIter<I>(pub I);
 
 impl<'a, I: Iterator<Item = Pretoken<'a>>> PretokenSpans<'a> for SpanIter<I> {
     #[inline(never)]
-    fn fill_spans_keyed(
-        &mut self,
-        spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
-        keys: &mut [u128; PRETOKEN_CHUNK],
-        hashes: &mut [u64; PRETOKEN_CHUNK],
-        prefetch: &impl Fn(u64),
-    ) -> usize {
-        let mut n = 0;
-        while n < PRETOKEN_CHUNK {
-            let Some(pretoken) = self.0.next() else { break };
-            let (key, h) = match pack_pretoken_key(pretoken.0) {
-                Some(key) => (key, pretoken_key_hash(key)),
-                None => (0, 0),
-            };
-            prefetch(h);
-            spans[n] = pretoken.0;
-            keys[n] = key;
-            hashes[n] = h;
-            n += 1;
-        }
-        n
+    fn fill_spans_keyed(&mut self, batch: &mut SpanBatch<'a>, prefetch: &impl Fn(u64)) -> usize {
+        fill_spans_keyed_with(|| self.0.next().map(|p| p.0), batch, prefetch)
     }
 }
 
@@ -638,22 +629,21 @@ mod span_source_tests {
     ) {
         let expected: Vec<&[u8]> = reference.map(|p| p.0).collect();
         let mut got: Vec<&[u8]> = Vec::new();
-        let mut spans = [&[][..]; PRETOKEN_CHUNK];
-        let mut keys = [0u128; PRETOKEN_CHUNK];
-        let mut hashes = [0u64; PRETOKEN_CHUNK];
+        let mut batch = SpanBatch::new();
         let prefetched = std::cell::Cell::new(0usize);
         loop {
-            let n = src.fill_spans_keyed(&mut spans, &mut keys, &mut hashes, &|_h| {
+            let n = src.fill_spans_keyed(&mut batch, &|_h| {
                 prefetched.set(prefetched.get() + 1)
             });
             for i in 0..n {
-                let (want_key, want_hash) = match pack_pretoken_key(spans[i]) {
+                let span = batch.spans[i];
+                let (want_key, want_hash) = match pack_pretoken_key(span) {
                     Some(key) => (key, pretoken_key_hash(key)),
                     None => (0, 0),
                 };
-                assert_eq!(keys[i], want_key, "{scheme}: bad key for {:?}", spans[i]);
-                assert_eq!(hashes[i], want_hash, "{scheme}: bad hash for {:?}", spans[i]);
-                got.push(spans[i]);
+                assert_eq!(batch.keys[i], want_key, "{scheme}: bad key for {span:?}");
+                assert_eq!(batch.hashes[i], want_hash, "{scheme}: bad hash for {span:?}");
+                got.push(span);
             }
             if n < PRETOKEN_CHUNK {
                 break;
@@ -721,7 +711,11 @@ mod span_source_tests {
                 FastDeepSeekV3Pretokenizer::new(b),
                 "deepseek_v3",
             );
-            check_source(PretokenizerIter::new(b), PretokenizerIter::new(b), "state_machine");
+            check_source(
+                SpanIter(PretokenizerIter::new(b)),
+                PretokenizerIter::new(b),
+                "state_machine",
+            );
             for pt in [
                 PretokenizerType::GPT2,
                 PretokenizerType::GPT4,

--- a/src/pretokenize/mod.rs
+++ b/src/pretokenize/mod.rs
@@ -48,6 +48,180 @@ pub fn pretokenize_as_iter(bytes: &[u8]) -> FastR50kPretokenizer<'_> {
 }
 
 // ---------------------------------------------------------------------------
+// Batched pretoken pulling (the encode loop's input interface)
+// ---------------------------------------------------------------------------
+
+/// Chunk size of [`PretokenSpans::fill_spans`] — one batch of the encode
+/// loop's phase arrays.
+pub const PRETOKEN_CHUNK: usize = 256;
+
+/// Per-length masks for [`pack_pretoken_key`]: one L1-resident table load
+/// replaces a 128-bit variable shift + sub (u128 shifts lower to a
+/// multi-instruction sequence). The length tag is computed (`n << 120`
+/// touches only the high half: one shift + or), not loaded.
+const PACK_MASK: [u128; 16] = {
+    let mut t = [0u128; 16];
+    let mut n = 1;
+    while n < 16 {
+        t[n] = u128::MAX >> (8 * (16 - n));
+        n += 1;
+    }
+    t
+};
+
+/// Pack a pretoken of ≤ 15 bytes into a `u128` cache key: bytes in the low
+/// 15 lanes, length in the top byte (so keys of different lengths never
+/// collide, and a real key is never 0). Returns `None` for longer
+/// pretokens, which use the slice-keyed fallback map.
+///
+/// The common path is a single unaligned 16-byte load followed by a mask,
+/// avoiding both a variable-length `memcpy` and per-byte branching. The
+/// load is only taken when it cannot cross a page boundary, so it can
+/// never touch an unmapped page; the rare near-boundary case falls back to
+/// a plain copy. Both paths produce the identical key.
+#[inline(always)]
+pub(crate) fn pack_pretoken_key(bytes: &[u8]) -> Option<u128> {
+    let n = bytes.len();
+    if n > 15 {
+        return None;
+    }
+    if n == 0 {
+        // Empty pretokens (possible through the public API, never from a
+        // pretokenizer) pack to key 0, which the short table reserves as
+        // its empty sentinel — the encode loop routes key 0 to the long
+        // map. Also keeps the read below from touching a zero-length
+        // slice's dangling pointer.
+        return Some(0);
+    }
+    let p = bytes.as_ptr();
+    let mask = PACK_MASK[n];
+    let low = if (p as usize) & 4095 <= 4096 - 16 {
+        // SAFETY: the offset within the (≥ 4096-byte) page is ≤ 4096 - 16,
+        // so a 16-byte read stays inside the page holding `p`, which is
+        // mapped because `p` points to at least one valid byte.
+        let v = unsafe { (p as *const u128).read_unaligned() };
+        v & mask
+    } else {
+        // Rare: `p` is within 16 bytes of a page boundary. Gather with a
+        // plain copy (≤ 15 bytes) — correctness over speed on this cold path.
+        let mut lanes = [0u8; 16];
+        lanes[..n].copy_from_slice(bytes);
+        u128::from_le_bytes(lanes) & mask
+    };
+    Some(low | ((n as u128) << 120))
+}
+
+/// Hash of a packed pretoken key: one folded multiply, the cheapest mix
+/// whose low bits (the table index) still see every key bit. Quality is
+/// noncritical for correctness (the table compares full keys).
+#[inline(always)]
+pub(crate) fn pretoken_key_hash(key: u128) -> u64 {
+    let lo = key as u64;
+    let hi = (key >> 64) as u64;
+    let mut h = (lo ^ hi.rotate_right(25)).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    h ^= h >> 32;
+    h
+}
+
+/// A source of pretoken spans, pulled a chunk at a time with their cache
+/// keys derived on the way out.
+///
+/// `Tokenizer::memoized_encode` consumes pretokens through this instead of
+/// `Iterator` for codegen reasons: pulling happens in a dedicated
+/// out-of-line loop, so the pretokenizer state is register-allocated
+/// across the whole chunk (inlined into the register-starved encode loop
+/// it lives in stack slots, ~9 cycles/pretoken of spill traffic on Zen 2).
+/// Key packing, hashing, and the cache-line prefetch ride along in the
+/// same loop because the span walker is a serial dependency chain (IPC
+/// ~1.7 standalone): the independent per-span key math fills its idle
+/// issue slots nearly for free, where a separate pass paid for it in full.
+pub trait PretokenSpans<'a> {
+    /// Fill the arrays from the front with the next pretoken spans, their
+    /// packed keys (0 for pretokens longer than 15 bytes) and key hashes,
+    /// calling `prefetch(hash)` for each. Returns how many were written; a
+    /// short count (including 0) means the input is exhausted.
+    /// (Recomputing the hash at the consumer instead of storing it here
+    /// measured 4% slower end to end: the extra multiply sits on the probe
+    /// loop's critical path, while this loop has store slots to spare.)
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
+        keys: &mut [u128; PRETOKEN_CHUNK],
+        hashes: &mut [u64; PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize;
+}
+
+macro_rules! impl_pretoken_spans {
+    ($ty:ty) => {
+        impl<'a> PretokenSpans<'a> for $ty {
+            // Out of line on purpose — see the trait docs.
+            #[inline(never)]
+            fn fill_spans_keyed(
+                &mut self,
+                spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
+                keys: &mut [u128; PRETOKEN_CHUNK],
+                hashes: &mut [u64; PRETOKEN_CHUNK],
+                prefetch: &impl Fn(u64),
+            ) -> usize {
+                let mut n = 0;
+                while n < PRETOKEN_CHUNK {
+                    let Some(pretoken) = self.next() else { break };
+                    let (key, h) = match pack_pretoken_key(pretoken.0) {
+                        Some(key) => (key, pretoken_key_hash(key)),
+                        None => (0, 0),
+                    };
+                    prefetch(h);
+                    spans[n] = pretoken.0;
+                    keys[n] = key;
+                    hashes[n] = h;
+                    n += 1;
+                }
+                n
+            }
+        }
+    };
+}
+
+// The Fast* pretokenizers and the dispatch enum implement PretokenSpans
+// directly over their walker state in their own modules (see
+// `fast::fill_spans_keyed_mask`) — routing through `Iterator::next` here
+// left the (large, `#[inline(always)]`) `next_span` un-inlined behind a
+// real call, costing ~23% of warm encode time. Only the reference
+// state-machine iterator takes the generic adapter path.
+impl_pretoken_spans!(PretokenizerIter<'a>);
+
+/// Adapter giving any pretoken iterator (tests, custom sources) the
+/// [`PretokenSpans`] interface.
+pub struct SpanIter<I>(pub I);
+
+impl<'a, I: Iterator<Item = Pretoken<'a>>> PretokenSpans<'a> for SpanIter<I> {
+    #[inline(never)]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; PRETOKEN_CHUNK],
+        keys: &mut [u128; PRETOKEN_CHUNK],
+        hashes: &mut [u64; PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        let mut n = 0;
+        while n < PRETOKEN_CHUNK {
+            let Some(pretoken) = self.0.next() else { break };
+            let (key, h) = match pack_pretoken_key(pretoken.0) {
+                Some(key) => (key, pretoken_key_hash(key)),
+                None => (0, 0),
+            };
+            prefetch(h);
+            spans[n] = pretoken.0;
+            keys[n] = key;
+            hashes[n] = h;
+            n += 1;
+        }
+        n
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Pretokenize trait — Layer 3
 // ---------------------------------------------------------------------------
 
@@ -450,5 +624,114 @@ mod test {
 
         let pretokens_count = pretokenize_as_iter(&file_bytes).count();
         eprintln!("Pretokenized {pretokens_count} tokens");
+    }
+}
+
+#[cfg(test)]
+mod span_source_tests {
+    use super::*;
+
+    fn check_source<'a>(
+        mut src: impl PretokenSpans<'a>,
+        reference: impl Iterator<Item = Pretoken<'a>>,
+        scheme: &str,
+    ) {
+        let expected: Vec<&[u8]> = reference.map(|p| p.0).collect();
+        let mut got: Vec<&[u8]> = Vec::new();
+        let mut spans = [&[][..]; PRETOKEN_CHUNK];
+        let mut keys = [0u128; PRETOKEN_CHUNK];
+        let mut hashes = [0u64; PRETOKEN_CHUNK];
+        let prefetched = std::cell::Cell::new(0usize);
+        loop {
+            let n = src.fill_spans_keyed(&mut spans, &mut keys, &mut hashes, &|_h| {
+                prefetched.set(prefetched.get() + 1)
+            });
+            for i in 0..n {
+                let (want_key, want_hash) = match pack_pretoken_key(spans[i]) {
+                    Some(key) => (key, pretoken_key_hash(key)),
+                    None => (0, 0),
+                };
+                assert_eq!(keys[i], want_key, "{scheme}: bad key for {:?}", spans[i]);
+                assert_eq!(hashes[i], want_hash, "{scheme}: bad hash for {:?}", spans[i]);
+                got.push(spans[i]);
+            }
+            if n < PRETOKEN_CHUNK {
+                break;
+            }
+        }
+        assert_eq!(prefetched.get(), got.len(), "{scheme}: one prefetch per span");
+        assert_eq!(
+            got.len(),
+            expected.len(),
+            "{scheme}: span count mismatch"
+        );
+        for (i, (g, e)) in got.iter().zip(&expected).enumerate() {
+            assert_eq!(
+                g, e,
+                "{scheme}: span {i} diverged: {:?} vs {:?}",
+                String::from_utf8_lossy(g),
+                String::from_utf8_lossy(e)
+            );
+        }
+    }
+
+    /// Every scheme's chunked `fill_spans_keyed` must reproduce its
+    /// iterator's spans exactly, with keys/hashes derived per the shared
+    /// helpers, one prefetch per span — including chunk-boundary and
+    /// end-of-input handling (buffer sizes straddle multiples of
+    /// PRETOKEN_CHUNK spans).
+    #[test]
+    fn fill_spans_keyed_matches_iterator_all_schemes() {
+        let pieces: &[&str] = &[
+            "word", " word", "12", " 345678", "'ll", "'s", " ", "  ", "\n", "\r\n", "\t",
+            "!", " ?!", "(", "caf\u{e9}", "\u{65e5}\u{672c}", "\u{1F389}", "\u{00A0}",
+            "\u{2003}", "a", " I", "don't", "one two three four five", "\u{4e2d}\u{6587}",
+            "\u{30ab}\u{30bf}", "123456", " longpretokenword", "supercalifragilistic",
+        ];
+        let mut state = 0x9E3779B97F4A7C15u64;
+        let mut rng = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for round in 0..60 {
+            // Vary length so end-of-input lands at many chunk offsets.
+            let target = 40 + round * 97;
+            let mut buf = Vec::new();
+            while buf.len() < target {
+                buf.extend_from_slice(pieces[(rng() % pieces.len() as u64) as usize].as_bytes());
+            }
+            let b: &[u8] = &buf;
+            check_source(FastR50kPretokenizer::new(b), FastR50kPretokenizer::new(b), "r50k");
+            check_source(
+                FastCl100kPretokenizer::new(b),
+                FastCl100kPretokenizer::new(b),
+                "cl100k",
+            );
+            check_source(FastQwen2Pretokenizer::new(b), FastQwen2Pretokenizer::new(b), "qwen2");
+            check_source(
+                FastQwen35Pretokenizer::new(b),
+                FastQwen35Pretokenizer::new(b),
+                "qwen3_5",
+            );
+            check_source(FastOlmo3Pretokenizer::new(b), FastOlmo3Pretokenizer::new(b), "olmo3");
+            check_source(
+                FastDeepSeekV3Pretokenizer::new(b),
+                FastDeepSeekV3Pretokenizer::new(b),
+                "deepseek_v3",
+            );
+            check_source(PretokenizerIter::new(b), PretokenizerIter::new(b), "state_machine");
+            for pt in [
+                PretokenizerType::GPT2,
+                PretokenizerType::GPT4,
+                PretokenizerType::Qwen2,
+                PretokenizerType::Qwen35,
+                PretokenizerType::Olmo3,
+                PretokenizerType::DeepSeekV3,
+            ] {
+                check_source(pt.pretokenize(b), pt.pretokenize(b), "dispatch");
+            }
+        }
     }
 }

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -122,31 +122,18 @@ impl<'a> crate::pretokenize::PretokenSpans<'a> for FastPretokenizerDispatch<'a> 
     #[inline]
     fn fill_spans_keyed(
         &mut self,
-        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
-        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
-        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        batch: &mut crate::pretokenize::SpanBatch<'a>,
         prefetch: &impl Fn(u64),
     ) -> usize {
         use crate::pretokenize::PretokenSpans;
         match self {
-            FastPretokenizerDispatch::R50k(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
-            FastPretokenizerDispatch::Cl100k(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
-            FastPretokenizerDispatch::Qwen2(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
-            FastPretokenizerDispatch::Qwen35(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
-            FastPretokenizerDispatch::Olmo3(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
-            FastPretokenizerDispatch::DeepSeekV3(it) => {
-                it.fill_spans_keyed(spans, keys, hashes, prefetch)
-            }
+            FastPretokenizerDispatch::R50k(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Cl100k(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Qwen2(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Qwen35(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Olmo3(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::DeepSeekV3(it) => it.fill_spans_keyed(batch, prefetch),
         }
     }
 }
+

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -115,3 +115,38 @@ impl<'a> Iterator for FastPretokenizerDispatch<'a> {
         }
     }
 }
+
+impl<'a> crate::pretokenize::PretokenSpans<'a> for FastPretokenizerDispatch<'a> {
+    /// One dispatch per chunk instead of one per pretoken, delegating to
+    /// the concrete pretokenizers' fused chunk fills.
+    #[inline]
+    fn fill_spans_keyed(
+        &mut self,
+        spans: &mut [&'a [u8]; crate::pretokenize::PRETOKEN_CHUNK],
+        keys: &mut [u128; crate::pretokenize::PRETOKEN_CHUNK],
+        hashes: &mut [u64; crate::pretokenize::PRETOKEN_CHUNK],
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        use crate::pretokenize::PretokenSpans;
+        match self {
+            FastPretokenizerDispatch::R50k(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+            FastPretokenizerDispatch::Cl100k(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+            FastPretokenizerDispatch::Qwen2(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+            FastPretokenizerDispatch::Qwen35(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+            FastPretokenizerDispatch::Olmo3(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+            FastPretokenizerDispatch::DeepSeekV3(it) => {
+                it.fill_spans_keyed(spans, keys, hashes, prefetch)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the pretoken-cache `HashMap` with a purpose-built encode pipeline and fixes the allocation behavior that dominated first-pass encoding. Includes the front-cache commit (`1c10270`) from `optimize-encode-front-cache` in its history; the front cache itself is superseded by the new table.

- **`ShortPretokenCache`** (`src/bpe/pretoken_cache.rs`): open-addressing table with self-contained 32-byte entries (one cache line per probe vs. hashbrown's two), 2 MiB-aligned `MADV_HUGEPAGE` backing, and an explicit prefetch API.
- **Chunked encode loop**: `memoized_encode` pulls 256 pretokens per chunk through the new `PretokenSpans::fill_spans_keyed` interface — keys, hashes, and cache-line prefetches are derived in the pretokenizer's fused walker loop, so by probe time the lines are in L1 instead of costing a serial DRAM stall. Each `Fast*` scheme gets a fused out-of-line chunk fill; ~90 % of encodings (1–2 tokens) are stored inline in the entry's `u64` value, eliminating the dependent `token_arena` load.
- **Single-pass allocation fixes** (`src/batch.rs`): chunk output `Vec`s are reserved once from a bytes/4 estimate instead of doubling from empty (which re-copied ~the final size per chunk with realloc churn across 255 threads), token slices are appended with `extend`, and the multi-GB flat gather buffer is `MADV_HUGEPAGE`d before first touch.
- **Benchmark methodology**: `encode_doc` now measures one cold round per process (restart for independent samples; `ENCODE_ROUNDS` opts into repetition). In-process repetition inherits worker pretoken caches, allocator arenas, and faulted pages, overstating steady throughput by ~45 % vs. a true first pass over fresh data — which is the workload that matters.

## Benchmarks

Whole-document encode (`cargo bench --bench encode_doc`), GPT-2 vocab, 10 GB OWT as one document, 255 threads, AMD EPYC 7742 (Zen 2, AVX2). Single pass per process, 5 interleaved samples per variant:

| variant | samples (MB/s) | mean |
|---|---|---|
| `encode-perf` baseline (`0e27c71`) | 4565 / 4382 / 4489 / 4599 / 4575 | 4522 |
| front cache (`1c10270`) | 4486 / 4367 / 4872 / 4474 / 4996 | 4639 |
| **this PR (`fb0be88`)** | **6251 / 5995 / 6057 / 6164 / 6058** | **6105 (+35 %)** |

All variants produce identical token counts (2,268,672,027). The single-pass gain comes from the allocation fixes; the two cache designs measure within noise of each other on a first pass (with the allocation fix applied to both: 6034 vs. 5995 MB/s), because a first pass is not hit-path-bound. On warm re-encodes of the same input (retained worker pools, earlier 5-round protocol at 10 GB) the pipeline reaches 8–10 GB/s vs. 6.3–6.5 GB/s for the front cache, so the cache redesign is kept for workloads that re-encode.

Also measured and **rejected**: a vocab-seeded shared cache (prebuilt vocab-entry → token table shared across workers) was 7 % slower single-pass — first-pass misses live in the Zipf tail, and the extra probe per lookup costs more than the saved merges.

## Testing

- `memoized_encode_matches_reference_owt` (ignored, run manually): token-for-token differential of the cached pipeline vs. the uncached BPE reference over 50 MB of OWT — all 11.4 M tokens match.
- New `span_source_tests`: every scheme's fused `fill_spans_keyed` reproduces its iterator's spans/keys/hashes exactly, including chunk-boundary and end-of-input handling.
- `cargo test --release`: 46 passed; the 6 failures are pre-existing missing-data-file failures on this host (`~/data/tokenizers/*.tiktoken`), unrelated to this change.
- Empty pretokens through the public API pack to key 0 and route to the long map (`pack_pretoken_key` gained the `n == 0` guard, which also makes its 16-byte read provably in-bounds).