### PR TITLE
Add o200k and Nemotron-3 fast pretokenizers, gemma-3/4 SP support

### DIFF
--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1349,6 +1349,8 @@ mod tests {
             PretokenizerType::Qwen35,
             PretokenizerType::Olmo3,
             PretokenizerType::DeepSeekV3,
+            PretokenizerType::O200k,
+            PretokenizerType::Nemotron,
         ];
         let input = "Hello, 世界! café 12345\r\ncan't  stop".as_bytes();
 

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -74,6 +74,10 @@ struct PreTokenizerJson {
     add_prefix_space: Option<bool>,
     #[serde(default)]
     split: Option<bool>,
+    /// `Split` field (e.g. "MergedWithPrevious" for the gemma-3/4 no-op
+    /// space Split).
+    #[serde(default)]
+    behavior: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -323,7 +327,7 @@ fn build_sentencepiece(tj: &TokenizerJson) -> Result<SentencePieceBPE> {
     if let Some(n) = &tj.normalizer {
         parse_sp_normalizer(n, &mut norm_ops)?;
     }
-    let metaspace = parse_sp_metaspace(&tj.pre_tokenizer)?;
+    let metaspace = parse_sp_metaspace(&tj.pre_tokenizer, &norm_ops)?;
 
     // --- Extract added tokens (for splitting before encoding) ----------------
 
@@ -451,7 +455,13 @@ fn parse_sp_normalizer(n: &NormalizerJson, out: &mut Vec<NormOp>) -> Result<()> 
 /// Translate a tokenizer.json `pre_tokenizer` into a [`Metaspace`] config.
 /// `None` (no pre-tokenizer, e.g. Llama 2) leaves spaces to the normalizer
 /// and lets merges cross word boundaries.
-fn parse_sp_metaspace(pre_tokenizer: &Option<PreTokenizerJson>) -> Result<Option<Metaspace>> {
+///
+/// `norm_ops`: the already-parsed normalizer ops, used to prove that a
+/// `Split` on a literal space is a no-op (gemma-3/4).
+fn parse_sp_metaspace(
+    pre_tokenizer: &Option<PreTokenizerJson>,
+    norm_ops: &[NormOp],
+) -> Result<Option<Metaspace>> {
     fn from_metaspace(pt: &PreTokenizerJson) -> Result<Metaspace> {
         ensure!(
             pt.replacement.as_deref().unwrap_or("\u{2581}") == "\u{2581}",
@@ -485,6 +495,24 @@ fn parse_sp_metaspace(pre_tokenizer: &Option<PreTokenizerJson>) -> Result<Option
             if pt.pretokenizers.len() == 1 && pt.pretokenizers[0].kind == "Metaspace" =>
         {
             Ok(Some(from_metaspace(&pt.pretokenizers[0])?))
+        }
+        // gemma-3/4: `Split` on a literal " " with MergedWithPrevious. The
+        // normalizer has already replaced every space with "\u{2581}", so
+        // the Split never matches and the model BPE-merges across word
+        // boundaries exactly as with no pre-tokenizer at all. Accept it
+        // only when a norm op proves all spaces are gone by then.
+        "Split"
+            if matches!(
+                &pt.pattern,
+                Some(PatternJson { literal: Some(l), .. }) if l == " "
+            ) && pt.behavior.as_deref() == Some("MergedWithPrevious")
+                && norm_ops.iter().any(|op| matches!(
+                    op,
+                    NormOp::Replace { pattern, content }
+                        if pattern == " " && !content.contains(' ')
+                )) =>
+        {
+            Ok(None)
         }
         other => Err(eyre::eyre!(
             "Unsupported pre_tokenizer type for SentencePiece tokenizers: {other}"

--- a/src/pretokenize/fast/cl100k_family.rs
+++ b/src/pretokenize/fast/cl100k_family.rs
@@ -359,12 +359,18 @@ fn family_extended_masks(
                 cl.l = chm;
                 c.pl = 1;
             }
-            // A digit P1 needs no carries: `\p{N}` groups restart at
-            // token boundaries, and a batch can only start inside a
-            // digit run after the previous batch deferred it — the `pd`
-            // seed below defers the leading run.
+            // A digit P1 sets no letter/punct carries: `\p{N}` groups
+            // restart at token boundaries. A P1 entirely before the batch
+            // is covered by the `pd` seed (bit 0 is then an ASCII digit
+            // when the run continues). A digit char STRADDLING into the
+            // batch defeats that seed — bit 0 is its continuation byte,
+            // not an ASCII digit — so its claimed bytes defer via resid
+            // and the bad<<1 seed catches the following run. (Found by
+            // the o200k-family port's differential fuzz: "٢1234" with the
+            // ٢ split across a batch edge mis-phased `\p{N}{1,3}`.)
             CharClass::Number => {
                 cl.n = chm;
+                cl.resid |= chm;
             }
             CharClass::Other => {
                 cl.o = chm;
@@ -690,6 +696,21 @@ mod tests {
                 buf.extend_from_slice(case.as_bytes());
                 check_all(&buf);
             }
+        }
+    }
+
+    /// A multi-byte digit char straddling a batch edge, followed by
+    /// ASCII digits: the `\p{N}{1,3}` phase starts at the straddling
+    /// char, which the `pd` seed alone cannot see (bit 0 is a
+    /// continuation byte). Regression for the resid fix in
+    /// `family_extended_masks`; lead 127 was the failing alignment.
+    #[test]
+    fn family_straddling_digit_char_phase() {
+        for lead in 100..200usize {
+            let mut buf = vec![b'a'; lead];
+            buf.extend_from_slice("\u{662}1234".as_bytes());
+            buf.extend_from_slice(&vec![b'a'; 262 - 6 - lead][..]);
+            check_all(&buf);
         }
     }
 

--- a/src/pretokenize/fast/mod.rs
+++ b/src/pretokenize/fast/mod.rs
@@ -8,9 +8,12 @@
 
 pub(crate) mod cl100k_family;
 pub(crate) mod mask;
+pub(crate) mod o200k_family;
 
 pub mod cl100k;
 pub mod deepseek_v3;
+pub mod nemotron;
+pub mod o200k;
 pub mod olmo3;
 pub mod qwen2;
 pub mod qwen3_5;
@@ -18,6 +21,8 @@ pub mod r50k;
 
 pub use cl100k::FastCl100kPretokenizer;
 pub use deepseek_v3::FastDeepSeekV3Pretokenizer;
+pub use nemotron::FastNemotronPretokenizer;
+pub use o200k::FastO200kPretokenizer;
 pub use olmo3::FastOlmo3Pretokenizer;
 pub use qwen2::FastQwen2Pretokenizer;
 pub use qwen3_5::FastQwen35Pretokenizer;

--- a/src/pretokenize/fast/nemotron.rs
+++ b/src/pretokenize/fast/nemotron.rs
@@ -1,0 +1,131 @@
+//! Fast pretokenizer for the Nemotron-3 regex (nvidia Nemotron-3 family):
+//! `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+//!
+//! The o200k scheme without contraction suffixes and with single-char
+//! `\p{N}` digit tokens. See `o200k_family` (`CONTRACTIONS = false`,
+//! `DIGITS3 = false`).
+
+use super::mask::{MaskScheme, MaskState};
+use super::o200k_family;
+use crate::pretokenize::Pretoken;
+
+pub(crate) struct NemotronScheme;
+
+impl MaskScheme for NemotronScheme {
+    #[inline(always)]
+    fn advance(bytes: &[u8], pos: usize) -> usize {
+        o200k_family::advance_pos::<false, false>(bytes, pos)
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[inline(always)]
+    fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
+        o200k_family::batch_masks::<false, false>(bytes, scan)
+    }
+}
+
+/// With SIMD support (aarch64 NEON, or x86_64 AVX-512/AVX2 detected at
+/// runtime), iteration runs the shared o200k-family mask scanner (see
+/// `o200k_family::batch_masks`); elsewhere every token takes the scalar
+/// `advance_pos`.
+pub struct FastNemotronPretokenizer<'a> {
+    bytes: &'a [u8],
+    state: MaskState,
+}
+
+impl<'a> FastNemotronPretokenizer<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self::with_pos(bytes, 0)
+    }
+
+    /// Resume iteration at a byte offset previously returned by [`Self::pos`].
+    #[inline]
+    pub fn with_pos(bytes: &'a [u8], pos: usize) -> Self {
+        Self { bytes, state: MaskState::new(pos) }
+    }
+
+    /// Current position as a byte offset into the input.
+    #[inline]
+    pub fn pos(&self) -> usize {
+        self.state.pos
+    }
+}
+
+impl<'a> Iterator for FastNemotronPretokenizer<'a> {
+    type Item = Pretoken<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Pretoken<'a>> {
+        let (start, end) = self.state.next_span::<NemotronScheme>(self.bytes)?;
+        Some(Pretoken(&self.bytes[start..end]))
+    }
+}
+
+super::impl_mask_pretoken_spans!(FastNemotronPretokenizer, NemotronScheme);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Nemotron pattern verbatim — no possessive quantifiers, so it
+    /// runs directly under fancy-regex.
+    const NEMOTRON_REF_REGEX: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+
+    fn regex_tokens(s: &str) -> Vec<String> {
+        let re = fancy_regex::Regex::new(NEMOTRON_REF_REGEX).unwrap();
+        re.find_iter(s)
+            .map(|m| m.unwrap().as_str().to_string())
+            .collect()
+    }
+
+    fn fast_tokens(s: &str) -> Vec<String> {
+        FastNemotronPretokenizer::new(s.as_bytes())
+            .map(|t| String::from_utf8_lossy(t.0).into_owned())
+            .collect()
+    }
+
+    /// The o200k small-case list applies verbatim (contraction cases just
+    /// tokenize differently, which the reference regex reflects).
+    #[test]
+    fn nemotron_small_cases() {
+        for case in crate::pretokenize::fast::o200k::tests::SMALL_CASES {
+            assert_eq!(
+                fast_tokens(case),
+                regex_tokens(case),
+                "Mismatch on case {case:?}"
+            );
+        }
+    }
+
+    /// Random codepoint soup drawn from classes the scheme distinguishes,
+    /// compared against the reference regex.
+    #[test]
+    fn nemotron_matches_regex_random() {
+        use rand::prelude::*;
+        let pools: &[&[char]] = &[
+            &['a', 'z', 'é', 'ß', 'ж', 'ا', '한', '日'],      // lower/caseless
+            &['A', 'Z', 'É', 'Ж', 'Ǆ', 'ǅ'],                  // upper/title
+            &['1', '9', '٢', '½', 'Ⅷ', '๕'],                // numbers
+            &[' ', '\t', '\n', '\r', '\u{a0}', '\u{2028}'],   // whitespace
+            &['\u{301}', '\u{5bf}', '\u{93b}', '\u{20dd}'],   // marks
+            &['.', ',', '!', '$', '\'', '«', '¡', '€', '☃', '/'], // punct/symbols
+            &['\u{0}', '\u{ad}', '\u{200b}', '\u{e0001}'],    // other (C*)
+        ];
+        let mut rng = StdRng::seed_from_u64(0x93E3_5EEE);
+        for round in 0..3000 {
+            let len = rng.random_range(1..40);
+            let s: String = (0..len)
+                .map(|_| {
+                    let pool = pools.choose(&mut rng).unwrap();
+                    *pool.choose(&mut rng).unwrap()
+                })
+                .collect();
+            assert_eq!(
+                fast_tokens(&s),
+                regex_tokens(&s),
+                "Mismatch on round {round}, case {s:?}"
+            );
+        }
+    }
+}

--- a/src/pretokenize/fast/o200k.rs
+++ b/src/pretokenize/fast/o200k.rs
@@ -1,0 +1,340 @@
+//! Fast pretokenizer for the o200k_base regex (GPT-4o, gpt-oss):
+//! `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+//!
+//! See `o200k_family` for the shared scalar walker and mask-scanner
+//! boundary algebra (`CONTRACTIONS = true`, `DIGITS3 = true`).
+
+use super::mask::{MaskScheme, MaskState};
+use super::o200k_family;
+use crate::pretokenize::Pretoken;
+
+pub(crate) struct O200kScheme;
+
+impl MaskScheme for O200kScheme {
+    #[inline(always)]
+    fn advance(bytes: &[u8], pos: usize) -> usize {
+        o200k_family::advance_pos::<true, true>(bytes, pos)
+    }
+
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    #[inline(always)]
+    fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
+        o200k_family::batch_masks::<true, true>(bytes, scan)
+    }
+}
+
+/// With SIMD support (aarch64 NEON, or x86_64 AVX-512/AVX2 detected at
+/// runtime), iteration runs the shared o200k-family mask scanner (see
+/// `o200k_family::batch_masks`); elsewhere every token takes the scalar
+/// `advance_pos`.
+pub struct FastO200kPretokenizer<'a> {
+    bytes: &'a [u8],
+    state: MaskState,
+}
+
+impl<'a> FastO200kPretokenizer<'a> {
+    #[inline]
+    pub fn new(bytes: &'a [u8]) -> Self {
+        Self::with_pos(bytes, 0)
+    }
+
+    /// Resume iteration at a byte offset previously returned by [`Self::pos`].
+    #[inline]
+    pub fn with_pos(bytes: &'a [u8], pos: usize) -> Self {
+        Self { bytes, state: MaskState::new(pos) }
+    }
+
+    /// Current position as a byte offset into the input.
+    #[inline]
+    pub fn pos(&self) -> usize {
+        self.state.pos
+    }
+}
+
+impl<'a> Iterator for FastO200kPretokenizer<'a> {
+    type Item = Pretoken<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Pretoken<'a>> {
+        let (start, end) = self.state.next_span::<O200kScheme>(self.bytes)?;
+        Some(Pretoken(&self.bytes[start..end]))
+    }
+}
+
+super::impl_mask_pretoken_spans!(FastO200kPretokenizer, O200kScheme);
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use std::io::Read;
+
+    /// The o200k pattern verbatim — no possessive quantifiers, so it runs
+    /// directly under fancy-regex.
+    const O200K_REF_REGEX: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+
+    fn regex_tokens(s: &str) -> Vec<String> {
+        let re = fancy_regex::Regex::new(O200K_REF_REGEX).unwrap();
+        re.find_iter(s)
+            .map(|m| m.unwrap().as_str().to_string())
+            .collect()
+    }
+
+    fn fast_tokens(s: &str) -> Vec<String> {
+        FastO200kPretokenizer::new(s.as_bytes())
+            .map(|t| String::from_utf8_lossy(t.0).into_owned())
+            .collect()
+    }
+
+    /// Load the first `max_bytes` of ~/data/owt_train.txt, truncated to a
+    /// UTF-8 boundary (streamed; the full file is ~12 GB).
+    fn load_owt_prefix(max_bytes: usize) -> Vec<u8> {
+        let path = std::env::home_dir().unwrap().join("data/owt_train.txt");
+        let f = std::fs::File::open(&path).expect("Could not open ~/data/owt_train.txt");
+        let mut buf = Vec::with_capacity(max_bytes);
+        f.take(max_bytes as u64).read_to_end(&mut buf).unwrap();
+        while !buf.is_empty() && std::str::from_utf8(&buf).is_err() {
+            buf.pop();
+        }
+        buf
+    }
+
+    pub(crate) const SMALL_CASES: &[&str] = &[
+        "hello",
+        "Hello",
+        "HELLO",
+        "HeLLo",
+        "camelCase",
+        "PascalCase",
+        "HTTPResponse",
+        "HTTPresponse",
+        "parseHTMLDocument",
+        "XMLHttpRequest",
+        "aB",
+        "aBc",
+        "ABc",
+        "ABCdef GHIjkl",
+        " hello",
+        " Hello World",
+        "hello world",
+        "  hello",
+        "\thello",
+        "\tHello",
+        "\nhello",
+        "\n\nHello",
+        "!hello",
+        "!Hello",
+        "!!hello",
+        "?!x",
+        "don't",
+        "DON'T",
+        "Don'T",
+        "don'ts",
+        "can'ts more",
+        "they'LL go",
+        "it'S he'Ll",
+        "we'Ve THEY'RE",
+        "x'll'd",
+        "don't's",
+        "o'clock",
+        "don'x",
+        "x'lm",
+        "x'm'm",
+        "'sound",
+        "'Sound",
+        "'lx",
+        "'hello",
+        " 'hello",
+        " 's",
+        " 'S",
+        "x'0",
+        "3's",
+        "3'ts",
+        "123",
+        "1234",
+        "1234567",
+        " 123",
+        "  123",
+        "3rd",
+        "abc1234def",
+        "hello, world!",
+        "hi!\n\ndef",
+        "hi !!\n\ndef",
+        " !!!",
+        "a-b",
+        "a - b",
+        "...",
+        "a/b",
+        "a//b",
+        "http://x.com/path",
+        ".\n//x",
+        "!\n/",
+        "!\n/\n/x",
+        "\n/",
+        "//\n/",
+        "x/\n",
+        "x\n/",
+        "hello\n",
+        "hello \n",
+        "hello \nx",
+        "hello\n x",
+        "hello  \n\n  ",
+        "x \n\n ",
+        "x  ",
+        "x \t",
+        "  \n  hello",
+        "\r\nhello",
+        "a\r\n",
+        "a\r\n ",
+        "a\n \n",
+        "a \n \t",
+        "\n\n",
+        "\n\n\t",
+        "   ",
+        " ",
+        "",
+        "café",
+        "Café",
+        "CAFÉ",
+        "cafÉ",
+        " café",
+        "\u{a0}word",
+        "voilà ¡hola!",
+        "ΑΒΓδε",
+        "αβΓΔ",
+        "Привет Мир",
+        "ПРИВЕТ мир",
+        "ẞßẞ",
+        "ǅungla ǄUNGLA ǆungla",
+        "١٢٣٤٥",
+        "1٢3x",
+        "١٢٣٤٥٦٧",
+        "tab\tsep\tvals",
+        "\x0bword",
+        "a\u{2028}b",
+        "a\u{2028}\n",
+        "price: $5.99!",
+        "'ſ",
+        "x'ſ fine",
+        "日本語のテキスト",
+        " 日本語",
+        "日本語ABC",
+        "abc日本語Def",
+        "e\u{301}f",
+        "cafe\u{301} de\u{301}composed",
+        "\u{301}leading mark",
+        "\u{301}\u{301}two marks",
+        " \u{301}abc",
+        "\t\u{301}abc",
+        "!\u{301}",
+        "!\u{301}!",
+        "!!\u{301}x",
+        "!!\u{301}X",
+        "1\u{301}2",
+        "'\u{301}s",
+        "A\u{301}B",
+        "a\u{301}B",
+        "x\u{301}'s",
+        "деВНАгарІ",
+        "देवनागरी में परीक्षण",
+        "עִבְרִית נִקּוּד",
+        "الْعَرَبِيَّة",
+        "a\u{20dd}b",
+        " \u{20dd}",
+        "\u{200b}\u{301}x",
+    ];
+
+    #[test]
+    fn o200k_small_cases() {
+        for case in SMALL_CASES {
+            assert_eq!(
+                fast_tokens(case),
+                regex_tokens(case),
+                "Mismatch on case {case:?}"
+            );
+        }
+    }
+
+    /// Random codepoint soup drawn from classes the scheme distinguishes,
+    /// compared against the reference regex.
+    #[test]
+    fn o200k_matches_regex_random() {
+        use rand::prelude::*;
+        let pools: &[&[char]] = &[
+            &['a', 'z', 'é', 'ß', 'ж', 'ا', '한', '日'],      // lower/caseless
+            &['A', 'Z', 'É', 'Ж', 'Ǆ', 'ǅ'],                  // upper/title
+            &['1', '9', '٢', '½', 'Ⅷ', '๕'],                // numbers
+            &[' ', '\t', '\n', '\r', '\u{a0}', '\u{2028}'],   // whitespace
+            &['\u{301}', '\u{5bf}', '\u{93b}', '\u{20dd}'],   // marks
+            &['.', ',', '!', '$', '\'', '«', '¡', '€', '☃', '/'], // punct/symbols
+            &['\u{0}', '\u{ad}', '\u{200b}', '\u{e0001}'],    // other (C*)
+            &['s', 't', 'm', 'd', 'l', 'v', 'r', 'e', 'S', 'T', 'L'], // suffix letters
+        ];
+        let mut rng = StdRng::seed_from_u64(0x93E3_5EED);
+        for round in 0..3000 {
+            let len = rng.random_range(1..40);
+            let s: String = (0..len)
+                .map(|_| {
+                    let pool = pools.choose(&mut rng).unwrap();
+                    *pool.choose(&mut rng).unwrap()
+                })
+                .collect();
+            assert_eq!(
+                fast_tokens(&s),
+                regex_tokens(&s),
+                "Mismatch on round {round}, case {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn o200k_matches_regex_owt() {
+        const SIZE: usize = 5_000_000;
+        let input = load_owt_prefix(SIZE);
+        let text = std::str::from_utf8(&input).unwrap();
+        eprintln!(
+            "Testing o200k fast pretokenizer vs regex on {:.1} MB of OWT",
+            input.len() as f64 / 1e6
+        );
+
+        let re = fancy_regex::Regex::new(O200K_REF_REGEX).unwrap();
+        let mut fast_iter = FastO200kPretokenizer::new(&input);
+        let mut re_iter = re.find_iter(text);
+        let mut token_idx: usize = 0;
+        let mut recent: Vec<(String, String)> = Vec::new();
+
+        loop {
+            match (fast_iter.next(), re_iter.next()) {
+                (Some(fast_tok), Some(re_match)) => {
+                    let re_match = re_match.expect("regex match error");
+                    let fast_str = String::from_utf8_lossy(fast_tok.0);
+                    let re_str = &text[re_match.start()..re_match.end()];
+                    recent.push((fast_str.to_string(), re_str.to_string()));
+                    if recent.len() > 10 {
+                        recent.remove(0);
+                    }
+                    assert_eq!(
+                        fast_str, re_str,
+                        "Mismatch at token {token_idx} (byte ~{}).\n  fast:  {:?}\n  regex: {:?}\n  recent tokens: {:?}",
+                        re_match.start(), fast_str, re_str, recent
+                    );
+                }
+                (None, None) => break,
+                (Some(fast_tok), None) => panic!(
+                    "Fast produced extra token at index {token_idx}: {:?}\n  recent: {:?}",
+                    String::from_utf8_lossy(fast_tok.0),
+                    recent
+                ),
+                (None, Some(re_match)) => {
+                    let re_match = re_match.expect("regex match error");
+                    panic!(
+                        "Regex produced extra token at index {token_idx}: {:?}\n  recent: {:?}",
+                        &text[re_match.start()..re_match.end()],
+                        recent
+                    );
+                }
+            }
+            token_idx += 1;
+        }
+        eprintln!("All {token_idx} tokens match.");
+    }
+}

--- a/src/pretokenize/fast/o200k_family.rs
+++ b/src/pretokenize/fast/o200k_family.rs
@@ -44,7 +44,7 @@ use super::{decode_cp, is_ascii_ws, is_digit, is_letter, scan_numbers_max3};
 use crate::pretokenize::unicode::{O200kCharClass, o200k_class_of};
 
 #[inline(always)]
-pub(crate) fn is_upper_ascii(b: u8) -> bool {
+fn is_upper_ascii(b: u8) -> bool {
     b.wrapping_sub(b'A') < 26
 }
 
@@ -71,18 +71,24 @@ enum CaseState {
     L,
 }
 
+/// Initial [`CaseState`] for a run starting on an ASCII letter (ASCII has
+/// no caseless letters).
+#[inline(always)]
+fn ascii_letter_state(b: u8) -> CaseState {
+    if is_upper_ascii(b) {
+        CaseState::U { last_cl_end: 0 }
+    } else {
+        CaseState::L
+    }
+}
+
 /// If the char at `pos` is a letter-run member (`\p{L}` or `\p{M}`),
 /// return (offset past it, initial scan state).
 #[inline(always)]
 fn letter_run_first(bytes: &[u8], pos: usize) -> Option<(usize, CaseState)> {
     let &b = bytes.get(pos)?;
     if is_letter(b) {
-        let st = if is_upper_ascii(b) {
-            CaseState::U { last_cl_end: 0 }
-        } else {
-            CaseState::L
-        };
-        return Some((pos + 1, st));
+        return Some((pos + 1, ascii_letter_state(b)));
     }
     if b >= 0x80 {
         let (cp, l) = unsafe { decode_cp(bytes, pos) };
@@ -279,12 +285,7 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
 
     // Hot path 1: ASCII letter run (empty prefix)
     if is_letter(b0) {
-        let st = if is_upper_ascii(b0) {
-            CaseState::U { last_cl_end: 0 }
-        } else {
-            CaseState::L
-        };
-        let e = scan_case_run(bytes, pos + 1, st);
+        let e = scan_case_run(bytes, pos + 1, ascii_letter_state(b0));
         return try_suffix::<CONTRACTIONS>(bytes, e);
     }
 
@@ -294,12 +295,7 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
             return pos + 1; // trailing lone space (`\s+(?!\S)` at EOS)
         };
         if is_letter(b1) {
-            let st = if is_upper_ascii(b1) {
-                CaseState::U { last_cl_end: 0 }
-            } else {
-                CaseState::L
-            };
-            let e = scan_case_run(bytes, pos + 2, st);
+            let e = scan_case_run(bytes, pos + 2, ascii_letter_state(b1));
             return try_suffix::<CONTRACTIONS>(bytes, e);
         }
         if b1 < 0x80 {
@@ -442,9 +438,13 @@ struct OUni {
     /// (char-counted grouping), ws straddling the batch end, stray
     /// continuation bytes.
     resid: u64,
-    /// Mark bytes (±4 bad smear: a mark's run-contextual class can affect
-    /// the boundary of a char up to two chars — 4 lookahead bytes for the
-    /// following lead — after it).
+    /// Mark bytes (±4 bad smear). A mark's run-contextual class can
+    /// affect boundaries up to two CHARS after it, which multi-byte
+    /// followers can push past the 4-byte smear; those stragglers are
+    /// wrongly-cleared bits (extending the scalar walk) or wrongly-set
+    /// bits interior to a token starting inside the zone, both killed by
+    /// MaskState's resume masking after the scalar overrun — the same
+    /// invariant the resid zones rely on.
     mk: u64,
 }
 
@@ -1388,24 +1388,78 @@ mod tests {
         out
     }
 
+    /// Scalar-vs-mask token streams for both family schemes.
     #[track_caller]
-    fn check_one<S: MaskScheme>(buf: &[u8], scheme: &str) {
-        let a = scalar_tokens::<S>(buf);
-        let b = mask_tokens::<S>(buf);
-        if a != b {
-            let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
-            panic!(
-                "{scheme} diverged at token {i} on {:?}\n  scalar: {:?}\n  mask:   {:?}",
-                String::from_utf8_lossy(buf),
-                a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-                b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-            );
+    fn check_all(buf: &[u8]) {
+        for (name, a, b) in [
+            ("o200k", scalar_tokens::<O200kScheme>(buf), mask_tokens::<O200kScheme>(buf)),
+            ("nemotron", scalar_tokens::<NemotronScheme>(buf), mask_tokens::<NemotronScheme>(buf)),
+        ] {
+            if a != b {
+                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
+                panic!(
+                    "{name} diverged at token {i} on {:?}\n  scalar: {:?}\n  mask:   {:?}",
+                    String::from_utf8_lossy(buf),
+                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                );
+            }
         }
     }
 
-    fn check_all(buf: &[u8]) {
-        check_one::<O200kScheme>(buf, "o200k");
-        check_one::<NemotronScheme>(buf, "nemotron");
+    /// Alignment-preserving shrink: replace chars with 'a' and trim the
+    /// tail while the buffer still diverges, then report the minimum.
+    fn shrink_and_report(bytes: &[u8]) -> String {
+        let fails = |b: &[u8]| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| check_all(b))).is_err()
+        };
+        let mut buf = bytes.to_vec();
+        let mut changed = true;
+        while changed {
+            changed = false;
+            let mut i = 0;
+            while i < buf.len() {
+                let mut l = 1;
+                if buf[i] >= 0xC2 {
+                    l = if buf[i] < 0xE0 { 2 } else if buf[i] < 0xF0 { 3 } else { 4 };
+                }
+                let saved: Vec<u8> = buf[i..i + l].to_vec();
+                if saved != vec![b'a'; l] {
+                    for j in 0..l {
+                        buf[i + j] = b'a';
+                    }
+                    if fails(&buf) {
+                        changed = true;
+                    } else {
+                        buf[i..i + l].copy_from_slice(&saved);
+                    }
+                }
+                i += l;
+            }
+            while buf.len() > 1 && buf[buf.len() - 1] == b'a' && fails(&buf[..buf.len() - 1]) {
+                buf.pop();
+                changed = true;
+            }
+        }
+        let mut report = format!("(len {}) {:?}", buf.len(), String::from_utf8_lossy(&buf));
+        for (name, a, b) in [
+            ("o200k", scalar_tokens::<O200kScheme>(&buf), mask_tokens::<O200kScheme>(&buf)),
+            (
+                "nemotron",
+                scalar_tokens::<NemotronScheme>(&buf),
+                mask_tokens::<NemotronScheme>(&buf),
+            ),
+        ] {
+            if a != b {
+                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
+                report.push_str(&format!(
+                    "\n  {name} token {i}: scalar {:?} mask {:?}",
+                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                ));
+            }
+        }
+        report
     }
 
     /// Crafted cases, padded so they cross the batch (not scalar-tail) path.
@@ -1428,6 +1482,10 @@ mod tests {
             "mixed 1\u{662}3x \u{661}\u{662}\u{663} arabic",
             "\u{65e5}\u{672c}\u{8a9e}ABC abc\u{65e5}\u{672c}Def \u{416}\u{416}dz",
             "e\u{301}f !!\u{301}x '\u{301}s x\u{301}'s A\u{301}B",
+            // A mark's contextual class reaching a boundary past the ±4
+            // bad smear (4-byte punct char in between): relies on the
+            // walker's scalar-overrun masking.
+            "a\u{301}\u{1f389}b !\u{301}\u{1f389}x a\u{301}\u{1f389}'s a\u{301}\n\n\n\n/x",
         ];
         for case in cases {
             for lead in [0usize, 1, 37, 61, 62, 63, 64, 65] {
@@ -1471,7 +1529,7 @@ mod tests {
             if !ok {
                 panic!(
                     "round {round} diverged; minimal case: {}",
-                    super::tests_shim::shrink_and_report(&buf)
+                    shrink_and_report(&buf)
                 );
             }
         }
@@ -1535,106 +1593,6 @@ mod owt_tests {
         let input = std::fs::read(&path).expect("Could not read ~/data/owt_train.txt");
         eprintln!("loaded {} bytes", input.len());
         check_streaming_all(&input);
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod tests_shim {
-    use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
-    use crate::pretokenize::fast::nemotron::NemotronScheme;
-    use crate::pretokenize::fast::o200k::O200kScheme;
-
-    fn scalar_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
-        let mut pos = 0;
-        let mut out = vec![];
-        while pos < bytes.len() {
-            let e = S::advance(bytes, pos);
-            out.push(bytes[pos..e].to_vec());
-            pos = e;
-        }
-        out
-    }
-
-    fn mask_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
-        let mut st = MaskState::new(0);
-        let mut out = vec![];
-        while let Some((s, e)) = st.next_span::<S>(bytes) {
-            out.push(bytes[s..e].to_vec());
-        }
-        out
-    }
-
-    /// Alignment-preserving shrink: replace chars with 'a' and trim the
-    /// tail while the buffer still diverges, then report the minimum.
-    pub(crate) fn shrink_and_report(bytes: &[u8]) -> String {
-        let fails = |b: &[u8]| {
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| check_all_pub(b))).is_err()
-        };
-        let mut buf = bytes.to_vec();
-        let mut changed = true;
-        while changed {
-            changed = false;
-            let mut i = 0;
-            while i < buf.len() {
-                let mut l = 1;
-                if buf[i] >= 0xC2 {
-                    l = if buf[i] < 0xE0 { 2 } else if buf[i] < 0xF0 { 3 } else { 4 };
-                }
-                let saved: Vec<u8> = buf[i..i + l].to_vec();
-                if saved != vec![b'a'; l] {
-                    for j in 0..l {
-                        buf[i + j] = b'a';
-                    }
-                    if fails(&buf) {
-                        changed = true;
-                    } else {
-                        buf[i..i + l].copy_from_slice(&saved);
-                    }
-                }
-                i += l;
-            }
-            while buf.len() > 1 && buf[buf.len() - 1] == b'a' && fails(&buf[..buf.len() - 1]) {
-                buf.pop();
-                changed = true;
-            }
-        }
-        let mut report = format!("(len {}) {:?}", buf.len(), String::from_utf8_lossy(&buf));
-        for (name, a, b) in [
-            ("o200k", scalar_tokens::<O200kScheme>(&buf), mask_tokens::<O200kScheme>(&buf)),
-            (
-                "nemotron",
-                scalar_tokens::<NemotronScheme>(&buf),
-                mask_tokens::<NemotronScheme>(&buf),
-            ),
-        ] {
-            if a != b {
-                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
-                report.push_str(&format!(
-                    "\n  {name} token {i}: scalar {:?} mask {:?}",
-                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-                ));
-            }
-        }
-        report
-    }
-
-    #[track_caller]
-    pub(crate) fn check_all_pub(buf: &[u8]) {
-        for (name, a, b) in [
-            ("o200k", scalar_tokens::<O200kScheme>(buf), mask_tokens::<O200kScheme>(buf)),
-            ("nemotron", scalar_tokens::<NemotronScheme>(buf), mask_tokens::<NemotronScheme>(buf)),
-        ] {
-            if a != b {
-                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
-                panic!(
-                    "{name} diverged at token {i} on {:?}\n  scalar: {:?}\n  mask:   {:?}",
-                    String::from_utf8_lossy(buf),
-                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
-                );
-            }
-        }
     }
 }
 

--- a/src/pretokenize/fast/o200k_family.rs
+++ b/src/pretokenize/fast/o200k_family.rs
@@ -1,0 +1,1640 @@
+//! Shared implementation for the o200k regex family: o200k_base (GPT-4o,
+//! gpt-oss) and the Nemotron-3 variant. Their patterns share the shape
+//!
+//! `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+SUF?|
+//!  [^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*SUF?|
+//!  \p{N}{1,3} or \p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+//!
+//! where `SUF = (?i:'s|'t|'re|'ve|'m|'ll|'d)` exists only in o200k
+//! (`CONTRACTIONS`), and the digit group is `\p{N}{1,3}` for o200k vs
+//! `\p{N}` for Nemotron (`DIGITS3`).
+//!
+//! Differences from the cl100k family:
+//! - Letter runs are case-structured. Under leftmost-greedy backtracking
+//!   the two letter alternatives reduce to a phase automaton (see
+//!   [`CaseState`]): ULC phase until the first strict-lower (Ll), then
+//!   LLC phase, where a strict-upper (Lu/Lt) ends the token; a run ending
+//!   while still in ULC phase backtracks to its last caseless/mark char
+//!   ("camelCase" -> `camel|Case`, "HTTPResponse" one token,
+//!   "AxxB" -> `Axx|B` for caseless x). For pure-ASCII text there are no
+//!   caseless letters, so the rule IS pairwise: a boundary sits before
+//!   `[A-Z]` exactly when the previous char is `[a-z]` — what the ASCII
+//!   mask algebra uses; caseless-before-upper needs the phase and
+//!   lookahead, so the extended path defers those (rare) chars.
+//! - Contractions are attached suffixes of the letter alternatives, not a
+//!   standalone alternative: "don't" is ONE token, and the char after a
+//!   consumed suffix always starts a new token ("can'ts" -> `can't|s`).
+//!   A contraction applies only when the apostrophe directly follows a
+//!   letter-run char; elsewhere `'` is ordinary punctuation (which may
+//!   still prefix a letter run: "3'ts" -> `3|'ts`).
+//! - Punctuation runs absorb a `[\r\n/]*` tail. Since `/` is itself in
+//!   the punct class, the absorbed tail always begins with a newline:
+//!   ".\n//" is one token.
+//! - Marks (`\p{M}`) are dual-class: they join letter runs (they sit in
+//!   both letter brackets) AND continue `[^\s\p{L}\p{N}]+` punct runs.
+//!   Their effective class is run-contextual, so the mask scanner routes
+//!   mark chars (rare) through the scalar path as bad zones.
+//!
+//! The boundary algebra below mirrors `cl100k_family` — see that module
+//! and pretokenizer_optimization_log.md step 16 for the base rules.
+
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+use super::mask::{self, AsciiMasks};
+use super::{decode_cp, is_ascii_ws, is_digit, is_letter, scan_numbers_max3};
+use crate::pretokenize::unicode::{O200kCharClass, o200k_class_of};
+
+#[inline(always)]
+pub(crate) fn is_upper_ascii(b: u8) -> bool {
+    b.wrapping_sub(b'A') < 26
+}
+
+/// Is this byte in the `[\r\n/]` tail class?
+#[inline(always)]
+fn is_tail_byte(b: u8) -> bool {
+    matches!(b, b'\r' | b'\n' | b'/')
+}
+
+// -----------------------------------------------------------------------
+// Scalar ground truth
+// -----------------------------------------------------------------------
+
+/// Scan state of a case-structured letter run, mirroring the two-bracket
+/// alternatives under leftmost-greedy backtracking. `U`: still inside
+/// `[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*` (no strict-lower seen yet);
+/// `last_cl_end` is the end offset of the last caseless/mark char in the
+/// phase (0 = none) — the backtrack split point if the run ends on a
+/// strict-upper tail. `L`: inside `[\p{Ll}\p{Lm}\p{Lo}\p{M}]+`, where a
+/// strict-upper char ends the token unconditionally.
+#[derive(Clone, Copy)]
+enum CaseState {
+    U { last_cl_end: usize },
+    L,
+}
+
+/// If the char at `pos` is a letter-run member (`\p{L}` or `\p{M}`),
+/// return (offset past it, initial scan state).
+#[inline(always)]
+fn letter_run_first(bytes: &[u8], pos: usize) -> Option<(usize, CaseState)> {
+    let &b = bytes.get(pos)?;
+    if is_letter(b) {
+        let st = if is_upper_ascii(b) {
+            CaseState::U { last_cl_end: 0 }
+        } else {
+            CaseState::L
+        };
+        return Some((pos + 1, st));
+    }
+    if b >= 0x80 {
+        let (cp, l) = unsafe { decode_cp(bytes, pos) };
+        match o200k_class_of(cp) {
+            O200kCharClass::Upper => return Some((pos + l, CaseState::U { last_cl_end: 0 })),
+            O200kCharClass::Lower => return Some((pos + l, CaseState::L)),
+            O200kCharClass::Caseless | O200kCharClass::Mark => {
+                return Some((pos + l, CaseState::U { last_cl_end: pos + l }));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Letter-run continuation with the o200k casing rules: scan run members
+/// (letters and marks) from `pos` with the phase automaton described on
+/// [`CaseState`]. In phase U a strict-upper char continues the token and
+/// a strict-lower switches to phase L; in phase L a strict-upper ends
+/// the token. A run that ends while still in phase U backtracks to the
+/// last caseless/mark char, splitting off the trailing strict-upper run
+/// (which the next `advance` then consumes whole): "AxxB" -> `Axx|B`
+/// for caseless x, "HTTPResponse" and "Z\u{5BF}\u{416}dz" one token.
+#[inline(always)]
+fn scan_case_run(bytes: &[u8], mut pos: usize, mut st: CaseState) -> usize {
+    let len = bytes.len();
+    loop {
+        while pos < len {
+            let b = unsafe { *bytes.get_unchecked(pos) };
+            if is_upper_ascii(b) {
+                if matches!(st, CaseState::L) {
+                    return pos;
+                }
+                pos += 1;
+            } else if is_letter(b) {
+                st = CaseState::L;
+                pos += 1;
+            } else {
+                break;
+            }
+        }
+        if pos < len && unsafe { *bytes.get_unchecked(pos) } >= 0x80 {
+            let (cp, l) = unsafe { decode_cp(bytes, pos) };
+            match o200k_class_of(cp) {
+                O200kCharClass::Upper => {
+                    if matches!(st, CaseState::L) {
+                        return pos;
+                    }
+                    pos += l;
+                }
+                O200kCharClass::Lower => {
+                    st = CaseState::L;
+                    pos += l;
+                }
+                O200kCharClass::Caseless | O200kCharClass::Mark => {
+                    pos += l;
+                    if let CaseState::U { ref mut last_cl_end } = st {
+                        *last_cl_end = pos;
+                    }
+                }
+                _ => break,
+            }
+            continue;
+        }
+        break;
+    }
+    // End of the letter run. A phase-U run ending on a strict-upper tail
+    // backtracks to the last caseless/mark char (`[LLC]+` must consume at
+    // least one char, and only a caseless/mark can be given back).
+    match st {
+        CaseState::U { last_cl_end } if last_cl_end != 0 => last_cl_end,
+        _ => pos,
+    }
+}
+
+/// Attach a `(?i:'s|'t|'re|'ve|'m|'ll|'d)?` suffix to a letter token
+/// ending at `end`, when the scheme has contractions.
+#[inline(always)]
+fn try_suffix<const CONTRACTIONS: bool>(bytes: &[u8], end: usize) -> usize {
+    if !CONTRACTIONS || bytes.get(end) != Some(&b'\'') {
+        return end;
+    }
+    match bytes.get(end + 1).map(u8::to_ascii_lowercase) {
+        Some(b's' | b'd' | b'm' | b't') => end + 2,
+        Some(b'l') if bytes.get(end + 2).map(u8::to_ascii_lowercase) == Some(b'l') => end + 3,
+        Some(b'v') if bytes.get(end + 2).map(u8::to_ascii_lowercase) == Some(b'e') => end + 3,
+        Some(b'r') if bytes.get(end + 2).map(u8::to_ascii_lowercase) == Some(b'e') => end + 3,
+        // U+017F LATIN SMALL LETTER LONG S case-folds to 's' under `(?i)`
+        Some(0xC5) if bytes.get(end + 2) == Some(&0xBF) => end + 3,
+        _ => end,
+    }
+}
+
+/// `[^\s\p{L}\p{N}]+` from `pos` (punctuation, symbols, marks, controls —
+/// everything except letters, numbers, and whitespace).
+#[inline(always)]
+fn scan_punct_from(bytes: &[u8], pos: usize) -> usize {
+    let len = bytes.len();
+    let mut p = pos;
+    loop {
+        while p < len {
+            let b = unsafe { *bytes.get_unchecked(p) };
+            if b >= 0x80 {
+                break;
+            }
+            if is_letter(b) || is_digit(b) || is_ascii_ws(b) {
+                return p;
+            }
+            p += 1;
+        }
+        if p < len {
+            let (cp, l) = unsafe { decode_cp(bytes, p) };
+            if matches!(
+                o200k_class_of(cp),
+                O200kCharClass::Other | O200kCharClass::Mark
+            ) {
+                p += l;
+                continue;
+            }
+        }
+        return p;
+    }
+}
+
+/// `[\r\n/]*`: the tail absorbed after a punctuation run.
+#[inline(always)]
+fn scan_tail(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && is_tail_byte(unsafe { *bytes.get_unchecked(pos) }) {
+        pos += 1;
+    }
+    pos
+}
+
+/// Whitespace-led token starting at `start`: `\s*[\r\n]+` | `\s+(?!\S)` |
+/// `\s+`, in that priority. Precondition: the letter-prefix and
+/// space+punct alternatives were ruled out.
+#[inline(always)]
+fn ws_token_end(bytes: &[u8], start: usize) -> usize {
+    let len = bytes.len();
+    let mut p = start;
+    let mut last_nl_end = 0usize; // 0 = run contains no \r\n
+    let mut last_char_start = start;
+    while p < len {
+        let b = unsafe { *bytes.get_unchecked(p) };
+        if b == b'\r' || b == b'\n' {
+            last_char_start = p;
+            p += 1;
+            last_nl_end = p;
+        } else if is_ascii_ws(b) {
+            last_char_start = p;
+            p += 1;
+        } else if b >= 0x80 {
+            let (cp, l) = unsafe { decode_cp(bytes, p) };
+            if o200k_class_of(cp) == O200kCharClass::Whitespace {
+                last_char_start = p;
+                p += l;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    if last_nl_end != 0 {
+        return last_nl_end; // `\s*[\r\n]+`: through the last newline
+    }
+    if p >= len {
+        return p; // `\s+(?!\S)`: lookahead succeeds at EOS
+    }
+    if last_char_start > start {
+        return last_char_start; // `\s+(?!\S)`: all but the last ws char
+    }
+    p // `\s+`: single whitespace char before content
+}
+
+/// `\p{N}{1,3}` or `\p{N}` starting at a digit char ending at `first_end`.
+#[inline(always)]
+fn digit_token_end<const DIGITS3: bool>(bytes: &[u8], first_end: usize) -> usize {
+    if DIGITS3 {
+        scan_numbers_max3(bytes, first_end, 1)
+    } else {
+        first_end
+    }
+}
+
+/// Advance past one token starting at `pos`. Returns the new position.
+/// `pos` must be < `bytes.len()`.
+#[inline(always)]
+pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    pos: usize,
+) -> usize {
+    let b0 = unsafe { *bytes.get_unchecked(pos) };
+
+    // Hot path 1: ASCII letter run (empty prefix)
+    if is_letter(b0) {
+        let st = if is_upper_ascii(b0) {
+            CaseState::U { last_cl_end: 0 }
+        } else {
+            CaseState::L
+        };
+        let e = scan_case_run(bytes, pos + 1, st);
+        return try_suffix::<CONTRACTIONS>(bytes, e);
+    }
+
+    // Hot path 2: space prefix
+    if b0 == b' ' {
+        let Some(&b1) = bytes.get(pos + 1) else {
+            return pos + 1; // trailing lone space (`\s+(?!\S)` at EOS)
+        };
+        if is_letter(b1) {
+            let st = if is_upper_ascii(b1) {
+                CaseState::U { last_cl_end: 0 }
+            } else {
+                CaseState::L
+            };
+            let e = scan_case_run(bytes, pos + 2, st);
+            return try_suffix::<CONTRACTIONS>(bytes, e);
+        }
+        if b1 < 0x80 {
+            if is_digit(b1) {
+                return pos + 1; // numbers never absorb the space
+            }
+            if is_ascii_ws(b1) {
+                return ws_token_end(bytes, pos);
+            }
+            // ` ?[^\s\p{L}\p{N}]+[\r\n/]*`
+            let p = scan_punct_from(bytes, pos + 2);
+            return scan_tail(bytes, p);
+        }
+        let (cp, l) = unsafe { decode_cp(bytes, pos + 1) };
+        let p1 = pos + 1 + l;
+        return match o200k_class_of(cp) {
+            O200kCharClass::Upper => try_suffix::<CONTRACTIONS>(
+                bytes,
+                scan_case_run(bytes, p1, CaseState::U { last_cl_end: 0 }),
+            ),
+            O200kCharClass::Lower => {
+                try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, p1, CaseState::L))
+            }
+            O200kCharClass::Caseless | O200kCharClass::Mark => try_suffix::<CONTRACTIONS>(
+                bytes,
+                scan_case_run(bytes, p1, CaseState::U { last_cl_end: p1 }),
+            ),
+            O200kCharClass::Whitespace => ws_token_end(bytes, pos),
+            O200kCharClass::Number => pos + 1,
+            O200kCharClass::Other => scan_tail(bytes, scan_punct_from(bytes, p1)),
+        };
+    }
+
+    // Non-ASCII first char
+    if b0 >= 0x80 {
+        let (cp, l) = unsafe { decode_cp(bytes, pos) };
+        let p0 = pos + l;
+        return match o200k_class_of(cp) {
+            O200kCharClass::Upper => try_suffix::<CONTRACTIONS>(
+                bytes,
+                scan_case_run(bytes, p0, CaseState::U { last_cl_end: 0 }),
+            ),
+            O200kCharClass::Lower => {
+                try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, p0, CaseState::L))
+            }
+            O200kCharClass::Caseless | O200kCharClass::Mark => try_suffix::<CONTRACTIONS>(
+                bytes,
+                scan_case_run(bytes, p0, CaseState::U { last_cl_end: p0 }),
+            ),
+            O200kCharClass::Number => digit_token_end::<DIGITS3>(bytes, p0),
+            // Any non-letter/number char except \r\n may prefix a run
+            class => {
+                if let Some((e, st)) = letter_run_first(bytes, p0) {
+                    return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+                }
+                if class == O200kCharClass::Whitespace {
+                    ws_token_end(bytes, pos)
+                } else {
+                    scan_tail(bytes, scan_punct_from(bytes, p0))
+                }
+            }
+        };
+    }
+
+    // ASCII digit
+    if is_digit(b0) {
+        return digit_token_end::<DIGITS3>(bytes, pos + 1);
+    }
+
+    // \r and \n are excluded from the letter-run prefix
+    if b0 == b'\r' || b0 == b'\n' {
+        return ws_token_end(bytes, pos);
+    }
+
+    // Other ASCII whitespace (\t, \x0b, \x0c) may prefix a letter run
+    if is_ascii_ws(b0) {
+        if let Some((e, st)) = letter_run_first(bytes, pos + 1) {
+            return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+        }
+        return ws_token_end(bytes, pos);
+    }
+
+    // ASCII punctuation/symbol/control (including `'`: o200k has no
+    // standalone contraction alternative, so a leading apostrophe is
+    // ordinary punctuation / a letter-run prefix: "'sound" is one token)
+    if let Some((e, st)) = letter_run_first(bytes, pos + 1) {
+        return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+    }
+    scan_tail(bytes, scan_punct_from(bytes, pos + 1))
+}
+
+// -----------------------------------------------------------------------
+// Mask-scanner boundary algebra
+// -----------------------------------------------------------------------
+
+/// Smear `seed` upward (toward higher bits) through contiguous set bits of
+/// `within`, in log steps.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+fn smear_up(seed: u64, within: u64) -> u64 {
+    let mut a = seed;
+    let mut m = within;
+    let mut sh = 1u32;
+    while sh < 64 {
+        a |= (a << sh) & m;
+        m &= m << sh;
+        sh <<= 1;
+    }
+    a
+}
+
+/// Per-byte class masks for a batch's unicode chars under the o200k
+/// classifier — the o200k analogue of [`mask::UniClasses`], with the
+/// case-split letter masks the scheme needs. Every byte of a classified
+/// char carries the char's class, so byte-adjacency == char-adjacency.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[derive(Clone, Copy, Default)]
+struct OUni {
+    /// All letter-run bytes (upper + lower + caseless; marks excluded —
+    /// they are contextual and deferred via `mk`).
+    l: u64,
+    /// Strict-upper (Lu/Lt) bytes.
+    u: u64,
+    /// Caseless-letter (Lm/Lo) bytes.
+    cl: u64,
+    /// Number / punct-run / whitespace bytes.
+    n: u64,
+    o: u64,
+    ws: u64,
+    /// Whitespace lead bits by char length (for `(?!\S)` shift tests).
+    w2: u64,
+    w3: u64,
+    /// Lead bits of all classified chars by length (two-chars-back rule).
+    lead2: u64,
+    lead3: u64,
+    lead4: u64,
+    /// Continuation bytes of classified chars.
+    cont: u64,
+    /// Bytes only the scalar path can decide (±1 bad smear): number chars
+    /// (char-counted grouping), ws straddling the batch end, stray
+    /// continuation bytes.
+    resid: u64,
+    /// Mark bytes (±4 bad smear: a mark's run-contextual class can affect
+    /// the boundary of a char up to two chars — 4 lookahead bytes for the
+    /// following lead — after it).
+    mk: u64,
+}
+
+/// Boundary carries from the chars before the batch (o200k variant of the
+/// cl100k family's `Carries`, plus the case and absorbed-tail bits).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[derive(Clone, Copy, Default)]
+struct OCarries {
+    /// P1 is a letter / strict-upper / caseless / space (0x20) /
+    /// non-newline non-space ws / punct / any ws / digit.
+    pl: u64,
+    pu: u64,
+    pcl: u64,
+    ps: u64,
+    pwt: u64,
+    po: u64,
+    pws: u64,
+    pd: u64,
+    /// P2 is punct-or-space, for a char lead at bit 0.
+    c2_os: u64,
+    /// Same test positioned at the first lead AFTER a straddling-in P1.
+    b2b_in: u64,
+    /// P1 is an absorbed `[\r\n/]*` tail byte whose token may continue
+    /// into this batch (seeds the tail smear at bit 0).
+    p_abs: bool,
+    /// The tail walkback could not resolve (pathological run): the batch's
+    /// leading tail-class run must be a bad zone.
+    force_bad_lead: bool,
+}
+
+/// Was the tail-class byte at `scan - 1` absorbed by a punct run's
+/// `[\r\n/]*` tail (as opposed to being a fresh punct-run `/` or a
+/// ws-run newline)? Walks the tail-class run back (bounded) and
+/// classifies the byte before it. `None`: unresolved (over-long run, or a
+/// preceding mark whose own class is run-contextual).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+fn prev_tail_absorbed(bytes: &[u8], scan: usize) -> Option<bool> {
+    debug_assert!(scan >= 1 && is_tail_byte(bytes[scan - 1]));
+    let mut r = scan - 1;
+    let mut steps = 0;
+    while r > 0 && is_tail_byte(bytes[r - 1]) {
+        r -= 1;
+        steps += 1;
+        if steps > 8 {
+            return None;
+        }
+    }
+    // T-run = bytes[r..scan]. The `[\r\n/]*` tail is greedy, so once
+    // absorption triggers — at the first newline that directly follows a
+    // punct-run char (an in-run slash, or the pre-run char for a
+    // run-leading newline) — everything to the run's end is absorbed.
+    // Before the trigger, newlines are ws-run members and slashes are
+    // ordinary punct-run bytes.
+    let run = &bytes[r..scan];
+    let mut trigger = usize::MAX;
+    let mut seen_slash = false;
+    for (j, &b) in run.iter().enumerate() {
+        if b == b'/' {
+            seen_slash = true;
+            continue;
+        }
+        if seen_slash {
+            trigger = j;
+            break;
+        }
+        if j == 0 {
+            // Run-leading newline: the pre-run char decides.
+            if r == 0 {
+                continue;
+            }
+            let pb = bytes[r - 1];
+            let pred_punct = if pb < 0x80 {
+                if !is_letter(pb) && !is_digit(pb) && !is_ascii_ws(pb) {
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            } else {
+                let mut k = r - 1;
+                while k > 0 && bytes[k] & 0xC0 == 0x80 {
+                    k -= 1;
+                }
+                let (cp, _) = unsafe { decode_cp(bytes, k) };
+                match o200k_class_of(cp) {
+                    O200kCharClass::Other => Some(true),
+                    // A mark continues whatever run precedes it.
+                    O200kCharClass::Mark => None,
+                    _ => Some(false),
+                }
+            };
+            match pred_punct {
+                Some(true) => {
+                    trigger = 0;
+                    break;
+                }
+                Some(false) => {}
+                None => return None,
+            }
+        }
+    }
+    Some(scan - 1 - r >= trigger)
+}
+
+/// Two-back "punct or space" test (`c2_os`) for the ASCII byte at `idx`.
+/// A slash may be an absorbed tail byte — a token end, neither punct-run
+/// member nor space — so it resolves through the walkback. `None`:
+/// unresolved (callers set `force_bad_lead`).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+fn c2_os_ascii(bytes: &[u8], idx: usize) -> Option<u64> {
+    let b2 = bytes[idx];
+    if b2 == b'/' {
+        return prev_tail_absorbed(bytes, idx + 1).map(|abs| u64::from(!abs));
+    }
+    Some(u64::from(
+        b2 == b' ' || (!is_letter(b2) && !is_digit(b2) && !is_ascii_ws(b2)),
+    ))
+}
+
+/// Pure-ASCII carries. Requires `scan > 0`, `bytes[scan-1] < 0x80` (and
+/// `bytes[scan-2] < 0x80` when present), and `bytes[scan-1]` NOT a
+/// tail-class byte (those route through [`prev_tail_absorbed`] first).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+fn ascii_carries(bytes: &[u8], scan: usize) -> OCarries {
+    let b = bytes[scan - 1];
+    debug_assert!(!is_tail_byte(b));
+    let bit = |c: bool| u64::from(c);
+    let (l, d, w) = (is_letter(b), is_digit(b), is_ascii_ws(b));
+    let (c2_os, c2_unresolved) = if scan >= 2 {
+        match c2_os_ascii(bytes, scan - 2) {
+            Some(v) => (v, false),
+            None => (0, true),
+        }
+    } else {
+        (0, false)
+    };
+    OCarries {
+        force_bad_lead: c2_unresolved,
+        pl: bit(l),
+        pu: bit(is_upper_ascii(b)),
+        pcl: 0,
+        ps: bit(b == b' '),
+        pwt: bit(w && b != b' '), // \r\n excluded by the debug_assert
+        po: bit(!l && !d && !w),
+        pws: bit(w),
+        pd: bit(d),
+        c2_os,
+        b2b_in: 0,
+        p_abs: false,
+    }
+}
+
+/// Carries when the byte before the batch is tail-class (`[\r\n/]`):
+/// resolves absorbed-tail vs fresh-run via [`prev_tail_absorbed`]. An
+/// absorbed tail ended the previous token, so every "P1 is X" carry is
+/// zero and only the tail-continuation seed survives.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(never)]
+fn tail_carries(bytes: &[u8], scan: usize) -> OCarries {
+    match prev_tail_absorbed(bytes, scan) {
+        Some(true) => OCarries { p_abs: true, ..OCarries::default() },
+        Some(false) => {
+            let b = bytes[scan - 1];
+            let bit = |c: bool| u64::from(c);
+            // A fresh '/' is an ordinary punct byte; \r\n are newlines
+            // (ws class, po = 0). c2_os as in ascii_carries when P2 is
+            // ASCII; a non-ASCII P2 next to a tail byte is rare — defer.
+            if scan >= 2 && bytes[scan - 2] >= 0x80 {
+                return OCarries {
+                    force_bad_lead: true,
+                    ..OCarries::default()
+                };
+            }
+            let c2_os = if scan >= 2 {
+                let b2 = bytes[scan - 2];
+                bit(b2 == b' ' || (!is_letter(b2) && !is_digit(b2) && !is_ascii_ws(b2)))
+            } else {
+                0
+            };
+            OCarries {
+                po: bit(b == b'/'),
+                pws: bit(b != b'/'),
+                c2_os,
+                ..OCarries::default()
+            }
+        }
+        None => OCarries {
+            force_bad_lead: true,
+            ..OCarries::default()
+        },
+    }
+}
+
+/// Classify every unicode char whose lead bit is in `m` for
+/// `bytes[scan..scan+64]` with the o200k classifier — the o200k analogue
+/// of [`mask::classify_uni_chars`] (NUMBERS = false, LEADS = true), with
+/// case-split letter masks and marks deferred via `mk`.
+///
+/// # Safety
+///
+/// `scan + 70 <= bytes.len()` (the batch classifiers' lookahead guard).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe fn classify_uni_o200k(bytes: &[u8], scan: usize, mut m: u64) -> OUni {
+    use super::decode_cp_inbounds;
+    let mut u = OUni::default();
+    while m != 0 {
+        let i = m.trailing_zeros() as usize;
+        m &= m - 1;
+        let b = bytes[scan + i];
+        if b < 0xC2 {
+            u.resid |= 1 << i; // stray continuation byte (invalid UTF-8)
+            continue;
+        }
+        let l = if b < 0xE0 {
+            2
+        } else if b < 0xF0 {
+            3
+        } else {
+            4
+        };
+        let chm = ((1u64 << l) - 1) << i; // in-batch bytes (excess drops)
+        let lead = 1u64 << i;
+        // SAFETY: scan + 70 <= len (this fn's contract), i <= 63, so
+        // scan + i + 4 <= len even for a 4-byte lead at bit 63.
+        let (cp, _) = unsafe { decode_cp_inbounds(bytes, scan + i) };
+        match o200k_class_of(cp) {
+            O200kCharClass::Upper => {
+                u.l |= chm;
+                u.u |= chm;
+            }
+            O200kCharClass::Lower => u.l |= chm,
+            O200kCharClass::Caseless => {
+                u.l |= chm;
+                u.cl |= chm;
+            }
+            O200kCharClass::Mark => {
+                // Contextual (letter-run joiner AND punct-run member):
+                // punct-class for the neighbors' mask algebra, deferred
+                // (±4) for everything the context could change.
+                u.o |= chm;
+                u.mk |= chm;
+            }
+            O200kCharClass::Number => {
+                u.n |= chm;
+                u.resid |= chm; // char-counted grouping: scalar
+            }
+            O200kCharClass::Other => u.o |= chm,
+            O200kCharClass::Whitespace => {
+                u.ws |= chm;
+                if i + l > 64 || l == 4 {
+                    u.resid |= chm; // straddling-out ws stays a bad zone
+                } else if l == 2 {
+                    u.w2 |= lead;
+                } else {
+                    u.w3 |= lead;
+                }
+            }
+        }
+        match l {
+            2 => u.lead2 |= lead,
+            3 => u.lead3 |= lead,
+            _ => u.lead4 |= lead,
+        }
+        u.cont |= chm & !lead;
+        m &= !chm;
+    }
+    u
+}
+
+/// ASCII class masks the o200k algebra needs on top of
+/// [`mask::AsciiMasks`]: strict-uppercase letters and slashes.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[derive(Clone, Copy, Default)]
+struct OAsciiExtra {
+    up: u64,
+    sl: u64,
+}
+
+/// Slow(er) path for batches with non-ASCII in or just before them — the
+/// o200k analogue of `cl100k_family::family_extended_masks`: carries walk
+/// back through multi-byte chars with the o200k classifier, unicode chars
+/// join the effective class masks, then the shared algebra applies.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg_attr(
+    target_arch = "x86_64",
+    target_feature(enable = "bmi1,bmi2,lzcnt,popcnt")
+)]
+#[inline(never)]
+fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+    am: AsciiMasks,
+    ax: OAsciiExtra,
+) -> (u64, u64) {
+    use super::decode_cp_inbounds;
+
+    /// The char containing byte `pos - 1`: its o200k class, lead index,
+    /// and end (exclusive) — [`mask::char_through`] with the o200k
+    /// classifier. Same safety contract (`pos > 0`, `pos + 3 <= len` when
+    /// `bytes[pos-1]` is non-ASCII; the batch guard covers callers).
+    #[inline(always)]
+    unsafe fn char_through_o200k(bytes: &[u8], pos: usize) -> (O200kCharClass, usize, usize) {
+        let b = bytes[pos - 1];
+        if b < 0x80 {
+            let cls = if is_upper_ascii(b) {
+                O200kCharClass::Upper
+            } else if is_letter(b) {
+                O200kCharClass::Lower
+            } else if is_digit(b) {
+                O200kCharClass::Number
+            } else if is_ascii_ws(b) {
+                O200kCharClass::Whitespace
+            } else {
+                O200kCharClass::Other
+            };
+            return (cls, pos - 1, pos);
+        }
+        let mut j = pos - 1;
+        while j > 0 && bytes[j] & 0xC0 == 0x80 {
+            j -= 1;
+        }
+        // SAFETY: j < pos and pos + 3 <= len (contract), so j + 4 <= len.
+        let (cp, l) = unsafe { decode_cp_inbounds(bytes, j) };
+        (o200k_class_of(cp), j, j + l)
+    }
+
+    let mut cl = OUni::default();
+    let cr = if scan == 0 {
+        OCarries::default()
+    } else if bytes[scan - 1] < 0x80 && is_tail_byte(bytes[scan - 1]) {
+        tail_carries(bytes, scan)
+    } else if bytes[scan - 1] < 0x80 && (scan < 2 || bytes[scan - 2] < 0x80) {
+        ascii_carries(bytes, scan)
+    } else {
+        // A multi-byte char within two bytes of the batch start.
+        // SAFETY: scan > 0, and the batch guard covers pos + 3 <= len.
+        let (c1, j1, e1) = unsafe { char_through_o200k(bytes, scan) };
+        let chm = if e1 > scan { (1u64 << (e1 - scan)) - 1 } else { 0 };
+        cl.cont = chm;
+        let (c2v, c2_defer) = if j1 == 0 {
+            (0, false)
+        } else if bytes[j1 - 1] == b'/' {
+            // An absorbed tail slash is a token end, not a punct-run char.
+            match prev_tail_absorbed(bytes, j1) {
+                Some(abs) => (u64::from(!abs), false),
+                None => (0, true),
+            }
+        } else {
+            // SAFETY: j1 > 0, j1 < scan keeps the decode in the guard.
+            let c2c = unsafe { char_through_o200k(bytes, j1) }.0;
+            (
+                u64::from(
+                    bytes[j1 - 1] == b' '
+                        || matches!(c2c, O200kCharClass::Other | O200kCharClass::Mark),
+                ),
+                // A mark P2 makes the two-back test run-contextual.
+                c2c == O200kCharClass::Mark,
+            )
+        };
+        let mut c = OCarries::default();
+        if e1 > scan {
+            c.b2b_in = c2v << (e1 - scan);
+        } else {
+            c.c2_os = c2v;
+        }
+        if c2_defer {
+            c.force_bad_lead = true;
+        }
+        c.pd = u64::from(c1 == O200kCharClass::Number);
+        match c1 {
+            O200kCharClass::Upper => {
+                cl.l |= chm;
+                cl.u |= chm;
+                c.pl = 1;
+                c.pu = 1;
+            }
+            O200kCharClass::Lower => {
+                cl.l |= chm;
+                c.pl = 1;
+            }
+            O200kCharClass::Caseless => {
+                cl.l |= chm;
+                cl.cl |= chm;
+                c.pl = 1;
+                c.pcl = 1;
+            }
+            O200kCharClass::Mark => {
+                // Contextual: defer the batch front to the scalar path.
+                cl.o |= chm;
+                cl.mk |= chm | 1; // bit 0 seeds the ±4 smear even when
+                // the mark sits entirely before the batch
+                c.po = 1;
+            }
+            O200kCharClass::Number => {
+                cl.n |= chm;
+                // A digit char straddling INTO the batch: the leading
+                // ASCII digit run's `\p{N}{1,3}` phase started before the
+                // batch, and the `pd` seed below can't see it (bit 0 is a
+                // continuation byte, not an ASCII digit). Defer via resid
+                // so the bad<<1 seed catches the run.
+                cl.resid |= chm;
+            }
+            O200kCharClass::Other => {
+                cl.o |= chm;
+                c.po = 1;
+            }
+            O200kCharClass::Whitespace => {
+                cl.ws |= chm;
+                if e1 > scan {
+                    cl.resid |= chm;
+                }
+                let pb = bytes[scan - 1];
+                c.ps = u64::from(pb == b' ');
+                let nl = pb == b'\r' || pb == b'\n';
+                c.pwt = u64::from(pb < 0x80 && pb != b' ' && !nl || pb >= 0x80);
+                c.pws = 1;
+            }
+        }
+        c
+    };
+
+    let mut uni = if am.hi != 0 {
+        // SAFETY: the batch guard is exactly `classify_uni_o200k`'s
+        // contract.
+        unsafe { classify_uni_o200k(bytes, scan, am.hi & !cl.cont) }
+    } else {
+        OUni::default()
+    };
+    uni.l |= cl.l;
+    uni.u |= cl.u;
+    uni.cl |= cl.cl;
+    uni.n |= cl.n;
+    uni.o |= cl.o;
+    uni.ws |= cl.ws;
+    uni.cont |= cl.cont;
+    uni.resid |= cl.resid;
+    uni.mk |= cl.mk;
+
+    o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, uni)
+}
+
+/// The o200k family's shared u64 boundary algebra over per-byte class
+/// masks — `cl100k_family::family_algebra` with the o200k rules: casing
+/// boundaries inside letter runs, suffix contractions, `[\r\n/]*` punct
+/// tails. `uni` is all-zero on the pure-ASCII path.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+    am: AsciiMasks,
+    ax: OAsciiExtra,
+    cr: OCarries,
+    uni: OUni,
+) -> (u64, u64) {
+    let OCarries {
+        pl,
+        pu,
+        pcl,
+        ps,
+        pwt,
+        po,
+        pws,
+        pd,
+        c2_os,
+        b2b_in,
+        p_abs,
+        force_bad_lead,
+    } = cr;
+    let contm = uni.cont;
+
+    // Effective per-byte classes.
+    let lb = am.l | uni.l;
+    let ub = ax.up | uni.u;
+    let clb = uni.cl;
+    let sb = am.s;
+    let wtb = am.wt | uni.ws;
+    let ob = !(am.l | am.d | am.s | am.wt | am.n | am.hi) | uni.o;
+    let ws_all = sb | wtb | am.n;
+
+    // --- Absorbed `[\r\n/]*` tails -----------------------------------------
+    // Seed: a newline right after a punct byte (a slash after a punct run
+    // is already a run member, so tails always begin with a newline), or
+    // a tail continuing from before the batch. Smear through [\r\n/].
+    let tcls = am.n | ax.sl;
+    let abs_seed = (am.n & ((ob << 1) | po)) | (u64::from(p_abs) & tcls);
+    let abs_t = if abs_seed == 0 { 0 } else { smear_up(abs_seed, tcls) };
+    // Absorbed bytes are no longer punct-run members for any boundary rule.
+    let ob_eff = ob & !abs_t;
+
+    // --- Letters -------------------------------------------------------------
+    let len1 = !(contm | uni.lead2 | uni.lead3 | uni.lead4);
+    let c_test = ((ob_eff | sb) << 1) | po | ps; // bit 0: byte scan-1 in O|S
+    let b2back = ((c_test & len1) << 1)
+        | ((c_test & uni.lead2) << 2)
+        | ((c_test & uni.lead3) << 3)
+        | ((c_test & uni.lead4) << 4)
+        | c2_os
+        | b2b_in;
+    let p_l = (lb << 1) | pl;
+    let p_u = (ub << 1) | pu;
+    let p_cl = (clb << 1) | pcl;
+    let p_s = (sb << 1) | ps;
+    let p_wt = (wtb << 1) | pwt;
+    let p_o = (ob_eff << 1) | po;
+    let absorb = p_o & !b2back;
+    // Casing boundary: a strict-upper char after a strict-lower one. (For
+    // ASCII text this is the whole rule; see the module docs.)
+    let p_sl = p_l & !p_u & !p_cl;
+    let b_su = ub & !contm & p_sl;
+    let b_letters =
+        (lb & !contm & !p_l & !p_s & !p_wt & !absorb) | b_su;
+
+    // --- Digits: `\p{N}{1,3}` or `\p{N}` -------------------------------------
+    let b_digits = if DIGITS3 && am.d & (am.d >> 1) != 0 {
+        mask::digit_run_splits3(am.d)
+    } else {
+        am.d
+    };
+
+    // --- Punct: ` ?[^\s\p{L}\p{N}]+[\r\n/]*` ----------------------------------
+    let b_punct = ob_eff & !contm & !p_o & !p_s;
+
+    // --- Bad zones ------------------------------------------------------------
+    let resid = uni.resid;
+    let mut bad = resid | resid << 1 | resid >> 1;
+    // Marks are run-contextual: they, and anything whose boundary rules
+    // can see them (up to two chars back — 4 bytes of lookahead for the
+    // following leads), go to the scalar path.
+    let mk = uni.mk;
+    if mk != 0 {
+        bad |= mk | mk << 1 | mk << 2 | mk << 3 | mk << 4 | mk >> 1;
+    }
+    // A strict-upper char after a caseless letter: phase- and
+    // lookahead-dependent (see the module docs) — scalar.
+    bad |= ub & !contm & ((clb << 1) | pcl);
+    if force_bad_lead {
+        // Unresolved carries: the leading tail-class run (plus the byte
+        // after it) can't be trusted.
+        bad |= smear_up(tcls & 1, tcls) << 1 | 0b11;
+    }
+
+    // --- Whitespace -----------------------------------------------------------
+    let ws_eff = ws_all & !abs_t;
+
+    // Byte-64 lookahead: is the char at the next batch's first byte
+    // non-ws? (See cl100k_family for the full reasoning.)
+    let nb64 = bytes[scan + 64]; // in bounds: scan + 70 <= len
+    let nn64 = if nb64 < 0x80 {
+        !is_ascii_ws(nb64)
+    } else {
+        // SAFETY: the batch guard puts the decode at scan + 64 in bounds.
+        bad >> 63 == 0 && unsafe { mask::nn_at_full(bytes, scan + 64) }
+    };
+    let nn64m = u64::from(nn64).wrapping_neg();
+
+    // An absorbed tail touching the batch end continues iff byte 64 is
+    // tail-class; the next batch's `tail_carries` walkback re-derives the
+    // context either way, so nothing defers here. A ws run touching the
+    // batch end still defers when byte 64 is ws (its last newline may lie
+    // beyond this batch).
+    let nonws = !ws_eff;
+    if ws_eff >> 63 != 0 && !nn64 {
+        if nonws == 0 {
+            return (0, u64::MAX); // whole batch one ws run
+        }
+        let h = 63 - nonws.leading_zeros(); // highest non-ws bit (< 63)
+        bad |= u64::MAX << (h + 1);
+    }
+
+    // A digit run whose `\p{N}{1,3}` phase did not start inside this batch
+    // (continuation from before it, or after a bad zone) defers.
+    if DIGITS3 {
+        let seed = (am.d & (bad << 1)) | (am.d & pd);
+        if seed != 0 {
+            bad |= smear_up(seed, am.d);
+        }
+    }
+
+    // Base rule (NL-free runs; NL runs are overridden below).
+    let ws_leads1 = (am.s | am.wt | am.n) & ws_eff;
+    let ws_leads = (ws_leads1 | uni.w2 | uni.w3) & !abs_t;
+    let p_ws = (ws_eff << 1) | pws;
+    let edge_last = (ws_leads1 & (1 << 63)) | (uni.w2 & (1 << 62)) | (uni.w3 & (1 << 61));
+    let split_ok = (ws_leads1 & (nonws >> 1))
+        | (uni.w2 & (nonws >> 2))
+        | (uni.w3 & (nonws >> 3))
+        | (edge_last & nn64m);
+    let mut b_ws = ws_leads & (!p_ws | split_ok);
+
+    // Override every run containing a (non-absorbed) newline: one token
+    // through the run's last newline, then tail rules.
+    let mut runs_n = am.n & ws_eff & !bad;
+    while runs_n != 0 {
+        let f = runs_n.trailing_zeros();
+        let below_gap = nonws & ((1u64 << f) - 1);
+        let a = if below_gap == 0 { 0 } else { 64 - below_gap.leading_zeros() };
+        let e = (nonws & (u64::MAX << f)).trailing_zeros();
+        let run_mask = (u64::MAX << a) & !u64::MAX.unbounded_shl(e);
+        b_ws &= !run_mask;
+        b_ws |= 1u64 << a;
+        let q = 63 - (am.n & run_mask).leading_zeros(); // last NL in run
+        if (q + 1) < e {
+            b_ws |= 1u64 << (q + 1);
+            let tail = run_mask & (u64::MAX << (q + 1));
+            let tail_leads = ws_leads & tail;
+            b_ws |= 1u64 << (63 - tail_leads.leading_zeros());
+        }
+        runs_n &= !run_mask;
+    }
+
+    let mut boundary = b_letters | b_digits | b_punct | b_ws;
+
+    // --- Contractions: suffix `(?i:'s|'t|'re|'ve|'m|'ll|'d)?` ----------------
+    // An apostrophe right after a letter-run char merges the suffix into
+    // that token and forces a boundary right after it. ('ſ is non-ASCII:
+    // an apostrophe before any non-ASCII char defers.)
+    if CONTRACTIONS {
+        let mut cand = am.ap & boundary & p_l & !bad;
+        let mut last_forced = usize::MAX;
+        while cand != 0 {
+            let i = cand.trailing_zeros() as usize;
+            cand &= cand - 1;
+            if i <= 2 {
+                // The preceding letter could itself end an earlier
+                // contraction that started before the batch — scalar.
+                bad |= 0b111u64 << i;
+                continue;
+            }
+            if i >= 61 {
+                bad |= u64::MAX << i;
+                break;
+            }
+            if i == last_forced {
+                // "x'll'd": the letter before this apostrophe is a
+                // consumed suffix's last char; a new (prefix) match
+                // starts here instead.
+                continue;
+            }
+            // The letter before this apostrophe may itself be a consumed
+            // suffix's last char resolved where last_forced can't see it
+            // (a scalar-walked zone like 'ſ, or a fixup before the
+            // batch): locally ambiguous, defer.
+            let p = scan + i;
+            let prev_suffix_possible = (bytes[p - 2] == b'\''
+                && matches!(bytes[p - 1] | 0x20, b's' | b'd' | b'm' | b't'))
+                || (p >= 3
+                    && bytes[p - 3] == b'\''
+                    && (matches!(
+                        (bytes[p - 2] | 0x20, bytes[p - 1] | 0x20),
+                        (b'l', b'l') | (b'v', b'e') | (b'r', b'e')
+                    ) || (bytes[p - 2] == 0xC5 && bytes[p - 1] == 0xBF)));
+            if prev_suffix_possible {
+                bad |= 0b111u64 << i;
+                continue;
+            }
+            let b1 = bytes[scan + i + 1];
+            if b1 >= 0x80 {
+                bad |= 0b111u64 << i;
+                continue;
+            }
+            let k = match b1 | 0x20 {
+                b's' | b'd' | b'm' | b't' => 2,
+                b'l' if bytes[scan + i + 2] | 0x20 == b'l' => 3,
+                b'v' if bytes[scan + i + 2] | 0x20 == b'e' => 3,
+                b'r' if bytes[scan + i + 2] | 0x20 == b'e' => 3,
+                _ => 0,
+            };
+            if k != 0 {
+                boundary &= !(1u64 << i);
+                boundary &= !(((1u64 << (k - 1)) - 1) << (i + 1));
+                boundary |= 1u64 << (i + k);
+                last_forced = i + k;
+            }
+        }
+    }
+
+    (boundary & !bad, bad)
+}
+
+// -----------------------------------------------------------------------
+// Batch classifiers (per-arch front-ends)
+// -----------------------------------------------------------------------
+
+/// Carries for a batch known to have only ASCII in and just before it:
+/// tail-class prev bytes route through the walkback, everything else
+/// through the branchless ASCII carries.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+fn ascii_batch_carries(bytes: &[u8], scan: usize) -> OCarries {
+    if scan == 0 {
+        OCarries::default()
+    } else if is_tail_byte(bytes[scan - 1]) {
+        tail_carries(bytes, scan)
+    } else {
+        ascii_carries(bytes, scan)
+    }
+}
+
+/// `(usable, bad)` for `bytes[scan..scan+64]` under the o200k-family
+/// rules — same contract as the cl100k family's `batch_masks`.
+///
+/// NEON front-end: classifies the ASCII classes (letter, upper, digit,
+/// space, whitespace, newline) with movemasks; apostrophe and slash sit
+/// behind horizontal any-tests. Batches with non-ASCII in or just before
+/// them take [`o200k_extended_masks`].
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub(crate) fn batch_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+) -> (u64, u64) {
+    use std::arch::aarch64::*;
+    let len = bytes.len();
+    if scan + 70 > len {
+        // Not enough lookahead for the batch-edge char classification.
+        return (0, u64::MAX);
+    }
+    unsafe {
+        let p = bytes.as_ptr().add(scan);
+        let zero = vdupq_n_u8(0);
+        let mut lv = [zero; 4];
+        let mut uv = [zero; 4];
+        let mut dv = [zero; 4];
+        let mut sv = [zero; 4];
+        let mut wsv = [zero; 4];
+        let mut nv = [zero; 4];
+        let mut hiv = [zero; 4];
+        let mut apv = [zero; 4];
+        let mut slv = [zero; 4];
+        for i in 0..4 {
+            let v = vld1q_u8(p.add(16 * i));
+            let lowered = vorrq_u8(v, vdupq_n_u8(0x20));
+            lv[i] = vcleq_u8(vsubq_u8(lowered, vdupq_n_u8(b'a')), vdupq_n_u8(25));
+            uv[i] = vcleq_u8(vsubq_u8(v, vdupq_n_u8(b'A')), vdupq_n_u8(25));
+            dv[i] = vcleq_u8(vsubq_u8(v, vdupq_n_u8(b'0')), vdupq_n_u8(9));
+            sv[i] = vceqq_u8(v, vdupq_n_u8(b' '));
+            wsv[i] = vorrq_u8(
+                sv[i],
+                vcleq_u8(vsubq_u8(v, vdupq_n_u8(9)), vdupq_n_u8(4)),
+            );
+            nv[i] = vorrq_u8(
+                vceqq_u8(v, vdupq_n_u8(b'\r')),
+                vceqq_u8(v, vdupq_n_u8(b'\n')),
+            );
+            hiv[i] = vcltzq_s8(vreinterpretq_s8_u8(v));
+            apv[i] = vceqq_u8(v, vdupq_n_u8(b'\''));
+            slv[i] = vceqq_u8(v, vdupq_n_u8(b'/'));
+        }
+        let l64 = mask::movemask64(lv[0], lv[1], lv[2], lv[3]);
+        let u64_ = mask::movemask64(uv[0], uv[1], uv[2], uv[3]);
+        let d64 = mask::movemask64(dv[0], dv[1], dv[2], dv[3]);
+        let s64 = mask::movemask64(sv[0], sv[1], sv[2], sv[3]);
+        let wsa = mask::movemask64(wsv[0], wsv[1], wsv[2], wsv[3]);
+        let n64 = mask::movemask64(nv[0], nv[1], nv[2], nv[3]);
+
+        // Apostrophes only matter for the contraction fixup, slashes only
+        // for the tail smear: movemask each lazily.
+        let ap64 = if CONTRACTIONS {
+            let ap_any = vorrq_u8(vorrq_u8(apv[0], apv[1]), vorrq_u8(apv[2], apv[3]));
+            if vmaxvq_u8(ap_any) != 0 {
+                mask::movemask64(apv[0], apv[1], apv[2], apv[3])
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+        let sl_any = vorrq_u8(vorrq_u8(slv[0], slv[1]), vorrq_u8(slv[2], slv[3]));
+        let sl64 = if vmaxvq_u8(sl_any) != 0 {
+            mask::movemask64(slv[0], slv[1], slv[2], slv[3])
+        } else {
+            0
+        };
+
+        let am = AsciiMasks {
+            l: l64,
+            d: d64,
+            s: s64,
+            wt: wsa & !s64 & !n64,
+            n: n64,
+            hi: 0,
+            ap: ap64,
+        };
+        let ax = OAsciiExtra { up: u64_, sl: sl64 };
+
+        let hi_any = vorrq_u8(vorrq_u8(hiv[0], hiv[1]), vorrq_u8(hiv[2], hiv[3]));
+        if vmaxvq_u8(hi_any) != 0
+            || (scan >= 1 && bytes[scan - 1] >= 0x80)
+            || (scan >= 2 && bytes[scan - 2] >= 0x80)
+        {
+            let mut am = am;
+            am.hi = mask::movemask64(hiv[0], hiv[1], hiv[2], hiv[3]);
+            return o200k_extended_masks::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax);
+        }
+
+        let cr = ascii_batch_carries(bytes, scan);
+        o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, OUni::default())
+    }
+}
+
+/// x86-64 front-end: same contract as the NEON `batch_masks` above,
+/// dispatching on the runtime-detected SIMD tier (AVX-512 or AVX2).
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+pub(crate) fn batch_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+) -> (u64, u64) {
+    debug_assert!(mask::simd_scanner_available());
+    if mask::avx512_scanner_available() {
+        // SAFETY: runtime AVX-512 detection right above.
+        unsafe { batch_masks_avx512::<CONTRACTIONS, DIGITS3>(bytes, scan) }
+    } else {
+        // SAFETY: MaskState enables the mask-scanner path only after
+        // runtime detection; without AVX-512 that detection was AVX2's.
+        unsafe { batch_masks_avx2::<CONTRACTIONS, DIGITS3>(bytes, scan) }
+    }
+}
+
+/// The strict-uppercase and slash masks for `bytes[scan..scan+64]`,
+/// AVX-512 tier.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi1,bmi2,lzcnt,popcnt")]
+#[inline]
+fn ascii_extra_avx512(bytes: &[u8], scan: usize) -> OAsciiExtra {
+    use std::arch::x86_64::*;
+    unsafe {
+        let v = _mm512_loadu_si512(bytes.as_ptr().add(scan) as *const _);
+        let up = _mm512_cmple_epu8_mask(
+            _mm512_sub_epi8(v, _mm512_set1_epi8(b'A' as i8)),
+            _mm512_set1_epi8(25),
+        );
+        let sl = _mm512_cmpeq_epi8_mask(v, _mm512_set1_epi8(b'/' as i8));
+        OAsciiExtra { up, sl }
+    }
+}
+
+/// The strict-uppercase and slash masks for `bytes[scan..scan+64]`,
+/// AVX2 tier. `#[inline(never)]` for the same vector-domain reason as
+/// [`mask::ascii_masks_avx2`].
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,bmi1,bmi2,lzcnt,popcnt")]
+#[inline(never)]
+fn ascii_extra_avx2(bytes: &[u8], scan: usize) -> OAsciiExtra {
+    use std::arch::x86_64::*;
+    unsafe {
+        let le = |v: __m256i, lim: __m256i| -> __m256i {
+            _mm256_cmpeq_epi8(_mm256_min_epu8(v, lim), v)
+        };
+        let mm = |m0: __m256i, m1: __m256i| -> u64 {
+            (_mm256_movemask_epi8(m0) as u32 as u64)
+                | ((_mm256_movemask_epi8(m1) as u32 as u64) << 32)
+        };
+        let p = bytes.as_ptr().add(scan);
+        let v0 = _mm256_loadu_si256(p as *const _);
+        let v1 = _mm256_loadu_si256(p.add(32) as *const _);
+        let ca = _mm256_set1_epi8(b'A' as i8);
+        let c25 = _mm256_set1_epi8(25);
+        let up = mm(
+            le(_mm256_sub_epi8(v0, ca), c25),
+            le(_mm256_sub_epi8(v1, ca), c25),
+        );
+        let slc = _mm256_set1_epi8(b'/' as i8);
+        let sl = mm(_mm256_cmpeq_epi8(v0, slc), _mm256_cmpeq_epi8(v1, slc));
+        OAsciiExtra { up, sl }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vl,bmi1,bmi2,lzcnt,popcnt")]
+#[inline]
+fn batch_masks_avx512<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+) -> (u64, u64) {
+    let len = bytes.len();
+    if scan + 70 > len {
+        return (0, u64::MAX);
+    }
+    let am = mask::ascii_masks_avx512(bytes, scan);
+    let ax = ascii_extra_avx512(bytes, scan);
+    if am.hi != 0
+        || (scan >= 1 && bytes[scan - 1] >= 0x80)
+        || (scan >= 2 && bytes[scan - 2] >= 0x80)
+    {
+        return o200k_extended_masks::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax);
+    }
+    let cr = ascii_batch_carries(bytes, scan);
+    o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, OUni::default())
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,bmi1,bmi2,lzcnt,popcnt")]
+#[inline]
+fn batch_masks_avx2<const CONTRACTIONS: bool, const DIGITS3: bool>(
+    bytes: &[u8],
+    scan: usize,
+) -> (u64, u64) {
+    let len = bytes.len();
+    if scan + 70 > len {
+        return (0, u64::MAX);
+    }
+    let am = mask::ascii_masks_avx2(bytes, scan);
+    let ax = ascii_extra_avx2(bytes, scan);
+    if am.hi != 0
+        || (scan >= 1 && bytes[scan - 1] >= 0x80)
+        || (scan >= 2 && bytes[scan - 2] >= 0x80)
+    {
+        return o200k_extended_masks::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax);
+    }
+    let cr = ascii_batch_carries(bytes, scan);
+    o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, OUni::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
+    use crate::pretokenize::fast::nemotron::NemotronScheme;
+    use crate::pretokenize::fast::o200k::O200kScheme;
+
+    fn scalar_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
+        let mut pos = 0;
+        let mut out = vec![];
+        while pos < bytes.len() {
+            let e = S::advance(bytes, pos);
+            out.push(bytes[pos..e].to_vec());
+            pos = e;
+        }
+        out
+    }
+
+    fn mask_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
+        let mut st = MaskState::new(0);
+        let mut out = vec![];
+        while let Some((s, e)) = st.next_span::<S>(bytes) {
+            out.push(bytes[s..e].to_vec());
+        }
+        out
+    }
+
+    #[track_caller]
+    fn check_one<S: MaskScheme>(buf: &[u8], scheme: &str) {
+        let a = scalar_tokens::<S>(buf);
+        let b = mask_tokens::<S>(buf);
+        if a != b {
+            let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
+            panic!(
+                "{scheme} diverged at token {i} on {:?}\n  scalar: {:?}\n  mask:   {:?}",
+                String::from_utf8_lossy(buf),
+                a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+            );
+        }
+    }
+
+    fn check_all(buf: &[u8]) {
+        check_one::<O200kScheme>(buf, "o200k");
+        check_one::<NemotronScheme>(buf, "nemotron");
+    }
+
+    /// Crafted cases, padded so they cross the batch (not scalar-tail) path.
+    #[test]
+    fn o200k_family_mask_matches_scalar_padded_cases() {
+        let pad = "The quick brown fox jumps over the lazy dog again and again. ";
+        let cases = [
+            "January 24, 2015 and 12345678 numbers 1 22 333 4444",
+            "don't DON'T they'Ll 'sound 'lx x'y '' ' \u{2019}s x'll'd don't's",
+            "camelCase HTTPResponse PascalCase aB ABc parseHTMLDocument iOS",
+            "!hello !Hello !!hello ?!x a-b ... !!!\n\nnext",
+            "paths /usr/bin/env a/b a//b http://x.com/y .\n//x !\n/\n/x",
+            "//\n/ x/\n x\n/ \n/ don't\n don'\n",
+            "tabs\tand\nnewlines\r\n mixed  \n  runs \n\n\n deep",
+            "hi!\n\ndef hi !!\n\nabc \"quoted\" (paren)",
+            "caf\u{e9} r\u{e9}sum\u{e9} \u{201c}word\u{201d} \u{2014}dash\u{2013} \u{00a0}nbsp",
+            "CAF\u{c9} \u{2003}em \u{2009}thin\u{2028}ls x\u{e9}\u{e9}y \u{416}dz Z\u{5bf}\u{416}dz",
+            "price: $5.99! 100,000.00 3.14159 2nd 3rd 4th",
+            "a\u{2028}b a\u{2028}\n \n\n\t x \n\n ",
+            "mixed 1\u{662}3x \u{661}\u{662}\u{663} arabic",
+            "\u{65e5}\u{672c}\u{8a9e}ABC abc\u{65e5}\u{672c}Def \u{416}\u{416}dz",
+            "e\u{301}f !!\u{301}x '\u{301}s x\u{301}'s A\u{301}B",
+        ];
+        for case in cases {
+            for lead in [0usize, 1, 37, 61, 62, 63, 64, 65] {
+                let mut buf = pad.as_bytes().repeat(4)[..pad.len() * 2 + lead].to_vec();
+                buf.extend_from_slice(case.as_bytes());
+                buf.extend_from_slice(pad.as_bytes());
+                buf.extend_from_slice(case.as_bytes());
+                check_all(&buf);
+            }
+        }
+    }
+
+    /// Differential fuzz across both family schemes.
+    #[test]
+    fn o200k_family_mask_matches_scalar_fuzz() {
+        let pieces: &[&str] = &[
+            "a", "B", "z", "9", "0", " ", "  ", "\n", "\t", "\r\n", "\r", "'", "'s", "'LL",
+            "'t", "!", ".", ",", "(", "/", "//", "/\n", "\n/", "é", "É", "ß", "日", "🎉",
+            "\u{00A0}", "\u{2003}", "word", "Word", "WORD", "camelCase", "12", "1234", "’",
+            "“", "”", "–", "—", "…", "\u{2009}", "\u{200B}", "\u{2028}", "\u{202F}", "×",
+            "÷", "«", "µ", "café", "éé", "naïve", "Α", "α", "а", "А", "Ж", "ж", "ǅ", "\n\n",
+            "!x", "!X", "\tx", " x", " X", "?!", "\u{301}", "ſ", "'ſ", "'\u{301}",
+            "\u{661}\u{662}", "\u{FF11}", "क", "\u{940}", "\u{1D54F}", "€", "™",
+            "…\u{2028}", "AxB", "ABc", "aB", "\u{416}dz", "x'", "n't",
+        ];
+        let mut state = 0x243F6A8885A308D3u64;
+        let mut rng = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for round in 0..4000 {
+            let target = 80 + (round % 400);
+            let mut buf = Vec::new();
+            while buf.len() < target {
+                buf.extend_from_slice(pieces[(rng() % pieces.len() as u64) as usize].as_bytes());
+            }
+            let ok = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| check_all(&buf)))
+                .is_ok();
+            if !ok {
+                panic!(
+                    "round {round} diverged; minimal case: {}",
+                    super::tests_shim::shrink_and_report(&buf)
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod owt_tests {
+    use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
+    use crate::pretokenize::fast::nemotron::NemotronScheme;
+    use crate::pretokenize::fast::o200k::O200kScheme;
+
+    fn check_streaming<S: MaskScheme>(bytes: &[u8], scheme: &str) {
+        let mut st = MaskState::new(0);
+        let mut pos = 0usize;
+        let mut idx = 0usize;
+        while pos < bytes.len() {
+            let scalar_end = S::advance(bytes, pos);
+            match st.next_span::<S>(bytes) {
+                Some((s, e)) => assert!(
+                    s == pos && e == scalar_end,
+                    "{scheme} diverged at token {idx} (byte {pos}): scalar {pos}..{scalar_end} \
+                     mask {s}..{e}: {:?} vs {:?}",
+                    String::from_utf8_lossy(&bytes[pos..scalar_end]),
+                    String::from_utf8_lossy(&bytes[s..e]),
+                ),
+                None => panic!("{scheme} ended early at token {idx} (byte {pos})"),
+            }
+            pos = scalar_end;
+            idx += 1;
+        }
+        assert!(st.next_span::<S>(bytes).is_none(), "{scheme} produced extra tokens");
+        eprintln!("{scheme}: all {idx} tokens match");
+    }
+
+    fn check_streaming_all(bytes: &[u8]) {
+        check_streaming::<O200kScheme>(bytes, "o200k");
+        check_streaming::<NemotronScheme>(bytes, "nemotron");
+    }
+
+    /// 100 MB of OWT, mask vs scalar.
+    #[test]
+    #[ignore]
+    fn o200k_family_mask_matches_scalar_owt() {
+        let path = std::env::home_dir().unwrap().join("data/owt_train.txt");
+        use std::io::Read;
+        let f = std::fs::File::open(&path).unwrap();
+        let mut input = Vec::new();
+        f.take(100_000_000).read_to_end(&mut input).unwrap();
+        while !input.is_empty() && std::str::from_utf8(&input).is_err() {
+            input.pop();
+        }
+        check_streaming_all(&input);
+    }
+
+    /// Full-OWT (~12 GB) mask-vs-scalar differential for both schemes.
+    #[test]
+    #[ignore = "reads the full ~12 GB OWT file"]
+    fn o200k_family_mask_matches_scalar_owt_full() {
+        let path = std::env::home_dir().unwrap().join("data/owt_train.txt");
+        let input = std::fs::read(&path).expect("Could not read ~/data/owt_train.txt");
+        eprintln!("loaded {} bytes", input.len());
+        check_streaming_all(&input);
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests_shim {
+    use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
+    use crate::pretokenize::fast::nemotron::NemotronScheme;
+    use crate::pretokenize::fast::o200k::O200kScheme;
+
+    fn scalar_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
+        let mut pos = 0;
+        let mut out = vec![];
+        while pos < bytes.len() {
+            let e = S::advance(bytes, pos);
+            out.push(bytes[pos..e].to_vec());
+            pos = e;
+        }
+        out
+    }
+
+    fn mask_tokens<S: MaskScheme>(bytes: &[u8]) -> Vec<Vec<u8>> {
+        let mut st = MaskState::new(0);
+        let mut out = vec![];
+        while let Some((s, e)) = st.next_span::<S>(bytes) {
+            out.push(bytes[s..e].to_vec());
+        }
+        out
+    }
+
+    /// Alignment-preserving shrink: replace chars with 'a' and trim the
+    /// tail while the buffer still diverges, then report the minimum.
+    pub(crate) fn shrink_and_report(bytes: &[u8]) -> String {
+        let fails = |b: &[u8]| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| check_all_pub(b))).is_err()
+        };
+        let mut buf = bytes.to_vec();
+        let mut changed = true;
+        while changed {
+            changed = false;
+            let mut i = 0;
+            while i < buf.len() {
+                let mut l = 1;
+                if buf[i] >= 0xC2 {
+                    l = if buf[i] < 0xE0 { 2 } else if buf[i] < 0xF0 { 3 } else { 4 };
+                }
+                let saved: Vec<u8> = buf[i..i + l].to_vec();
+                if saved != vec![b'a'; l] {
+                    for j in 0..l {
+                        buf[i + j] = b'a';
+                    }
+                    if fails(&buf) {
+                        changed = true;
+                    } else {
+                        buf[i..i + l].copy_from_slice(&saved);
+                    }
+                }
+                i += l;
+            }
+            while buf.len() > 1 && buf[buf.len() - 1] == b'a' && fails(&buf[..buf.len() - 1]) {
+                buf.pop();
+                changed = true;
+            }
+        }
+        let mut report = format!("(len {}) {:?}", buf.len(), String::from_utf8_lossy(&buf));
+        for (name, a, b) in [
+            ("o200k", scalar_tokens::<O200kScheme>(&buf), mask_tokens::<O200kScheme>(&buf)),
+            (
+                "nemotron",
+                scalar_tokens::<NemotronScheme>(&buf),
+                mask_tokens::<NemotronScheme>(&buf),
+            ),
+        ] {
+            if a != b {
+                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
+                report.push_str(&format!(
+                    "\n  {name} token {i}: scalar {:?} mask {:?}",
+                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                ));
+            }
+        }
+        report
+    }
+
+    #[track_caller]
+    pub(crate) fn check_all_pub(buf: &[u8]) {
+        for (name, a, b) in [
+            ("o200k", scalar_tokens::<O200kScheme>(buf), mask_tokens::<O200kScheme>(buf)),
+            ("nemotron", scalar_tokens::<NemotronScheme>(buf), mask_tokens::<NemotronScheme>(buf)),
+        ] {
+            if a != b {
+                let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
+                panic!(
+                    "{name} diverged at token {i} on {:?}\n  scalar: {:?}\n  mask:   {:?}",
+                    String::from_utf8_lossy(buf),
+                    a.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                    b.get(i).map(|t| String::from_utf8_lossy(t).into_owned()),
+                );
+            }
+        }
+    }
+}
+

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -1,7 +1,8 @@
 use crate::pretokenize::Pretoken;
 use crate::pretokenize::fast::{
-    FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastOlmo3Pretokenizer,
-    FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer,
+    FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastNemotronPretokenizer,
+    FastO200kPretokenizer, FastOlmo3Pretokenizer, FastQwen2Pretokenizer,
+    FastQwen35Pretokenizer, FastR50kPretokenizer,
 };
 
 /// Which pretokenization scheme (regex) a tokenizer uses.
@@ -13,6 +14,8 @@ pub enum PretokenizerType {
     Qwen35,     // Qwen2 with `[\p{L}\p{M}]+` letter runs, marks excluded from punct runs
     Olmo3,      // dolma2: Qwen2 scheme with cl100k's \p{N}{1,3}; used by Olmo 2/3
     DeepSeekV3, // Sequence of three Splits (digits, CJK, main); used by DeepSeek V3/V3.1/V4
+    O200k,      // o200k_base: case-structured letter runs; GPT-4o, gpt-oss
+    Nemotron,   // o200k without contractions, single-digit \p{N}; nvidia Nemotron-3
 }
 
 /// The three Split regexes of the DeepSeek V3/V4 pre_tokenizer Sequence, as
@@ -50,6 +53,12 @@ impl PretokenizerType {
             PretokenizerType::DeepSeekV3 => {
                 FastPretokenizerDispatch::DeepSeekV3(FastDeepSeekV3Pretokenizer::new(bytes))
             }
+            PretokenizerType::O200k => {
+                FastPretokenizerDispatch::O200k(FastO200kPretokenizer::new(bytes))
+            }
+            PretokenizerType::Nemotron => {
+                FastPretokenizerDispatch::Nemotron(FastNemotronPretokenizer::new(bytes))
+            }
         }
     }
 
@@ -84,6 +93,12 @@ impl PretokenizerType {
             r"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+" => {
                 Some(PretokenizerType::Olmo3)
             }
+            r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+" => {
+                Some(PretokenizerType::O200k)
+            }
+            r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+" => {
+                Some(PretokenizerType::Nemotron)
+            }
             _ => None,
         }
     }
@@ -98,6 +113,8 @@ pub enum FastPretokenizerDispatch<'a> {
     Qwen35(FastQwen35Pretokenizer<'a>),
     Olmo3(FastOlmo3Pretokenizer<'a>),
     DeepSeekV3(FastDeepSeekV3Pretokenizer<'a>),
+    O200k(FastO200kPretokenizer<'a>),
+    Nemotron(FastNemotronPretokenizer<'a>),
 }
 
 impl<'a> Iterator for FastPretokenizerDispatch<'a> {
@@ -112,6 +129,8 @@ impl<'a> Iterator for FastPretokenizerDispatch<'a> {
             FastPretokenizerDispatch::Qwen35(it) => it.next(),
             FastPretokenizerDispatch::Olmo3(it) => it.next(),
             FastPretokenizerDispatch::DeepSeekV3(it) => it.next(),
+            FastPretokenizerDispatch::O200k(it) => it.next(),
+            FastPretokenizerDispatch::Nemotron(it) => it.next(),
         }
     }
 }
@@ -135,6 +154,8 @@ unsafe impl<'a> crate::pretokenize::PretokenSpans<'a> for FastPretokenizerDispat
             FastPretokenizerDispatch::Qwen35(it) => it.fill_spans_keyed(batch, prefetch),
             FastPretokenizerDispatch::Olmo3(it) => it.fill_spans_keyed(batch, prefetch),
             FastPretokenizerDispatch::DeepSeekV3(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::O200k(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Nemotron(it) => it.fill_spans_keyed(batch, prefetch),
         }
     }
 }

--- a/src/pretokenize/unicode.rs
+++ b/src/pretokenize/unicode.rs
@@ -188,6 +188,87 @@ pub(crate) fn ds_class_of(cp: u32) -> DsCharClass {
     }
 }
 
+// ---------------------------------------------------------------------------
+// o200k character classes (case-aware split of Letter)
+// ---------------------------------------------------------------------------
+
+/// Character class as used by the o200k regex family (gpt-oss, Nemotron-3),
+/// whose letter runs are case-structured:
+/// `[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+` etc.
+/// `Upper` is Lu|Lt (the strict-uppercase classes that appear only in the
+/// first bracket), `Lower` is Ll (only in the second), and `Caseless` is
+/// Lm|Lo (in both). Marks (`\p{M}`) are their own class: they join letter
+/// runs like `Caseless` but, being outside `\p{L}`, also continue
+/// `[^\s\p{L}\p{N}]+` punctuation runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum O200kCharClass {
+    Upper = 0,
+    Lower = 1,
+    Caseless = 2,
+    Mark = 3,
+    Number = 4,
+    Whitespace = 5,
+    Other = 6,
+}
+
+/// 4-bit class per codepoint, 2 codepoints per byte (~544 KiB total).
+static O200K_CLASS_TABLE: std::sync::LazyLock<Box<[u8]>> =
+    std::sync::LazyLock::new(build_o200k_class_table);
+
+fn build_o200k_class_table() -> Box<[u8]> {
+    use icu::properties::CodePointMapData;
+    const N: usize = 0x110000;
+    let mut classes = vec![O200kCharClass::Other as u8; N];
+    let gc = CodePointMapData::<GeneralCategory>::new();
+    for (category, class) in [
+        (GeneralCategory::UppercaseLetter, O200kCharClass::Upper),
+        (GeneralCategory::TitlecaseLetter, O200kCharClass::Upper),
+        (GeneralCategory::LowercaseLetter, O200kCharClass::Lower),
+        (GeneralCategory::ModifierLetter, O200kCharClass::Caseless),
+        (GeneralCategory::OtherLetter, O200kCharClass::Caseless),
+    ] {
+        for range in gc.iter_ranges_for_value(category) {
+            classes[*range.start() as usize..=*range.end() as usize].fill(class as u8);
+        }
+    }
+    for (group, class) in [
+        (GeneralCategoryGroup::Mark, O200kCharClass::Mark),
+        (GeneralCategoryGroup::Number, O200kCharClass::Number),
+    ] {
+        for range in gc.iter_ranges_for_group(group) {
+            classes[*range.start() as usize..=*range.end() as usize].fill(class as u8);
+        }
+    }
+    // White_Space is disjoint from Letter/Mark/Number, so fill order is moot.
+    for range in CodePointSetData::new::<WhiteSpace>().iter_ranges() {
+        classes[*range.start() as usize..=*range.end() as usize]
+            .fill(O200kCharClass::Whitespace as u8);
+    }
+    classes
+        .as_chunks::<2>().0.iter()
+        .map(|c| c[0] | (c[1] << 4))
+        .collect()
+}
+
+/// Classify a codepoint for the o200k scheme family with one table load.
+/// `cp` must be a valid scalar value (guaranteed when decoded from valid
+/// UTF-8).
+#[inline(always)]
+pub(crate) fn o200k_class_of(cp: u32) -> O200kCharClass {
+    debug_assert!(cp < 0x110000);
+    let byte = unsafe { *O200K_CLASS_TABLE.get_unchecked((cp >> 1) as usize) };
+    match (byte >> ((cp & 1) << 2)) & 0xF {
+        0 => O200kCharClass::Upper,
+        1 => O200kCharClass::Lower,
+        2 => O200kCharClass::Caseless,
+        3 => O200kCharClass::Mark,
+        4 => O200kCharClass::Number,
+        5 => O200kCharClass::Whitespace,
+        _ => O200kCharClass::Other,
+    }
+}
+
 /// The CJK ranges isolated by the DeepSeek pretokenizer's second Split:
 /// `[\u{4E00}-\u{9FA5}\u{3040}-\u{309F}\u{30A0}-\u{30FF}]` (CJK unified
 /// ideographs, hiragana, katakana — the two kana blocks are contiguous).
@@ -215,6 +296,34 @@ mod tests {
                 CharClass::Other
             };
             assert_eq!(class_of(cp), expected, "mismatch at U+{cp:04X}");
+        }
+    }
+
+    /// The o200k table must agree with ICU for every scalar.
+    #[test]
+    fn o200k_class_table_matches_icu() {
+        for cp in 0..=char::MAX as u32 {
+            let Some(c) = char::from_u32(cp) else { continue };
+            let gc = get_general_category(c);
+            let expected = if matches!(
+                gc,
+                GeneralCategory::UppercaseLetter | GeneralCategory::TitlecaseLetter
+            ) {
+                O200kCharClass::Upper
+            } else if gc == GeneralCategory::LowercaseLetter {
+                O200kCharClass::Lower
+            } else if is_gc_letter(gc) {
+                O200kCharClass::Caseless
+            } else if GeneralCategoryGroup::Mark.contains(gc) {
+                O200kCharClass::Mark
+            } else if is_gc_number(gc) {
+                O200kCharClass::Number
+            } else if is_whitespace(c) {
+                O200kCharClass::Whitespace
+            } else {
+                O200kCharClass::Other
+            };
+            assert_eq!(o200k_class_of(cp), expected, "mismatch at U+{cp:04X}");
         }
     }
 


### PR DESCRIPTION
Closes the remaining fixable gaps from the top-100 HF model parity sweep: **gemma-3/4 (15 models), gpt-oss (2), and nvidia Nemotron-3 (3)** now load and produce token IDs exactly matching HuggingFace `tokenizers`. With this branch, 26/28 unique tokenizer configs among the top-100 most-downloaded >3B models are exact (the two remaining — ESMC-6B, PowerMoE-3b — have byte-gap vocabs and are deliberately unsupported).

## What's in here

- **`o200k_family`**: shared scalar walker + mask-scanner boundary algebra for the o200k_base regex (gpt-oss — the regex is o200k_base verbatim, so this covers GPT-4o-style tokenizers generally) and the Nemotron-3 variant, const-generic over `CONTRACTIONS`/`DIGITS3`. New `O200kCharClass` packed table (Lu/Lt vs Ll vs Lm/Lo vs M) in `unicode.rs`.
  - Cased letter runs reduce to a phase automaton (ULC until the first strict-lower, then LLC; a run ending in ULC phase backtracks to its last caseless char). Pure-ASCII text has no caseless letters, so the SIMD algebra keeps an exact pairwise rule and defers only caseless-before-upper chars to the scalar path.
  - Contraction suffixes attach to letter tokens; locally-ambiguous apostrophes (batch front, non-ASCII follower, possible preceding suffix) defer.
  - `[\r\n/]*` punct tails absorb greedily; cross-batch context resolves via a bounded walkback, including the two-chars-back position.
  - Marks are run-contextual (join letter runs AND continue punct runs) → deferred as bad zones.
- **gemma-3/4 SP loader**: their `Split(" ", MergedWithPrevious)` pre_tokenizer is a no-op (the normalizer already replaced every space with `▁`); accepted when a norm op proves all spaces are gone, mapping to the existing no-split path.
- **Upstream fix in `cl100k_family`**: a multi-byte digit char straddling a 64-byte batch edge followed by ASCII digits mis-phased `\p{N}{1,3}` (the `pd` seed can't see the straddling char — bit 0 is a continuation byte). Found by this port's differential fuzz; affected cl100k/olmo3 masks at 1/64 alignments. Regression test included.

## Verification

- fancy-regex oracle: curated cases, 3000-round codepoint-soup fuzz, 5 MB OWT — both schemes
- mask-vs-scalar: padded batch-alignment cases, 4000-round auto-shrinking fuzz, **full ~12 GB OWT differential**
- HF parity: full edge-case battery + each tokenizer's own added tokens + 20 MB curated DCLM corpus for all 28 top-100 configs (26 exact)
- `cargo test --release` (150 tests) and pytest (1333 passed) green; x86_64 (AVX-512/AVX2 tiers) compile-checked
- Independent review + simplification pass over the new module

## Performance (encode_st, 1 GB OWT, interleaved A/B vs main, best-of-5 MB/s, cold/warm)

| config | main | branch |
|---|---|---|
| gpt2 (r50k) | 803 / 1214 | 797 / 1211 |
| qwen2 | 678 / 1027 | 654 / 1025 |
| olmo3 (cl100k family) | 682 / 1023 | 685 / 1018 |
| deepseek_v3 | 429 / 572 | 459 / 592 |
| **gpt-oss (o200k)** | unsupported | **609 / 954** |
| **nemotron** | unsupported | **678 / 1017** |

Existing schemes unchanged within noise (warm deltas ≤0.5%); the new schemes run at full mask-scanner throughput, in the same class as qwen2/olmo3.