### PR TITLE
Add BytesSource: separator-splitting inside the encode for in-memory batches

### DIFF
--- a/gigatoken/__init__.py
+++ b/gigatoken/__init__.py
@@ -1,4 +1,5 @@
 from gigatoken.gigatoken_rs import (
+    BytesSource,
     FileSource,
     JsonlFileSource,
     TextFileSource,
@@ -11,6 +12,7 @@ from gigatoken._tiktoken_compat import TiktokenCompat
 from gigatoken._tokenizer import Tokenizer
 
 __all__ = [
+    "BytesSource",
     "FileSource",
     "HFCompat",
     "JsonlFileSource",

--- a/gigatoken/_cli.py
+++ b/gigatoken/_cli.py
@@ -121,28 +121,29 @@ def bench(
 
     import awkward as ak
 
+    from gigatoken import BytesSource, TextFileSource
+
     gt_tokenizer = _load_tokenizer(tokenizer)
 
-    # gigatoken pass. Without --in-memory and without a separator the files
-    # are read inside Rust via encode_files, so timing includes disk IO.
-    docs: list[bytes] | None = None
+    # gigatoken pass. A separator is handed to gigatoken along with the whole
+    # files (documents are split inside Rust, during the encode itself) —
+    # never pre-split into per-document objects here, which is several times
+    # slower. Without --in-memory the files are also read inside Rust via
+    # encode_files, so timing includes disk IO. Byte counts are whole-file
+    # bytes, separators included.
     if in_memory:
-        docs = _read_docs(files, separator)
-        gt_bytes = sum(len(doc) for doc in docs)
+        raws = [file.read_bytes() for file in files]
+        gt_bytes = sum(len(raw) for raw in raws)
         start = time.perf_counter()
-        encoded = gt_tokenizer.encode_batch(docs)
-        gt_seconds = time.perf_counter() - start
-    elif separator is None:
-        gt_bytes = sum(file.stat().st_size for file in files)
-        start = time.perf_counter()
-        encoded = gt_tokenizer.encode_files(list(files))
+        encoded = gt_tokenizer.encode_batch(BytesSource(raws, separator=separator))
         gt_seconds = time.perf_counter() - start
     else:
+        gt_bytes = sum(file.stat().st_size for file in files)
+        # Bare paths keep their extension-based format detection (.jsonl).
+        source = list(files) if separator is None else TextFileSource(list(files), separator=separator)
         start = time.perf_counter()
-        docs = _read_docs(files, separator)
-        encoded = gt_tokenizer.encode_batch(docs)
+        encoded = gt_tokenizer.encode_files(source)
         gt_seconds = time.perf_counter() - start
-        gt_bytes = sum(len(doc) for doc in docs)
     _report("gigatoken", gt_seconds, gt_bytes, int(ak.count(encoded)))
 
     if compare_to != "hf":
@@ -161,8 +162,10 @@ def bench(
         raise typer.Exit(1)
     hf_tokenizer = HFTokenizer.from_str(hf_json.decode("utf-8") if isinstance(hf_json, bytes) else hf_json)
 
-    if docs is None:
-        docs = _read_docs(files, separator)
+    # The comparison needs one Python object per document (tokenizers takes
+    # a str per document, and validation compares per-document ids), so here
+    # — outside any timed region — the files are split in Python.
+    docs = _read_docs(files, separator)
     subset, last_truncated = _subset_docs(docs, limit_bytes)
     if not subset:
         typer.echo("error: --comparison-limit is smaller than the first document; nothing to compare", err=True)

--- a/gigatoken/_tokenizer.py
+++ b/gigatoken/_tokenizer.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from gigatoken._hf_compat import HFCompat
     from gigatoken._load.hf import HFTokenizerLike
     from gigatoken._tiktoken_compat import TiktokenCompat
-    from gigatoken.gigatoken_rs import FileSource, _WrapTruncate
+    from gigatoken.gigatoken_rs import BytesSource, FileSource, _WrapTruncate
 
 _BACKEND_TYPES = (BPETokenizer, SentencePieceTokenizer)
 
@@ -168,7 +168,7 @@ class Tokenizer:
 
     def encode_batch(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool | None = None,
     ) -> ak.Array:
@@ -184,7 +184,7 @@ class Tokenizer:
 
     def encode_batch_padded(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         pad_id: int,
         max_length: int | None = None,
         pad_to_max_length: bool = False,
@@ -214,7 +214,7 @@ class Tokenizer:
 
     def encode_batch_list(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool | None = None,
     ) -> list[list[int]]:

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -11,13 +11,14 @@ class FileSource:
     def __repr__(self) -> str: ...
 
 class TextFileSource(FileSource):
-    """Plain-text files. With `separator`, documents are the pieces between
-    separator occurrences; without one, each file is a single document."""
+    """Plain-text files. With `separator` (str separators are encoded to
+    UTF-8 bytes), documents are the pieces between separator occurrences;
+    without one, each file is a single document."""
 
     def __init__(
         self,
         paths: list[str | Path | PathLike[str]],
-        separator: bytes | None = None,
+        separator: bytes | str | None = None,
     ) -> None: ...
 
 class JsonlFileSource(FileSource):
@@ -28,6 +29,20 @@ class JsonlFileSource(FileSource):
         paths: list[str | Path | PathLike[str]],
         field: str = "text",
     ) -> None: ...
+
+class BytesSource:
+    """In-memory bytes for encode_batch, the buffer analog of TextFileSource:
+    documents are the pieces between separator occurrences (empty pieces
+    skipped), or one document per buffer without a separator. Buffers are
+    borrowed and split inside the parallel encode — pass whole buffers plus
+    a separator rather than pre-splitting."""
+
+    def __init__(
+        self,
+        data: bytes | list[bytes],
+        separator: bytes | str | None = None,
+    ) -> None: ...
+    def __repr__(self) -> str: ...
 
 def train_bpe(
     in_data: bytes | Path | str | FileSource,
@@ -69,7 +84,7 @@ class BPETokenizer:
     def encode(self, input: str | bytes) -> npt.NDArray[np.uint32]: ...
     def encode_batch(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool = True,
     ) -> ak.Array:
@@ -78,7 +93,7 @@ class BPETokenizer:
         workers; gigatoken.Tokenizer passes it automatically."""
     def encode_batch_list(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool = True,
     ) -> list[list[int]]:
@@ -95,7 +110,7 @@ class BPETokenizer:
         with row assembly options (see _WrapTruncate)."""
     def encode_batch_padded(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         options: PadTruncate,
         *,
         parallel: bool = True,
@@ -136,7 +151,7 @@ class SentencePieceTokenizer:
     def encode(self, input: str | bytes) -> npt.NDArray[np.uint32]: ...
     def encode_batch(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool = True,
     ) -> ak.Array:
@@ -145,7 +160,7 @@ class SentencePieceTokenizer:
         workers; gigatoken.Tokenizer passes it automatically."""
     def encode_batch_padded(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         options: PadTruncate,
         *,
         parallel: bool = True,
@@ -155,7 +170,7 @@ class SentencePieceTokenizer:
         gigatoken.Tokenizer.encode_batch_padded."""
     def encode_batch_list(
         self,
-        inputs: list[str] | list[bytes] | ak.Array,
+        inputs: list[str] | list[bytes] | BytesSource | ak.Array,
         *,
         parallel: bool = True,
     ) -> list[list[int]]:

--- a/src/bindings/bridge.rs
+++ b/src/bindings/bridge.rs
@@ -3,6 +3,7 @@
 //! other way, and the shared front-ends that resolve an encode_batch input
 //! and hand the ragged result back to Python.
 
+use crate::input::file_source::DocFormat;
 use crate::token::TokenId;
 use numpy::{IntoPyArray, PyArray1, PyArrayMethods, PyReadonlyArray1};
 use pyo3::prelude::*;
@@ -45,19 +46,6 @@ pub(crate) fn extract_doc(obj: &Bound<'_, PyAny>) -> PyResult<EncodeInput> {
         "expected str or bytes, got {}{hint}",
         obj.get_type()
     )))
-}
-
-/// View one document's bytes as UTF-8 text for the SentencePiece path.
-pub(crate) fn utf8_doc(doc: &[u8]) -> PyResult<&str> {
-    if simdutf::validate_utf8(doc) {
-        // SAFETY: just validated.
-        Ok(unsafe { std::str::from_utf8_unchecked(doc) })
-    } else {
-        let e = std::str::from_utf8(doc).expect_err("simdutf rejected UTF-8 that std accepts");
-        Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-            "invalid UTF-8 in document: {e}"
-        )))
-    }
 }
 
 /// decode() input resolved to a `TokenId` slice. A numpy uint32 array is
@@ -219,22 +207,36 @@ pub(crate) fn ragged_to_python<'py>(
     }
 }
 
-/// Shared front-end of encode_batch: extract the documents (a list of str, a
-/// list of bytes, or an awkward Array of strings — whose flat buffer is used
-/// directly, with no per-document Python objects) and run `encode` on the
-/// resolved byte slices with the GIL released, returning the ragged result
-/// as one flat id buffer plus per-document row lengths. `encode`'s second
-/// argument reports whether the documents are known-valid UTF-8, letting
-/// text consumers skip revalidation; it is true only for documents that
-/// came from Python str objects (whose validity CPython guarantees).
-/// Awkward "string" arrays are deliberately not trusted — their type
-/// parameter is a forgeable convention, not an enforced invariant — and
-/// get revalidated downstream.
+/// Format for every non-BytesSource encode_batch input: each byte region
+/// handed to `encode` is exactly one document.
+const WHOLE_DOCS: DocFormat = DocFormat::Text { separator: None };
+
+/// Shared front-end of encode_batch: extract the documents (a BytesSource,
+/// a list of str, a list of bytes, or an awkward Array of strings — whose
+/// flat buffer is used directly, with no per-document Python objects) and
+/// run `encode` on the resolved byte slices with the GIL released,
+/// returning the ragged result as one flat id buffer plus per-document row
+/// lengths. `encode`'s `DocFormat` argument says how its byte regions split
+/// into documents: one document per region for everything except a
+/// BytesSource, whose buffers carry its separator format and are split
+/// during the encode itself. Bytes-shaped inputs are trusted to be valid
+/// UTF-8 by the consumers that care (the SentencePiece backend) — nothing
+/// is validated here or downstream.
 pub(crate) fn encode_batch_flat<'py>(
     py: Python<'py>,
     inputs: &Bound<'py, PyAny>,
-    encode: impl Fn(&[&[u8]], bool) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
+    encode: impl Fn(&[&[u8]], &DocFormat) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
 ) -> PyResult<(Vec<u32>, Vec<i64>)> {
+    // BytesSource: hand the borrowed buffers over as byte regions together
+    // with the source's separator format.
+    if let Ok(source) = inputs.cast::<super::sources::BytesSource>() {
+        let source = source.get();
+        return py.detach(|| {
+            let regions: Vec<&[u8]> = source.buffers.iter().map(|b| &**b).collect();
+            encode(&regions, &source.format)
+        });
+    }
+
     // Awkward input: encode straight from the flat content buffer.
     if let Some((content, in_counts)) = extract_awkward_docs(inputs)? {
         let content = content.readonly();
@@ -248,13 +250,13 @@ pub(crate) fn encode_batch_flat<'py>(
                 docs.push(&bytes[pos..pos + n as usize]);
                 pos += n as usize;
             }
-            encode(&docs, false)
+            encode(&docs, &WHOLE_DOCS)
         });
     }
 
     let inputs: Vec<Bound<'py, PyAny>> = inputs.extract().map_err(|_| {
         PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-            "expected a list of str, a list of bytes, or an awkward Array of strings",
+            "expected a list of str, a list of bytes, a BytesSource, or an awkward Array of strings",
         )
     })?;
     if inputs.is_empty() {
@@ -272,11 +274,9 @@ pub(crate) fn encode_batch_flat<'py>(
         }
         docs.push(doc);
     }
-    let known_utf8 = matches!(docs[0], EncodeInput::Text(_));
-
     py.detach(|| {
         let slices: Vec<&[u8]> = docs.iter().map(|d| d.as_bytes()).collect();
-        encode(&slices, known_utf8)
+        encode(&slices, &WHOLE_DOCS)
     })
 }
 
@@ -284,7 +284,7 @@ pub(crate) fn encode_batch_flat<'py>(
 pub(crate) fn encode_batch_ragged<'py>(
     py: Python<'py>,
     inputs: &Bound<'py, PyAny>,
-    encode: impl Fn(&[&[u8]], bool) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
+    encode: impl Fn(&[&[u8]], &DocFormat) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
 ) -> PyResult<Bound<'py, PyAny>> {
     let (flat, counts) = encode_batch_flat(py, inputs, encode)?;
     ragged_to_python(py, flat, counts)
@@ -347,7 +347,7 @@ pub(crate) fn encode_batch_pylist<'py>(
     inputs: &Bound<'py, PyAny>,
     options: Option<&WrapTruncate>,
     parallel: bool,
-    encode: impl Fn(&[&[u8]], bool) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
+    encode: impl Fn(&[&[u8]], &DocFormat) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
 ) -> PyResult<Bound<'py, PyList>> {
     static PLAIN: WrapTruncate = WrapTruncate {
         prefix: Vec::new(),
@@ -359,11 +359,11 @@ pub(crate) fn encode_batch_pylist<'py>(
     let opts = options.unwrap_or(&PLAIN);
     let (prefix, suffix) = (opts.prefix.as_slice(), opts.suffix.as_slice());
     let truncate_left = opts.truncate_left;
-    let (flat, counts) = encode_batch_flat(py, inputs, |docs, known_utf8| {
+    let (flat, counts) = encode_batch_flat(py, inputs, |docs, format| {
         if let Some(matcher) = &opts.forbid {
             matcher.get().scan_docs(docs, parallel)?;
         }
-        encode(docs, known_utf8)
+        encode(docs, format)
     })?;
     let cap = opts.max_tokens.unwrap_or(usize::MAX);
     let wrap = !prefix.is_empty() || !suffix.is_empty();

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,7 +1,7 @@
 //! pyo3 glue for everything except the two tokenizer classes, which stay in
 //! lib.rs so the main path of the API remains front and center. One
 //! submodule per feature: Python<->Rust bridging shared by the bindings
-//! (bridge), the FileSource classes (sources), BPE training (train), padded
+//! (bridge), the FileSource/BytesSource classes (sources), BPE training (train), padded
 //! compat-API encoding (padding), the compat layers' special-token scanner
 //! (matcher), and the pretokenizer helpers (pretokenize).
 

--- a/src/bindings/padding.rs
+++ b/src/bindings/padding.rs
@@ -6,6 +6,7 @@
 //! typed downcast rather than dict-key lookups. The friendly keyword
 //! signature lives on `gigatoken.Tokenizer.encode_batch_padded`.
 
+use crate::input::file_source::DocFormat;
 use numpy::{IntoPyArray, PyArray1, PyArray2, PyArrayMethods};
 use pyo3::prelude::*;
 
@@ -89,7 +90,7 @@ pub fn encode_batch_matrix<'py>(
     inputs: &Bound<'py, PyAny>,
     opts: PadTruncate,
     parallel: bool,
-    encode: impl Fn(&[&[u8]], bool) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
+    encode: impl Fn(&[&[u8]], &DocFormat) -> PyResult<(Vec<u32>, Vec<i64>)> + Send + Sync,
 ) -> PyResult<PaddedMatrix<'py>> {
     let (flat, counts) = super::bridge::encode_batch_flat(py, inputs, encode)?;
     let (data, lengths, width) = py.detach(|| pad_truncate_matrix(&flat, &counts, &opts, parallel))?;

--- a/src/bindings/sources.rs
+++ b/src/bindings/sources.rs
@@ -1,9 +1,11 @@
-//! The FileSource Python classes and the helpers that turn an encode_files
-//! or train_bpe argument into loaded, format-tagged file contents.
+//! The FileSource/BytesSource Python classes and the helpers that turn an
+//! encode_files or train_bpe argument into loaded, format-tagged file
+//! contents.
 
 use crate::input::Resource;
 use crate::input::file_source::{DocFormat, LoadedFile, detect_default_format, load_file};
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use std::path::PathBuf;
 
 /// Base class for file sources. Not directly constructible from Python —
@@ -38,9 +40,26 @@ impl FileSource {
     }
 }
 
-/// Plain-text files. With `separator`, documents are the pieces between
-/// separator occurrences (the separator itself belongs to no document);
-/// without one, each file is a single document.
+/// A `separator` argument: bytes used as-is, or str encoded to its UTF-8
+/// bytes.
+#[derive(FromPyObject)]
+pub(crate) enum Separator {
+    Bytes(Vec<u8>),
+    Str(String),
+}
+
+impl Separator {
+    fn into_bytes(self) -> Vec<u8> {
+        match self {
+            Separator::Bytes(b) => b,
+            Separator::Str(s) => s.into_bytes(),
+        }
+    }
+}
+
+/// Plain-text files. With `separator` (str or bytes), documents are the
+/// pieces between separator occurrences (the separator itself belongs to no
+/// document); without one, each file is a single document.
 #[pyclass(extends = FileSource)]
 pub(crate) struct TextFileSource;
 
@@ -48,10 +67,12 @@ pub(crate) struct TextFileSource;
 impl TextFileSource {
     #[new]
     #[pyo3(signature = (paths, separator = None))]
-    fn new(paths: Vec<PathBuf>, separator: Option<Vec<u8>>) -> PyClassInitializer<Self> {
+    fn new(paths: Vec<PathBuf>, separator: Option<Separator>) -> PyClassInitializer<Self> {
         PyClassInitializer::from(FileSource {
             paths,
-            format: DocFormat::Text { separator },
+            format: DocFormat::Text {
+                separator: separator.map(Separator::into_bytes),
+            },
         })
         .add_subclass(Self)
     }
@@ -73,6 +94,58 @@ impl JsonlFileSource {
             },
         })
         .add_subclass(Self)
+    }
+}
+
+/// In-memory bytes for encode_batch, the buffer analog of TextFileSource:
+/// with `separator` (str or bytes), each buffer's documents are the pieces
+/// between separator occurrences (the separator itself belongs to no
+/// document, and empty pieces are skipped); without one, each buffer is a
+/// single document. The buffers are borrowed, not copied, and split during
+/// the (parallel) encode itself — handing a whole corpus over as a few
+/// buffers plus a separator is much faster than pre-splitting it into
+/// per-document Python objects.
+#[pyclass(frozen)]
+pub(crate) struct BytesSource {
+    pub(crate) buffers: Vec<PyBackedBytes>,
+    pub(crate) format: DocFormat,
+}
+
+#[pymethods]
+impl BytesSource {
+    #[new]
+    #[pyo3(signature = (data, separator = None))]
+    fn new(data: &Bound<'_, PyAny>, separator: Option<Separator>) -> PyResult<Self> {
+        let buffers = if let Ok(buffer) = data.extract::<PyBackedBytes>() {
+            vec![buffer]
+        } else {
+            data.extract::<Vec<PyBackedBytes>>().map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+                    "expected bytes or a list of bytes, got {}",
+                    data.get_type()
+                ))
+            })?
+        };
+        Ok(Self {
+            buffers,
+            format: DocFormat::Text {
+                separator: separator.map(Separator::into_bytes),
+            },
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        let n = self.buffers.len();
+        let total: usize = self.buffers.iter().map(|b| b.len()).sum();
+        match &self.format {
+            DocFormat::Text {
+                separator: Some(sep),
+            } => format!(
+                "BytesSource(data=[{n} buffers, {total} bytes], separator={:?})",
+                String::from_utf8_lossy(sep)
+            ),
+            _ => format!("BytesSource(data=[{n} buffers, {total} bytes])"),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,21 +13,21 @@ pub use crate::bpe::sentencepiece::EncodeState;
 pub mod load_tokenizer;
 
 use crate::batch::{
-    encode_docs_ragged_serial, encode_files_docs, encode_files_docs_serial, encode_into,
-    sp_encode_docs_ragged, sp_encode_docs_ragged_serial, sp_encode_files_docs,
-    sp_encode_files_docs_serial,
+    encode_files_docs, encode_files_docs_serial, encode_into, sp_encode_docs_ragged,
+    sp_encode_docs_ragged_serial, sp_encode_files_docs, sp_encode_files_docs_serial,
 };
 use crate::bindings::bridge::{
     EncodeInput, encode_batch_pylist, encode_batch_ragged, extract_doc, extract_token_ids,
-    merges_to_pylist, utf8_doc, vocab_to_pydict,
+    merges_to_pylist, vocab_to_pydict,
 };
 use crate::bindings::matcher::{SpecialTokenFound, SubstringMatcher};
 use crate::bindings::padding;
 use crate::bindings::pretokenize::{PretokenizerIter, pretokenized_counts, pretokenizer};
 use crate::bindings::sources::{
-    FileSource, JsonlFileSource, TextFileSource, encode_files_ragged,
+    BytesSource, FileSource, JsonlFileSource, TextFileSource, encode_files_ragged,
 };
 use crate::bindings::train::train_bpe;
+use crate::input::file_source::DocFormat;
 use numpy::{IntoPyArray, PyArray1};
 use pyo3::prelude::*;
 use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
@@ -41,13 +41,20 @@ struct BPETokenizer {
 }
 
 impl BPETokenizer {
-    /// See `batch::encode_docs_ragged` / `batch::encode_docs_ragged_serial`.
-    /// Call with the GIL released.
-    fn encode_slices_ragged(&self, docs: &[&[u8]], parallel: bool) -> (Vec<u32>, Vec<i64>) {
+    /// See `batch::encode_files_docs` / `batch::encode_files_docs_serial`:
+    /// each region splits into documents per `format` during the encode —
+    /// one document per region for plain batches, separator pieces for a
+    /// BytesSource. Call with the GIL released.
+    fn encode_regions_ragged(
+        &self,
+        regions: &[&[u8]],
+        format: &DocFormat,
+        parallel: bool,
+    ) -> (Vec<u32>, Vec<i64>) {
         if parallel {
-            encode_docs_ragged(&self.workers, &self.tokenizer, docs)
+            encode_files_docs(&self.workers, &self.tokenizer, regions, format)
         } else {
-            encode_docs_ragged_serial(&self.workers, &self.tokenizer, docs)
+            encode_files_docs_serial(&self.workers, &self.tokenizer, regions, format)
         }
     }
 }
@@ -93,11 +100,13 @@ impl BPETokenizer {
 
     /// Encode a batch of documents in parallel with rayon, releasing the GIL.
     /// Takes a list of str or a list of bytes (all elements of the same
-    /// type), or an awkward Array of strings/bytestrings — whose flat
-    /// buffers are used directly, with no per-document Python objects. For
-    /// files, use encode_files. Returns an awkward.Array with one row of
-    /// token ids per document (a single flat buffer plus offsets, not one
-    /// numpy array per document).
+    /// type), an awkward Array of strings/bytestrings — whose flat buffers
+    /// are used directly, with no per-document Python objects — or a
+    /// BytesSource, whose buffers are split into documents on its separator
+    /// during the encode itself (pass pre-read corpora that way instead of
+    /// pre-splitting them). For files, use encode_files. Returns an
+    /// awkward.Array with one row of token ids per document (a single flat
+    /// buffer plus offsets, not one numpy array per document).
     ///
     /// Documents are grouped into chunks of at least MIN_CHUNK_BYTES (small
     /// batches are encoded serially), and a document larger than a chunk is
@@ -117,8 +126,8 @@ impl BPETokenizer {
         inputs: Bound<'py, PyAny>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        encode_batch_ragged(py, &inputs, |docs, _| {
-            Ok(self.encode_slices_ragged(docs, parallel))
+        encode_batch_ragged(py, &inputs, |docs, format| {
+            Ok(self.encode_regions_ragged(docs, format, parallel))
         })
     }
 
@@ -133,8 +142,8 @@ impl BPETokenizer {
         inputs: Bound<'py, PyAny>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyList>> {
-        encode_batch_pylist(py, &inputs, None, parallel, |docs, _| {
-            Ok(self.encode_slices_ragged(docs, parallel))
+        encode_batch_pylist(py, &inputs, None, parallel, |docs, format| {
+            Ok(self.encode_regions_ragged(docs, format, parallel))
         })
     }
 
@@ -150,8 +159,8 @@ impl BPETokenizer {
         options: Py<bindings::bridge::WrapTruncate>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyList>> {
-        encode_batch_pylist(py, &inputs, Some(options.get()), parallel, |docs, _| {
-            Ok(self.encode_slices_ragged(docs, parallel))
+        encode_batch_pylist(py, &inputs, Some(options.get()), parallel, |docs, format| {
+            Ok(self.encode_regions_ragged(docs, format, parallel))
         })
     }
 
@@ -168,8 +177,8 @@ impl BPETokenizer {
         options: padding::PadTruncate,
         parallel: bool,
     ) -> PyResult<padding::PaddedMatrix<'py>> {
-        padding::encode_batch_matrix(py, &inputs, options, parallel, |docs, _| {
-            Ok(self.encode_slices_ragged(docs, parallel))
+        padding::encode_batch_matrix(py, &inputs, options, parallel, |docs, format| {
+            Ok(self.encode_regions_ragged(docs, format, parallel))
         })
     }
 
@@ -248,36 +257,55 @@ struct SentencePieceTokenizer {
 
 impl SentencePieceTokenizer {
     /// See `batch::sp_encode_docs_ragged` (`_serial` when `parallel` is
-    /// false); documents must be valid UTF-8. `known_utf8` skips the
-    /// validation pass and must be set only for documents that came from
-    /// Python str objects, whose UTF-8 validity CPython guarantees — the
-    /// one source strong enough to hang an `unsafe` on. Everything else
-    /// (bytes, awkward arrays — even "string"-typed ones, whose type
-    /// parameter is a forgeable convention) gets the simdutf-accelerated
-    /// validation pass. Call with the GIL released.
-    fn encode_slices_ragged(
+    /// false); a separator format (a BytesSource input) goes through
+    /// `batch::sp_encode_files_docs` instead, which splits the regions into
+    /// documents during the encode. Regions are trusted to be valid UTF-8
+    /// per the documented contract — never validated, matching
+    /// encode_files' treatment of file contents — which is what makes the
+    /// unchecked str conversions here and inside sp_encode_files_docs
+    /// sound. Call with the GIL released.
+    fn encode_regions_ragged(
         &self,
-        docs: &[&[u8]],
-        known_utf8: bool,
+        regions: &[&[u8]],
+        format: &DocFormat,
         parallel: bool,
     ) -> PyResult<(Vec<u32>, Vec<i64>)> {
-        let texts: Vec<&str> = if known_utf8 {
-            docs.iter()
-                .map(|d| {
-                    debug_assert!(std::str::from_utf8(d).is_ok());
-                    // SAFETY: the docs came from Python str objects (the only
-                    // source that sets known_utf8), so CPython guarantees
-                    // their UTF-8 validity.
-                    unsafe { std::str::from_utf8_unchecked(d) }
-                })
-                .collect()
-        } else {
-            docs.iter().map(|d| utf8_doc(d)).collect::<PyResult<_>>()?
-        };
-        Ok(if parallel {
-            sp_encode_docs_ragged(&self.tokenizer, &texts)
-        } else {
-            sp_encode_docs_ragged_serial(&self.tokenizer, &texts)
+        debug_assert!(regions.iter().all(|d| std::str::from_utf8(d).is_ok()));
+        Ok(match format {
+            DocFormat::Text { separator: None } => {
+                // SAFETY: valid UTF-8 by the documented input contract.
+                let texts: Vec<&str> = regions
+                    .iter()
+                    .map(|d| unsafe { std::str::from_utf8_unchecked(d) })
+                    .collect();
+                if parallel {
+                    sp_encode_docs_ragged(&self.tokenizer, &texts)
+                } else {
+                    sp_encode_docs_ragged_serial(&self.tokenizer, &texts)
+                }
+            }
+            format => {
+                // A separator match inside valid UTF-8 lands on char
+                // boundaries only when the separator is itself valid UTF-8
+                // (its first byte is a lead byte, and a complete match ends
+                // a complete character) — an arbitrary byte separator could
+                // cut a document mid-character and break the unchecked
+                // conversion inside sp_encode_files_docs. This one
+                // constant-time argument check stays even though document
+                // bytes are trusted.
+                if let DocFormat::Text { separator: Some(sep) } = format
+                    && std::str::from_utf8(sep).is_err()
+                {
+                    return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                        "the SentencePiece backend requires a separator that is valid UTF-8",
+                    ));
+                }
+                if parallel {
+                    sp_encode_files_docs(&self.tokenizer, regions, format)
+                } else {
+                    sp_encode_files_docs_serial(&self.tokenizer, regions, format)
+                }
+            }
         })
     }
 }
@@ -295,7 +323,7 @@ impl SentencePieceTokenizer {
     /// Encode a batch of documents in parallel, releasing the GIL. Accepts
     /// the same inputs, returns the same awkward.Array shape, and honors the
     /// same `parallel` keyword as BPETokenizer.encode_batch. Documents must
-    /// be valid UTF-8.
+    /// be valid UTF-8 — trusted, never validated, like encode_files.
     #[pyo3(signature = (inputs, *, parallel = true))]
     fn encode_batch<'py>(
         &self,
@@ -303,8 +331,8 @@ impl SentencePieceTokenizer {
         inputs: Bound<'py, PyAny>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        encode_batch_ragged(py, &inputs, |docs, known_utf8| {
-            self.encode_slices_ragged(docs, known_utf8, parallel)
+        encode_batch_ragged(py, &inputs, |docs, format| {
+            self.encode_regions_ragged(docs, format, parallel)
         })
     }
 
@@ -317,8 +345,8 @@ impl SentencePieceTokenizer {
         inputs: Bound<'py, PyAny>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyList>> {
-        encode_batch_pylist(py, &inputs, None, parallel, |docs, known_utf8| {
-            self.encode_slices_ragged(docs, known_utf8, parallel)
+        encode_batch_pylist(py, &inputs, None, parallel, |docs, format| {
+            self.encode_regions_ragged(docs, format, parallel)
         })
     }
 
@@ -333,8 +361,8 @@ impl SentencePieceTokenizer {
         options: Py<bindings::bridge::WrapTruncate>,
         parallel: bool,
     ) -> PyResult<Bound<'py, PyList>> {
-        encode_batch_pylist(py, &inputs, Some(options.get()), parallel, |docs, known_utf8| {
-            self.encode_slices_ragged(docs, known_utf8, parallel)
+        encode_batch_pylist(py, &inputs, Some(options.get()), parallel, |docs, format| {
+            self.encode_regions_ragged(docs, format, parallel)
         })
     }
 
@@ -348,8 +376,8 @@ impl SentencePieceTokenizer {
         options: padding::PadTruncate,
         parallel: bool,
     ) -> PyResult<padding::PaddedMatrix<'py>> {
-        padding::encode_batch_matrix(py, &inputs, options, parallel, |docs, known_utf8| {
-            self.encode_slices_ragged(docs, known_utf8, parallel)
+        padding::encode_batch_matrix(py, &inputs, options, parallel, |docs, format| {
+            self.encode_regions_ragged(docs, format, parallel)
         })
     }
 
@@ -363,7 +391,12 @@ impl SentencePieceTokenizer {
         let input = extract_doc(&input)?;
         let text: &str = match &input {
             EncodeInput::Text(s) => s,
-            EncodeInput::Bytes(b) => utf8_doc(b)?,
+            EncodeInput::Bytes(b) => {
+                debug_assert!(std::str::from_utf8(b).is_ok());
+                // SAFETY: valid UTF-8 by the documented input contract
+                // (trusted unchecked, like the batch and file paths).
+                unsafe { std::str::from_utf8_unchecked(b) }
+            }
         };
         let mut ids: Vec<u32> = Vec::new();
         self.tokenizer
@@ -488,6 +521,7 @@ fn gigatoken_rs<'py>(py: Python, m: &Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<FileSource>()?;
     m.add_class::<TextFileSource>()?;
     m.add_class::<JsonlFileSource>()?;
+    m.add_class::<BytesSource>()?;
     m.add_class::<PretokenizerIter>()?;
     m.add_class::<SubstringMatcher>()?;
     m.add_class::<bindings::bridge::WrapTruncate>()?;

--- a/tests/test_encode_files.py
+++ b/tests/test_encode_files.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from gigatoken import JsonlFileSource, TextFileSource
+from gigatoken import BytesSource, JsonlFileSource, TextFileSource
 from gigatoken.gigatoken_rs import BPETokenizer
 
 DOCS = [
@@ -90,6 +90,80 @@ def test_encode_batch_awkward_rejects_non_strings(tok):
 
 
 # ---------------------------------------------------------------------------
+# encode_batch with a BytesSource: in-memory buffers split on a separator
+# inside Rust, never pre-split into per-document objects
+# ---------------------------------------------------------------------------
+
+
+def test_bytes_source_separator_matches_presplit(tok, expected):
+    blob = "<|sep|>".join(DOCS).encode()
+    assert _ids(tok.encode_batch(BytesSource([blob], separator=b"<|sep|>"))) == expected
+
+
+def test_bytes_source_str_separator(tok, expected):
+    """A str separator is encoded to its UTF-8 bytes."""
+    blob = "<|sep|>".join(DOCS).encode()
+    assert _ids(tok.encode_batch(BytesSource([blob], separator="<|sep|>"))) == expected
+
+
+def test_bytes_source_empty(tok):
+    assert len(tok.encode_batch(BytesSource([]))) == 0
+
+
+def test_bytes_source_repr():
+    assert repr(BytesSource([b"ab", b"c"], separator=b"|")) == 'BytesSource(data=[2 buffers, 3 bytes], separator="|")'
+    assert repr(BytesSource(b"ab")) == "BytesSource(data=[1 buffers, 2 bytes])"
+
+
+def test_bytes_source_without_separator_one_doc_per_buffer(tok, expected):
+    assert _ids(tok.encode_batch(BytesSource([d.encode() for d in DOCS]))) == expected
+
+
+def test_bytes_source_single_buffer(tok, expected):
+    blob = "<|sep|>".join(DOCS[:3]).encode()
+    assert _ids(tok.encode_batch(BytesSource(blob, separator=b"<|sep|>"))) == expected[:3]
+
+
+def test_bytes_source_multiple_buffers_preserve_order(tok, expected):
+    half = len(DOCS) // 2
+    blobs = ["<|sep|>".join(part).encode() for part in (DOCS[:half], DOCS[half:])]
+    assert _ids(tok.encode_batch(BytesSource(blobs, separator=b"<|sep|>"))) == expected
+
+
+def test_bytes_source_skips_empty_documents(tok):
+    """Leading, trailing, and consecutive separators yield no empty rows —
+    the same semantics as TextFileSource."""
+    blob = b"<|sep|>a<|sep|><|sep|>b<|sep|>"
+    got = tok.encode_batch(BytesSource([blob], separator=b"<|sep|>"))
+    assert _ids(got) == _ids(tok.encode_batch(["a", "b"]))
+
+
+def test_bytes_source_parallel_chunking(tok):
+    """A buffer well above the chunk target is cut at separator boundaries
+    and encoded in parallel; ids must match the pre-split batch."""
+    docs = DOCS * 200  # ~1.8 MB, > MIN_CHUNK_BYTES
+    blob = "<|sep|>".join(docs).encode()
+    got = tok.encode_batch(BytesSource([blob], separator=b"<|sep|>"))
+    assert _ids(got) == _ids(tok.encode_batch(docs))
+
+
+def test_bytes_source_parallel_false_matches(tok, expected):
+    blob = "<|sep|>".join(DOCS).encode()
+    got = tok.encode_batch(BytesSource([blob], separator=b"<|sep|>"), parallel=False)
+    assert _ids(got) == expected
+
+
+def test_bytes_source_encode_batch_list(tok, expected):
+    blob = "<|sep|>".join(DOCS).encode()
+    assert tok.encode_batch_list(BytesSource([blob], separator=b"<|sep|>")) == expected
+
+
+def test_bytes_source_rejects_str_data(tok):
+    with pytest.raises(TypeError, match="list of bytes"):
+        BytesSource(["text"])
+
+
+# ---------------------------------------------------------------------------
 # encode_files
 # ---------------------------------------------------------------------------
 
@@ -123,6 +197,13 @@ def test_text_source_with_separator(tok, expected, tmp_path):
     path.write_text("<|sep|>".join(DOCS))
     got = tok.encode_files(TextFileSource([path], separator=b"<|sep|>"))
     assert _ids(got) == expected
+
+
+def test_text_source_str_separator(tok, expected, tmp_path):
+    """A str separator is encoded to its UTF-8 bytes."""
+    path = tmp_path / "docs.txt"
+    path.write_text("<|sep|>".join(DOCS))
+    assert _ids(tok.encode_files(TextFileSource([path], separator="<|sep|>"))) == expected
 
 
 def test_text_source_one_doc_per_file(tok, tmp_path):

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -16,7 +16,7 @@ from tokenizers import Tokenizer as HFTokenizer
 from tokenizers import normalizers, pre_tokenizers
 from tokenizers.models import BPE
 
-from gigatoken import Tokenizer
+from gigatoken import BytesSource, Tokenizer
 
 TEXTS = [
     "Hello, world!",
@@ -84,6 +84,26 @@ def test_hf_json_decode_parity(tinyllama_tokenizer_path):
     for text in TEXTS:
         ids = hf_tok.encode(text, add_special_tokens=False).ids
         assert gigatoken_tok.decode(ids).decode("utf-8", "replace") == hf_tok.decode(ids, skip_special_tokens=False)
+
+
+def test_bytes_source_separator_matches_presplit(tinyllama_tokenizer_path):
+    """encode_batch with a BytesSource splits on the separator inside Rust
+    (the SentencePiece backend's region path); ids must match the same
+    documents pre-split in Python."""
+    gigatoken_tok = Tokenizer(tinyllama_tokenizer_path)
+    docs = [t for t in TEXTS if t]  # the separator split skips empty documents
+    blob = "<|sep|>".join(docs).encode()
+    got = gigatoken_tok.encode_batch(BytesSource([blob], separator=b"<|sep|>"))
+    assert got.tolist() == gigatoken_tok.encode_batch(docs).tolist()
+
+
+def test_bytes_source_invalid_utf8_separator_raises(tinyllama_tokenizer_path):
+    """Document bytes are trusted to be valid UTF-8, but a separator that is
+    not valid UTF-8 could cut a document mid-character, so the SentencePiece
+    backend rejects it up front (a constant-time argument check)."""
+    gigatoken_tok = Tokenizer(tinyllama_tokenizer_path)
+    with pytest.raises(ValueError, match="separator"):
+        gigatoken_tok.encode_batch(BytesSource(["é".encode()], separator=b"\xa9"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`encode_batch` (all variants, both backends) now accepts a **`BytesSource`** — borrowed in-memory byte buffers plus an optional document separator — and splits documents on the separator **inside Rust, during the parallel encode**, instead of requiring callers to pre-split corpora into per-document Python objects.

```python
tok.encode_batch(BytesSource([blob], separator="<|endoftext|>"))
```

- Reuses the exact region machinery `encode_files` has always used: chunk boundaries are probed at ~target intervals (O(#chunks) short scans, not a full pass), then a streaming `DocumentIter` finds separators one document at a time, interleaved with encoding — the scan doubles as a prefetch for the encoder.
- `separator` accepts **str or bytes** on both `BytesSource` and `TextFileSource` (str is UTF-8-encoded); stored as a plain `Vec<u8>` in `DocFormat`. Only the document buffers stay zero-copy (`PyBackedBytes`).
- Semantics match the Python `raw.split(sep)`-and-skip-empties convention exactly (leading/trailing/consecutive separators yield no empty rows).

## Also in this PR

- The SentencePiece batch path **no longer validates UTF-8** — inputs are trusted per the documented contract, matching `encode_files`' treatment of file contents. This removes `utf8_doc` and the `known_utf8` plumbing from the encode callbacks. One constant-time check remains: a non-UTF-8 *separator* is rejected on the SP path, since a mid-character separator match would break the unchecked `str` conversion on the split pieces.
- The CLI `gigatoken bench` passes separators through (`BytesSource` with `--in-memory`, `TextFileSource` otherwise) instead of pre-splitting in Python. Reported byte counts are now whole-file bytes, separators included.

## Performance

Interleaved A/B vs `main`, sequential, min-of-N, GPT-2 on OWT:

| config | main | this PR |
|---|---|---|
| 300 MB, separator path | 0.0421 s (pre-split) | **0.0367 s (BytesSource, ~11% faster)** |
| full OWT (11.9 GB), separator path | 1.763 s (pre-split) | **1.515 s (BytesSource, ~16% faster, 7.9 GB/s)** |
| pre-split list (unchanged API) | 0.0421 s | 0.0423 s (parity) |
| single huge doc (fragment path) | 0.0366 s | 0.0375 s (parity, within noise) |
| SP (tinyllama) bytes list, 300 MB | 0.265 s | **0.252 s (~5% faster — removed validation pass)** |

Token counts are bit-identical between the pre-split and BytesSource paths in every configuration (2,701,647,155 tokens on full OWT).

## Testing

- New tests: separator/pre-split id parity (BPE + SP), str separators, multi-buffer ordering, empty-document skipping, parallel chunking above the chunk target, `parallel=False`, `encode_batch_list`, empty source, repr, and SP rejection of non-UTF-8 separators.
- Full suites green: `cargo test --release` and pytest (1353 passed, 8 skipped).