### PR TITLE
Zen 5 round 2: vpcompressb flatten_bits, merge-scan rank prefetch, qwen2-family classifier cuts

### DIFF
--- a/profiling/x86_port_plan.md
+++ b/profiling/x86_port_plan.md
@@ -453,3 +453,78 @@ re-taught: back-to-back NON-interleaved sessions on this box can differ
 by ~4% from post-compile thermal state — a standalone triple-run of the
 rebased binary first read as a 4% regression that interleaving inverted.
 Never compare across sessions; interleave or it didn't happen.
+
+## 8. Zen 5 round 2: the §7 leftovers + the qwen2-family classifier
+
+Fresh profile on main @ b092ad7 (worktree `encode-profiling`) reproduced
+the §7 residual shape exactly (gpt2 1 GB: 833 cold / 1122 warm; fill
+44.7% / emit 38.7% / merge_short 16.8% cold), plus a first profile of the
+qwen2-scheme path (Qwen3-8B tokenizer, same corpus: 720 cold / 965 warm —
+the gap is classification: `batch_masks_avx512::<class_of>` 17.6% warm +
+`family_extended_masks` 8.1%, vs r50k's 13.1% total). All changes below
+interleaved min-of-4/5 at 1 GB, token counts bit-identical throughout.
+
+Applied:
+
+1. **`vpcompressb` flatten_bits (§5.5) — gpt2 +3-6% cold / +4-8% warm;
+   carries to every mask scheme.** New `fill_spans_two_phase_crc_avx512`
+   shim (`+avx512vbmi2`, gated on `avx512_fill_available()`, dispatched
+   once per fill) monomorphizes the fill with `const X86_AVX512`; phase A's
+   8-octet BIT_POS LUT walk becomes compress-iota + widen + `vpaddw rel` +
+   two unconditional 64 B stores (BOUND_BUF slack grown 144 → 208 for the
+   128-lane scribble; worst-case cursor analysis in the comment).
+2. **Rank-slot prefetch in the short-merge refresh (§5.4a) — cold +0.8%,
+   warm neutral.** After the min-rank scan picks `best`, both refresh
+   pairs' first rank addresses (dense cell or first sparse slot) are known
+   before the list surgery; `PairRankTable::prefetch_rank` issues both
+   `prefetcht0`s there, overlapping the two serial loads with the surgery.
+3. **Family classifier: LazyLock hoist + 2-byte fast lane — qwen2 warm
+   +1.3%, cold +0.5%; r50k neutral.** Per-char `class_of` paid a LazyLock
+   state check + Box-pointer load before the table index; schemes now
+   resolve a `ClassTable` handle once per batch and pass a capturing
+   closure. `classify_uni_chars` gained a lead `< 0xE0` lane (inline
+   2-byte decode, constant masks) — western corpora's dominant non-ASCII
+   case. Family fuzz differentials (all four schemes) + 100 MB OWT
+   streaming differentials green.
+
+Tried, measured, and REVERTED:
+
+- **AVX-512 masked key load in phase B (§5.6): −36% warm / −30% cold.**
+  The scalar pack's 16-byte load address depends only on `prev`, so it
+  issues before `tok_len` resolves; `vmovdqu8 {k}{z}` made the load wait
+  on the boundary→len→kmask chain and added a `vpextrq` GPR crossing
+  before the CRC — ~90% of loop samples piled on the masked load and its
+  dependents. Overlapped work became serialized. Do not re-try (comment
+  at the phase-B loop records this).
+
+Full-dataset (11.9 GB OWT, page cache warm, interleaved ×2), before →
+after this round:
+
+| bench | before | after |
+|---|---|---|
+| encode_st full pass 0 (gpt2) | 936-942 MB/s | **1005-1009 MB/s (+7.2%)** |
+| encode_st full pass 0 (Qwen3-8B) | 805-810 MB/s | **862-863 MB/s (+7.0%)** |
+| gpt2 1 GB cold / warm | 827 / 1120 | 879 / 1210 (+6% / +8%) |
+| Qwen3-8B 1 GB cold / warm | 711 / 960 | 759 / 1043 (+6.7% / +8.6%) |
+
+Counts: 2717102153 (gpt2 full), 2624517214 (Qwen3-8B full), 228107519 /
+220398751 @ 1 GB — identical on every build. Still open: §5.7 PGO for
+cold I-cache; qwen2 carry-forwarding across sequential batches (assessed,
+skipped — the fill walker's rewinds make the invalidation story unsafe
+and the sequential-case saving is ~10 L1-hot ops per batch).
+
+Rebase note: this round was rebased onto a4bcfcb's x86-tier fill
+monomorphization; the `const X86_AVX512` bool + `_crc_avx512` shim above
+became a fourth tier value `X86_TIER_AVX512_VBMI2` (wrapper
+`fill_spans_two_phase_avx512_vbmi2_crc` = AVX-512 tier features +
+`avx512vbmi2`, still gated once per fill on `avx512_fill_available()`;
+plain-AVX-512 CPUs without VBMI2 keep the `X86_TIER_AVX512` wrapper and
+scalar flatten), and the classifier hoist moved into the schemes'
+collapsed `batch_masks_x86` bodies (a silent rebase hazard: git
+auto-applied the hoist only to the aarch64 `batch_masks`, leaving the
+hot x86 bodies on the bare classifier — caught in review of the merged
+tree). Numbers above predate the rebase; post-rebase interleaved re-A/B
+vs the new main (which a4bcfcb itself sped up to 851 cold / ~1162 warm
+gpt2, 747 / ~1020 qwen at 1 GB): gpt2 895 / ~1241 (+5.2% / +6.5%),
+qwen 780 / ~1074 (+4.3% / +5.4%); full-file gpt2 ~1002-1027 vs ~974,
+qwen 889 vs ~847 MB/s. Counts unchanged on every build.

--- a/src/bpe/mod.rs
+++ b/src/bpe/mod.rs
@@ -248,6 +248,39 @@ impl PairRankTable {
             idx = (idx + 1) & self.mask;
         }
     }
+
+    /// `prefetcht0` the first line [`Self::rank`] would load for `(a, b)`:
+    /// the dense cell when both sides sit in the grid, else the first
+    /// sparse probe slot. The short-merge loop's refresh lookups sit on a
+    /// serial dependency chain and their slot-load consumers are ~5-7% of
+    /// cold cycles on Zen 5 (profiling/zen5_st_profile.md §4.3); both
+    /// refresh pairs are known before the list surgery, so issuing their
+    /// prefetches first overlaps the load latency with the surgery and
+    /// with each other. Address math mirrors `rank` exactly (same bounds:
+    /// dense idx < dense.len(), slot idx < slots.len() via `shift`), so
+    /// every prefetched address lies within the table's allocations.
+    /// x86_64 only; a no-op elsewhere (aarch64 uses the NEON merge core).
+    #[inline(always)]
+    pub(crate) fn prefetch_rank(&self, a: TokenId, b: TokenId) {
+        #[cfg(target_arch = "x86_64")]
+        // SAFETY: `_mm_prefetch` does not dereference; both index
+        // computations are the bounded ones from `rank` (see its SAFETY
+        // comments), so the address stays inside the live allocation.
+        unsafe {
+            use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+            let addr = if (a.0 | b.0) >> self.dense_log2 == 0 {
+                let idx = ((a.0 as usize) << self.dense_log2) | b.0 as usize;
+                self.dense.as_ptr().add(idx) as *const i8
+            } else {
+                let key = ((a.0 as u64) << PAIR_ID_BITS) | b.0 as u64;
+                let idx = (key.wrapping_mul(0x9E37_79B9_7F4A_7C15) >> self.shift) as usize;
+                self.slots.as_ptr().add(idx) as *const i8
+            };
+            _mm_prefetch(addr, _MM_HINT_T0);
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = (a, b);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -507,8 +540,14 @@ pub(crate) const SHORT_MERGE_MAX: usize = 16;
 /// Kept separate from the Vec-based [`bpe_merge_symbols_small`] (16..=32
 /// symbols): the domains are disjoint and unification was measured as a
 /// regression risk to this tuned miss path.
+///
+/// `prefetch_rank` is [`PairRankTable::prefetch_rank`] when a table backs
+/// `get_rank`, and a no-op closure for the HashMap fallback — the merge
+/// scan itself stays identical either way (restructuring it was measured
+/// negative; the prefetch only reorders when the refresh loads issue).
 pub(crate) fn bpe_merge_symbols_short_scalar(
     get_rank: impl Fn(TokenId, TokenId) -> u32,
+    prefetch_rank: impl Fn(TokenId, TokenId),
     symbols: &mut [TokenId; SHORT_MERGE_MAX],
     n: usize,
 ) -> usize {
@@ -539,10 +578,27 @@ pub(crate) fn bpe_merge_symbols_short_scalar(
             break;
         }
         let i = best_i;
-        symbols[i] = TokenId(best);
-        // Unlink the right element of the merged pair.
+        // Both refresh pairs are fixed the moment `best` is chosen:
+        // (best, symbols[new_right]) and (symbols[left], best). Their rank
+        // lines are the serial chain's next loads (their consumers are
+        // ~5-7% of cold cycles, profiling/zen5_st_profile.md §4.3), so
+        // request both before the list surgery. List indices are strictly
+        // increasing, so new_right > i and the surgery's `prev[new_right]`
+        // store cannot alias `prev[i]` — reading `left` early is safe.
+        // `symbols[new_right]` / `symbols[left]` are read only behind the
+        // same `< n` guards the refresh uses: active positions holding
+        // live tokens, never garbage lanes.
         let dead = next[i] as usize;
         let new_right = next[dead] as usize;
+        let left = prev[i] as usize;
+        if new_right < n {
+            prefetch_rank(TokenId(best), symbols[new_right]);
+        }
+        if left < n {
+            prefetch_rank(symbols[left], TokenId(best));
+        }
+        symbols[i] = TokenId(best);
+        // Unlink the right element of the merged pair.
         next[i] = new_right as u8;
         ranks[dead] = u32::MAX;
         // Refresh the two pairs now touching the merged symbol.
@@ -552,7 +608,6 @@ pub(crate) fn bpe_merge_symbols_short_scalar(
         } else {
             ranks[i] = u32::MAX;
         }
-        let left = prev[i] as usize;
         if left < n {
             ranks[left] = get_rank(symbols[left], symbols[i]);
         }
@@ -1118,7 +1173,12 @@ mod tests {
 
             let mut scalar = [TokenId(0); SHORT_MERGE_MAX];
             scalar[..n].copy_from_slice(&init);
-            let len = bpe_merge_symbols_short_scalar(|a, b| table.rank(a, b), &mut scalar, n);
+            let len = bpe_merge_symbols_short_scalar(
+                |a, b| table.rank(a, b),
+                |a, b| table.prefetch_rank(a, b),
+                &mut scalar,
+                n,
+            );
             assert_eq!(&scalar[..len], &reference[..], "scalar diverged: {init:?}");
 
             #[cfg(target_arch = "aarch64")]

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -387,9 +387,15 @@ impl Tokenizer {
             // scan's `rank < best` branches predict well on Zen 5. See
             // profiling/x86_port_plan.md §6.
             #[cfg(not(target_arch = "aarch64"))]
-            Some(table) => bpe_merge_symbols_short_scalar(|a, b| table.rank(a, b), buf, n),
+            Some(table) => bpe_merge_symbols_short_scalar(
+                |a, b| table.rank(a, b),
+                |a, b| table.prefetch_rank(a, b),
+                buf,
+                n,
+            ),
             None => bpe_merge_symbols_short_scalar(
                 |a, b| merges.get(&(a, b)).map_or(u32::MAX, |m| m.0),
+                |_, _| {},
                 buf,
                 n,
             ),

--- a/src/pretokenize/fast/cl100k.rs
+++ b/src/pretokenize/fast/cl100k.rs
@@ -37,14 +37,20 @@ impl MaskScheme for Cl100kScheme {
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        batch_masks(bytes, scan, true, unicode::class_of)
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
+        batch_masks(bytes, scan, true, move |cp| ct.class_of(cp))
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { batch_masks_x86::<AVX512>(bytes, scan, true, unicode::class_of) }
+        unsafe { batch_masks_x86::<AVX512>(bytes, scan, true, move |cp| ct.class_of(cp)) }
     }
 }
 

--- a/src/pretokenize/fast/mask.rs
+++ b/src/pretokenize/fast/mask.rs
@@ -57,6 +57,18 @@ pub(crate) fn avx512_scanner_available() -> bool {
         && std::arch::is_x86_feature_detected!("popcnt")
 }
 
+/// Does this x86_64 CPU also have AVX-512 VBMI2 (native 512-bit
+/// `vpcompressb`: Zen 4/5, Ice Lake+ — i.e. nearly every AVX-512 CPU,
+/// but the bit is detected, not assumed: Skylake-X lacks it and stays on
+/// the plain AVX-512 tier)? Gates the `X86_TIER_AVX512_VBMI2` fill tier
+/// ([`MaskState::fill_spans_two_phase`]'s `_avx512_vbmi2_crc` wrapper),
+/// whose `flatten_bits_avx512` needs VBMI2 on top of the scanner tier.
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub(crate) fn avx512_fill_available() -> bool {
+    avx512_scanner_available() && std::arch::is_x86_feature_detected!("avx512vbmi2")
+}
+
 /// Does this x86_64 CPU have the AVX2 tier (Haswell+, all Zen)? The bit
 /// features (BMI1/2, LZCNT, POPCNT) arrived with or before AVX2 on every
 /// AVX2 CPU, but are detected explicitly since the boundary algebra's
@@ -432,7 +444,9 @@ pub(crate) struct UniClasses {
 ///
 /// The loop stays branchy on purpose: a branchless csel-selected
 /// decode/classify body measured 0.986x (predicted branches beat data
-/// chains, log step 13/17).
+/// chains, log step 13/17). 2-byte chars (nearly all non-ASCII in western
+/// corpora) take a dedicated lane with an inline decode; 3/4-byte chars
+/// pay the general ladder.
 ///
 /// # Safety
 ///
@@ -452,17 +466,49 @@ pub(crate) unsafe fn classify_uni_chars<const NUMBERS: bool, const LEADS: bool>(
         let i = m.trailing_zeros() as usize;
         m &= m - 1;
         let b = bytes[scan + i];
-        if b < 0xC2 {
-            u.resid |= 1 << i; // stray continuation byte (invalid UTF-8)
+        if b < 0xE0 {
+            // 2-byte lane (leads 0xC2..0xDF, cp < 0x800): nearly every
+            // non-ASCII char in western corpora, so this branch predicts
+            // taken and skips the length ladder + general decode.
+            if b < 0xC2 {
+                u.resid |= 1 << i; // stray continuation byte (invalid UTF-8)
+                continue;
+            }
+            let lead = 1u64 << i;
+            let chm = 3u64 << i; // in-batch bytes (excess drops at bit 63)
+            // SAFETY: scan + 70 <= len (this fn's # Safety contract),
+            // i <= 63, so scan + i + 1 <= scan + 64 < len.
+            let b1 = unsafe { *bytes.get_unchecked(scan + i + 1) };
+            let cp = ((b as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F);
+            match class(cp) {
+                CharClass::Letter => u.l |= chm,
+                CharClass::Number => {
+                    u.n |= chm;
+                    if !NUMBERS {
+                        u.resid |= chm;
+                    }
+                }
+                CharClass::Other => u.o |= chm,
+                CharClass::Whitespace => {
+                    u.ws |= chm;
+                    if i + 2 > 64 {
+                        // Straddling-out ws stays a bad zone; its true
+                        // class marks keep neighbors' `(?!\S)` tests
+                        // exact.
+                        u.resid |= chm;
+                    } else {
+                        u.w2 |= lead;
+                    }
+                }
+            }
+            if LEADS {
+                u.lead2 |= lead;
+            }
+            u.cont |= chm & !lead;
+            m &= !chm;
             continue;
         }
-        let l = if b < 0xE0 {
-            2
-        } else if b < 0xF0 {
-            3
-        } else {
-            4
-        };
+        let l = if b < 0xF0 { 3 } else { 4 };
         let chm = ((1u64 << l) - 1) << i; // in-batch bytes (excess drops)
         let lead = 1u64 << i;
         // SAFETY: scan + 70 <= len (this fn's # Safety contract), i <= 63,
@@ -484,18 +530,16 @@ pub(crate) unsafe fn classify_uni_chars<const NUMBERS: bool, const LEADS: bool>(
                     // is ws in Unicode) stays a bad zone; its true class
                     // marks keep neighbors' `(?!\S)` tests exact.
                     u.resid |= chm;
-                } else if l == 2 {
-                    u.w2 |= lead;
                 } else {
                     u.w3 |= lead;
                 }
             }
         }
         if LEADS {
-            match l {
-                2 => u.lead2 |= lead,
-                3 => u.lead3 |= lead,
-                _ => u.lead4 |= lead,
+            if l == 3 {
+                u.lead3 |= lead;
+            } else {
+                u.lead4 |= lead;
             }
         }
         u.cont |= chm & !lead;
@@ -622,11 +666,14 @@ unsafe fn batch_masks_dyn_avx2<S: MaskScheme>(bytes: &[u8], scan: usize) -> (u64
 /// ([`MaskState::fill_spans_two_phase_impl`]): `DYN` keeps the per-batch
 /// runtime dispatch of the provided `MaskScheme::batch_masks`; `AVX2` /
 /// `AVX512` pin the tier, chosen once per fill inside a matching
-/// `#[target_feature]` wrapper. Meaningless (and always `DYN`) off
-/// x86_64.
+/// `#[target_feature]` wrapper. `AVX512_VBMI2` is the AVX-512 tier plus
+/// VBMI2 ([`avx512_fill_available`]): same batch classifiers, but phase
+/// A's flatten runs `vpcompressb` (`flatten_bits_avx512`) — its only
+/// divergence. Meaningless (and always `DYN`) off x86_64.
 pub(crate) const X86_TIER_DYN: u8 = 0;
 pub(crate) const X86_TIER_AVX2: u8 = 1;
 pub(crate) const X86_TIER_AVX512: u8 = 2;
+pub(crate) const X86_TIER_AVX512_VBMI2: u8 = 3;
 
 /// Scheme-agnostic mask-scanner state: pops trusted boundary bits, walks
 /// bad zones through the scheme's scalar `advance`, runs the buffer tail
@@ -867,6 +914,72 @@ unsafe fn flatten_bits(m: u64, rel: u16, out: *mut u16) -> usize {
     (incl >> 56) as usize
 }
 
+/// [`flatten_bits`] via AVX-512 VBMI2: `vpcompressb` packs the set-bit
+/// positions of `m` (as compressed iota-byte lanes) in one op, replacing
+/// the 8-octet BIT_POS LUT walk (~3.8% of warm cycles on Zen 5,
+/// profiling/zen5_st_profile.md §5.5). Widen both halves to u16, add the
+/// broadcast `rel` (wrapping, as the scalar version), two unconditional
+/// 64-byte stores. Scribbles `out[0..128]` regardless of popcount — a
+/// wider scribble than the scalar version's `out[popcount + 7]`; BOUND_BUF
+/// reserves the 128-lane slack past every call site's worst-case cursor.
+///
+/// # Safety
+///
+/// The CPU must support AVX-512 F/BW/VBMI2 (reached only from the
+/// `fill_spans_two_phase_avx512_vbmi2_crc` wrapper, gated on
+/// [`avx512_fill_available`]), and `out[0..128]` must be writable.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512bw,avx512vbmi2")]
+#[inline]
+unsafe fn flatten_bits_avx512(m: u64, rel: u16, out: *mut u16) -> usize {
+    use std::arch::x86_64::*;
+    const IOTA: [u8; 64] = {
+        let mut a = [0u8; 64];
+        let mut i = 0;
+        while i < 64 {
+            a[i] = i as u8;
+            i += 1;
+        }
+        a
+    };
+    unsafe {
+        let iota = _mm512_loadu_si512(IOTA.as_ptr() as *const _);
+        let comp = _mm512_maskz_compress_epi8(m, iota);
+        let relv = _mm512_set1_epi16(rel as i16);
+        let lo = _mm512_add_epi16(_mm512_cvtepu8_epi16(_mm512_castsi512_si256(comp)), relv);
+        let hi = _mm512_add_epi16(
+            _mm512_cvtepu8_epi16(_mm512_extracti64x4_epi64::<1>(comp)),
+            relv,
+        );
+        _mm512_storeu_si512(out as *mut _, lo);
+        _mm512_storeu_si512(out.add(32) as *mut _, hi);
+    }
+    m.count_ones() as usize
+}
+
+/// [`flatten_bits`], monomorphized on the fill's x86 tier: the const
+/// comparison folds at compile time (no per-call branch survives), and
+/// the VBMI2 variant is only instantiated live inside the
+/// `#[target_feature]` `_avx512_vbmi2_crc` wrapper, so its intrinsics
+/// inline there.
+///
+/// # Safety
+///
+/// As [`flatten_bits`]; with `X86_TIER = X86_TIER_AVX512_VBMI2`,
+/// additionally [`flatten_bits_avx512`]'s contract (VBMI2 CPU, 128
+/// writable lanes).
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe fn flatten_bits_dispatch<const X86_TIER: u8>(m: u64, rel: u16, out: *mut u16) -> usize {
+    #[cfg(target_arch = "x86_64")]
+    if X86_TIER == X86_TIER_AVX512_VBMI2 {
+        // SAFETY: forwarded from this fn's contract.
+        return unsafe { flatten_bits_avx512(m, rel, out) };
+    }
+    // SAFETY: forwarded from this fn's contract.
+    unsafe { flatten_bits(m, rel, out) }
+}
+
 /// [`pack_mask_halves`](crate::pretokenize::pack_mask_halves) — the single
 /// source of the mask math — evaluated for each clamped length `m` in
 /// 1..=15 (entry 0 unused), as one 16-byte row so the phase-B emission
@@ -891,10 +1004,14 @@ static PACK_MASK_TABLE: [[u64; 2]; 16] = {
 
 /// Boundary scratch of one fill: PRETOKEN_CHUNK live entries, one batch of
 /// overshoot from the last harvested batch (64 in-batch boundaries plus one
-/// scalar-overrun end), and [`flatten_bits`]' 8-lane scribble slack, with
-/// margin.
+/// scalar-overrun end), and the flatten scribble slack — 128 lanes for
+/// [`flatten_bits_avx512`]'s two unconditional 64-byte stores (the widest
+/// path; [`flatten_bits`]' 8-lane scribble is subsumed), with margin.
+/// Worst-case cursor at a flatten call: needed - 1 (= 255) at batch entry
+/// plus up to 64 in-batch boundaries already written = 319; 319 + 128 =
+/// 447 <= 464.
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-const BOUND_BUF: usize = crate::pretokenize::PRETOKEN_CHUNK + 144;
+const BOUND_BUF: usize = crate::pretokenize::PRETOKEN_CHUNK + 208;
 
 /// Boundary offsets are u16-relative to the fill base; a batch is only
 /// harvested while every position it can contribute (base + 63, or the
@@ -944,6 +1061,19 @@ impl MaskState {
         // every AVX2/AVX-512 CPU has SSE4.2.
         #[cfg(target_arch = "x86_64")]
         if crate::pretokenize::crc_hash_selected() {
+            // Feature detection (including the VBMI2 bit) stays in this
+            // once-per-fill dispatch: `is_x86_feature_detected!` does NOT
+            // const-fold inside a matching `#[target_feature]` fn (it
+            // stays an atomic load), so testing it any deeper would put
+            // the load in the loop.
+            if avx512_fill_available() {
+                // SAFETY: `avx512_fill_available` verified the AVX-512
+                // scanner tier plus VBMI2; every such CPU has SSE4.2
+                // (also implied by `crc_hash_selected` above).
+                return unsafe {
+                    self.fill_spans_two_phase_avx512_vbmi2_crc::<S>(bytes, batch, prefetch)
+                };
+            }
             if avx512_scanner_available() {
                 // SAFETY: AVX-512 tier + SSE4.2 detected right above.
                 return unsafe {
@@ -960,6 +1090,31 @@ impl MaskState {
             return unsafe { self.fill_spans_two_phase_crc::<S>(bytes, batch, prefetch) };
         }
         self.fill_spans_two_phase_impl::<S, false, X86_TIER_DYN>(bytes, batch, prefetch)
+    }
+
+    /// The AVX-512 + VBMI2 tier, CRC-hash monomorphization of
+    /// [`Self::fill_spans_two_phase`] (Zen 4/5, Ice Lake+): the AVX-512
+    /// tier wrapper plus `avx512vbmi2` for `flatten_bits_avx512` — its
+    /// only divergence from [`Self::fill_spans_two_phase_avx512_crc`],
+    /// which stays the tier for AVX-512 CPUs without VBMI2 (Skylake-X).
+    /// An AVX-512 phase-B key pack measured a large regression, see the
+    /// phase-B loop's comment.
+    ///
+    /// # Safety
+    ///
+    /// The CPU must support the AVX-512 scanner tier plus VBMI2
+    /// ([`avx512_fill_available`]) and SSE4.2 (`crc_hash_selected`).
+    #[cfg(target_arch = "x86_64")]
+    #[target_feature(
+        enable = "avx512f,avx512bw,avx512vl,avx512vbmi2,bmi1,bmi2,lzcnt,popcnt,sse4.2"
+    )]
+    unsafe fn fill_spans_two_phase_avx512_vbmi2_crc<'a, S: MaskScheme>(
+        &mut self,
+        bytes: &'a [u8],
+        batch: &mut crate::pretokenize::SpanBatch<'a>,
+        prefetch: &impl Fn(u64),
+    ) -> usize {
+        self.fill_spans_two_phase_impl::<S, true, X86_TIER_AVX512_VBMI2>(bytes, batch, prefetch)
     }
 
     /// The AVX-512-tier, CRC-hash monomorphization of
@@ -1027,8 +1182,9 @@ impl MaskState {
     /// [`Self::fill_spans_two_phase`]'s body, monomorphized on the hash
     /// arm (`X86_CRC` — see `fill_span_hash`'s reachability contract) and
     /// the x86 SIMD tier (`X86_TIER` — the `X86_TIER_*` constants; the
-    /// AVX2/AVX-512 instantiations are only reachable through the
-    /// matching `#[target_feature]` wrappers above).
+    /// AVX2/AVX-512/VBMI2 instantiations are only reachable through the
+    /// matching `#[target_feature]` wrappers above, whose feature sets
+    /// cover every intrinsic their tier's arms use).
     #[inline(always)]
     fn fill_spans_two_phase_impl<'a, S: MaskScheme, const X86_CRC: bool, const X86_TIER: u8>(
         &mut self,
@@ -1107,7 +1263,11 @@ impl MaskState {
                     // SAFETY: the tier wrappers instantiate these arms
                     // only after runtime tier detection (see
                     // `fill_spans_two_phase`).
-                    X86_TIER_AVX512 => unsafe { S::batch_masks_x86::<true>(bytes, base) },
+                    // The VBMI2 tier runs the same AVX-512 classifiers;
+                    // it only diverges in the flatten below.
+                    X86_TIER_AVX512 | X86_TIER_AVX512_VBMI2 => unsafe {
+                        S::batch_masks_x86::<true>(bytes, base)
+                    },
                     X86_TIER_AVX2 => unsafe { S::batch_masks_x86::<false>(bytes, base) },
                     _ => S::batch_masks(bytes, base),
                 };
@@ -1131,8 +1291,12 @@ impl MaskState {
                 };
                 let rel = base.wrapping_sub(fill_base) as u16;
                 if bad & blive == 0 {
-                    debug_assert!(nb + 72 <= BOUND_BUF);
-                    nb += unsafe { flatten_bits(usable & ulive, rel, bufp.add(nb)) };
+                    // Scribble bound: 128 lanes (VBMI2 tier) / popcount +
+                    // 7 (scalar) — see BOUND_BUF's worst-case analysis.
+                    debug_assert!(nb + if X86_TIER == X86_TIER_AVX512_VBMI2 { 128 } else { 72 } <= BOUND_BUF);
+                    nb += unsafe {
+                        flatten_bits_dispatch::<X86_TIER>(usable & ulive, rel, bufp.add(nb))
+                    };
                     scan = base + 64;
                     continue;
                 }
@@ -1143,15 +1307,17 @@ impl MaskState {
                 loop {
                     let seg_bad = bad & blive;
                     if seg_bad == 0 {
-                        debug_assert!(nb + 72 <= BOUND_BUF);
-                        nb += unsafe { flatten_bits(usable & ulive, rel, bufp.add(nb)) };
+                        debug_assert!(nb + if X86_TIER == X86_TIER_AVX512_VBMI2 { 128 } else { 72 } <= BOUND_BUF);
+                        nb += unsafe {
+                            flatten_bits_dispatch::<X86_TIER>(usable & ulive, rel, bufp.add(nb))
+                        };
                         scan = base + 64;
                         break;
                     }
                     let fb = seg_bad.trailing_zeros();
                     let prefix = usable & ulive & !(u64::MAX << fb);
-                    debug_assert!(nb + 72 <= BOUND_BUF);
-                    nb += unsafe { flatten_bits(prefix, rel, bufp.add(nb)) };
+                    debug_assert!(nb + if X86_TIER == X86_TIER_AVX512_VBMI2 { 128 } else { 72 } <= BOUND_BUF);
+                    nb += unsafe { flatten_bits_dispatch::<X86_TIER>(prefix, rel, bufp.add(nb)) };
                     let mut p = if nb > 0 {
                         fill_base + unsafe { *bufp.add(nb - 1) } as usize
                     } else {
@@ -1227,6 +1393,19 @@ impl MaskState {
             // compiler cannot see end >= prev in u16 subtraction).
             let mut prev = 0usize;
             if fill_base + last_end + 16 <= len {
+                // Every x86 tier shares this scalar key pack. An AVX-512
+                // masked pack (`vmovdqu8 {k}{z}` under a tok_len-derived
+                // kmask, vpextrq/vmovq into the CRC) measured −36% warm /
+                // −30% cold on Zen 5 (5-round interleaved A/B, 1 GB
+                // gpt2, tokens identical): this plain load's address
+                // depends only on `prev`, so it issues early and the
+                // table row + ANDs apply late, while the masked load's
+                // kmask waits on the whole boundary→tok_len chain and the
+                // extracts add a vector→GPR crossing before the CRC —
+                // per-span work went from overlapping to serialized
+                // (~90% of loop samples on the masked load + dependents).
+                // Do not re-try; the VBMI2 tier's only divergence is
+                // `flatten_bits_avx512` in phase A.
                 for (i, e) in entries.iter_mut().enumerate() {
                     let end = unsafe { *bufp.add(i) } as usize;
                     let tok_len = end - prev;

--- a/src/pretokenize/fast/olmo3.rs
+++ b/src/pretokenize/fast/olmo3.rs
@@ -33,14 +33,20 @@ impl MaskScheme for Olmo3Scheme {
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        batch_masks(bytes, scan, true, unicode::class_of)
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
+        batch_masks(bytes, scan, true, move |cp| ct.class_of(cp))
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { batch_masks_x86::<AVX512>(bytes, scan, true, unicode::class_of) }
+        unsafe { batch_masks_x86::<AVX512>(bytes, scan, true, move |cp| ct.class_of(cp)) }
     }
 }
 

--- a/src/pretokenize/fast/qwen2.rs
+++ b/src/pretokenize/fast/qwen2.rs
@@ -35,14 +35,20 @@ impl MaskScheme for Qwen2Scheme {
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        batch_masks(bytes, scan, false, unicode::class_of)
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
+        batch_masks(bytes, scan, false, move |cp| ct.class_of(cp))
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::ClassTable::get();
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { batch_masks_x86::<AVX512>(bytes, scan, false, unicode::class_of) }
+        unsafe { batch_masks_x86::<AVX512>(bytes, scan, false, move |cp| ct.class_of(cp)) }
     }
 }
 

--- a/src/pretokenize/fast/qwen3_5.rs
+++ b/src/pretokenize/fast/qwen3_5.rs
@@ -36,14 +36,20 @@ impl MaskScheme for Qwen35Scheme {
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        batch_masks(bytes, scan, false, unicode::class_of_marks_join)
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::DsClassTable::get();
+        batch_masks(bytes, scan, false, move |cp| ct.class_of_marks_join(cp))
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
+        // Class-table LazyLock resolved once per batch; the extended
+        // path's per-char classify is then a bare slice index.
+        let ct = unicode::DsClassTable::get();
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { batch_masks_x86::<AVX512>(bytes, scan, false, unicode::class_of_marks_join) }
+        unsafe { batch_masks_x86::<AVX512>(bytes, scan, false, move |cp| ct.class_of_marks_join(cp)) }
     }
 }
 

--- a/src/pretokenize/fast/r50k.rs
+++ b/src/pretokenize/fast/r50k.rs
@@ -287,6 +287,11 @@ fn extended_masks(
 ) -> (u64, u64) {
     let wsa = ws64;
 
+    // Class-table LazyLock resolved once; the per-char classify below is
+    // then a bare slice index.
+    let ct = unicode::ClassTable::get();
+    let class = move |cp| ct.class_of(cp);
+
     // Bit-0 carries via the prev-char walk-back; a char straddling into
     // this batch claims its continuation bytes with its class. Without
     // this, every batch following a unicode char became a bad zone at
@@ -300,7 +305,7 @@ fn extended_masks(
     } else {
         // SAFETY: scan > 0 on this branch, and the classifier's
         // scan + 70 <= len batch guard covers pos + 3 <= len.
-        let (cls, _lead, end) = unsafe { mask::char_through(bytes, scan, unicode::class_of) };
+        let (cls, _lead, end) = unsafe { mask::char_through(bytes, scan, class) };
         let chm = if end > scan { (1u64 << (end - scan)) - 1 } else { 0 };
         claim.cont = chm;
         match cls {
@@ -330,7 +335,7 @@ fn extended_masks(
     // SAFETY: this classifier's scan + 70 <= len batch guard is exactly
     // `classify_uni_chars`' contract.
     let uni = unsafe {
-        mask::classify_uni_chars::<true, false>(bytes, scan, hi64 & !claim.cont, unicode::class_of)
+        mask::classify_uni_chars::<true, false>(bytes, scan, hi64 & !claim.cont, class)
     };
 
     // Effective per-byte classes: every byte of a classified char carries

--- a/src/pretokenize/unicode.rs
+++ b/src/pretokenize/unicode.rs
@@ -93,18 +93,42 @@ fn build_class_table() -> Box<[u8]> {
         .collect()
 }
 
+/// Pre-resolved handle to the packed class table. The static is a
+/// `LazyLock<Box<[u8]>>`, so every bare [`class_of`] call pays the
+/// lazy-init state check plus a dependent load of the Box pointer before
+/// the table load itself; per-char classify loops resolve the handle once
+/// and index the slice directly.
+#[derive(Clone, Copy)]
+pub(crate) struct ClassTable(&'static [u8]);
+
+impl ClassTable {
+    #[inline]
+    pub(crate) fn get() -> Self {
+        Self(&CLASS_TABLE)
+    }
+
+    /// [`class_of`] without the per-call static resolution. `cp` must be
+    /// a valid scalar value (guaranteed when decoded from valid UTF-8).
+    #[inline(always)]
+    pub(crate) fn class_of(self, cp: u32) -> CharClass {
+        debug_assert!(cp < 0x110000);
+        // SAFETY: `self.0` is CLASS_TABLE (the only constructor), sized
+        // 0x110000 / 4; cp >> 2 is in range for any scalar value.
+        let byte = unsafe { *self.0.get_unchecked((cp >> 2) as usize) };
+        match (byte >> ((cp & 3) << 1)) & 3 {
+            0 => CharClass::Letter,
+            1 => CharClass::Number,
+            2 => CharClass::Whitespace,
+            _ => CharClass::Other,
+        }
+    }
+}
+
 /// Classify a codepoint with one table load. `cp` must be a valid scalar
 /// value (guaranteed when decoded from valid UTF-8).
 #[inline(always)]
 pub(crate) fn class_of(cp: u32) -> CharClass {
-    debug_assert!(cp < 0x110000);
-    let byte = unsafe { *CLASS_TABLE.get_unchecked((cp >> 2) as usize) };
-    match (byte >> ((cp & 3) << 1)) & 3 {
-        0 => CharClass::Letter,
-        1 => CharClass::Number,
-        2 => CharClass::Whitespace,
-        _ => CharClass::Other,
-    }
+    ClassTable::get().class_of(cp)
 }
 
 // ---------------------------------------------------------------------------
@@ -132,12 +156,7 @@ pub(crate) enum DsCharClass {
 /// letters, everything else as in [`class_of`].
 #[inline(always)]
 pub(crate) fn class_of_marks_join(cp: u32) -> CharClass {
-    match ds_class_of(cp) {
-        DsCharClass::Letter | DsCharClass::Mark => CharClass::Letter,
-        DsCharClass::Number => CharClass::Number,
-        DsCharClass::Whitespace => CharClass::Whitespace,
-        DsCharClass::PunctSym | DsCharClass::Other => CharClass::Other,
-    }
+    DsClassTable::get().class_of_marks_join(cp)
 }
 
 /// 4-bit class per codepoint, 2 codepoints per byte (~544 KiB total).
@@ -172,20 +191,52 @@ fn build_ds_class_table() -> Box<[u8]> {
         .collect()
 }
 
+/// Pre-resolved handle to the packed DeepSeek class table — same
+/// LazyLock-hoist rationale as [`ClassTable`].
+#[derive(Clone, Copy)]
+pub(crate) struct DsClassTable(&'static [u8]);
+
+impl DsClassTable {
+    #[inline]
+    pub(crate) fn get() -> Self {
+        Self(&DS_CLASS_TABLE)
+    }
+
+    /// [`ds_class_of`] without the per-call static resolution. `cp` must
+    /// be a valid scalar value (guaranteed when decoded from valid UTF-8).
+    #[inline(always)]
+    pub(crate) fn ds_class_of(self, cp: u32) -> DsCharClass {
+        debug_assert!(cp < 0x110000);
+        // SAFETY: `self.0` is DS_CLASS_TABLE (the only constructor), sized
+        // 0x110000 / 2; cp >> 1 is in range for any scalar value.
+        let byte = unsafe { *self.0.get_unchecked((cp >> 1) as usize) };
+        match (byte >> ((cp & 1) << 2)) & 0xF {
+            0 => DsCharClass::Letter,
+            1 => DsCharClass::Number,
+            2 => DsCharClass::Whitespace,
+            3 => DsCharClass::Mark,
+            4 => DsCharClass::PunctSym,
+            _ => DsCharClass::Other,
+        }
+    }
+
+    /// [`class_of_marks_join`] without the per-call static resolution.
+    #[inline(always)]
+    pub(crate) fn class_of_marks_join(self, cp: u32) -> CharClass {
+        match self.ds_class_of(cp) {
+            DsCharClass::Letter | DsCharClass::Mark => CharClass::Letter,
+            DsCharClass::Number => CharClass::Number,
+            DsCharClass::Whitespace => CharClass::Whitespace,
+            DsCharClass::PunctSym | DsCharClass::Other => CharClass::Other,
+        }
+    }
+}
+
 /// Classify a codepoint for the DeepSeek scheme with one table load. `cp`
 /// must be a valid scalar value (guaranteed when decoded from valid UTF-8).
 #[inline(always)]
 pub(crate) fn ds_class_of(cp: u32) -> DsCharClass {
-    debug_assert!(cp < 0x110000);
-    let byte = unsafe { *DS_CLASS_TABLE.get_unchecked((cp >> 1) as usize) };
-    match (byte >> ((cp & 1) << 2)) & 0xF {
-        0 => DsCharClass::Letter,
-        1 => DsCharClass::Number,
-        2 => DsCharClass::Whitespace,
-        3 => DsCharClass::Mark,
-        4 => DsCharClass::PunctSym,
-        _ => DsCharClass::Other,
-    }
+    DsClassTable::get().ds_class_of(cp)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Profile-guided follow-up to the §7 Zen 5 campaign, targeting the items that round left open plus a first profiling pass on the qwen2-scheme (Qwen3-8B) path. Full round log in `profiling/x86_port_plan.md` §8. All numbers are interleaved A/B on the 9800X3D, single-threaded `encode_st`, token counts bit-identical on every build.

## Results (vs current main, post-rebase re-verification)

| bench | main | this PR | delta |
|---|---|---|---|
| gpt2 1 GB cold / warm | 851 / ~1162 MB/s | 895 / ~1241 MB/s | **+5.2% / +6.5%** |
| Qwen3-8B 1 GB cold / warm | 747 / ~1020 MB/s | 780 / ~1074 MB/s | **+4.3% / +5.4%** |
| gpt2 full 11.9 GB cold | ~974 MB/s | ~1002–1027 MB/s | **≥ +3%, crosses 1 GB/s** |
| Qwen3-8B full 11.9 GB cold | ~847 MB/s | 889 MB/s | **+4.8%** |

## Changes

- **`vpcompressb` flatten_bits** (the bulk of the win, all mask schemes): a fourth x86 fill tier `X86_TIER_AVX512_VBMI2` on the tier axis from the recent fill monomorphization — wrapper enables the AVX-512 tier features + `avx512vbmi2`, selected once per fill via `avx512_fill_available()`; AVX-512 CPUs without VBMI2 (Skylake-X) keep the plain AVX-512 tier and scalar flatten. Phase A's 8-octet BIT_POS LUT walk becomes compress-iota + widen + `vpaddw rel` + two unconditional 64 B stores; `BOUND_BUF` slack grown 144 → 208 for the 128-lane scribble (worst-case cursor analysis in the comment).
- **`PairRankTable::prefetch_rank` in the short-merge refresh** (cold +0.8%): once the min-rank scan picks `best`, both refresh pairs' first rank addresses are computable before the list surgery; issuing both `prefetcht0`s there overlaps the two serial rank loads.
- **qwen2-family classifier cuts** (qwen warm +1.3%, r50k neutral): the per-char `class_of` paid a `LazyLock` state check + Box-pointer load per character — schemes now resolve a `ClassTable` handle once per batch; `classify_uni_chars` gains a 2-byte-lead fast lane (the dominant non-ASCII case in western corpora).

## Measured and reverted

AVX-512 masked key load in phase B (`vmovdqu8 {k}{z}`): **−36% warm / −30% cold**. The scalar pack's 16-byte load address depends only on `prev` and issues before `tok_len` resolves; the kmask serialized the load behind the boundary→length chain and added a `vpextrq` GPR crossing before the CRC. Documented at the phase-B loop as do-not-re-try.

## Verification

- Differential fuzz for all four family schemes + padded cases, 100 MB OWT streaming differentials, `--lib pretokenize` (41) and `--lib bpe` (18) green on the final tree.
- Token identity on every build: 2717102153 (gpt2 full) / 2624517214 (Qwen3-8B full) / 228107519 & 220398751 @ 1 GB.
- `vpcompressb` engagement confirmed by disassembly (24 sites, all inside the VBMI2 wrapper monomorphizations, all 7 schemes) and a gdb breakpoint on the dispatch; zero masked xmm key loads in the binary.
- Rebased onto the x86-tier fill monomorphization; a silent auto-merge hazard (classifier hoist applied only to the aarch64 path) was caught and fixed, and all wins re-verified on the new base.

aarch64 untouched: x86-only tiers/prefetch, arch-neutral slack growth, and the classifier hoist threads the same closures the NEON path already used.