### PR TITLE
Fix 10-100x slow encode for gemma-3/4: keep unit splitting despite boundary-crossing vocab pieces

### DIFF
--- a/benches/encode_st.rs
+++ b/benches/encode_st.rs
@@ -1,4 +1,4 @@
-use gigatoken_rs::load_tokenizer::hf::load_hf_bpe;
+use gigatoken_rs::load_tokenizer::hf::{HfTokenizer, load_hf_slice};
 use gigatoken_rs::pretokenize::FastR50kPretokenizer;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -24,7 +24,10 @@ fn main() {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("data/gpt2_tokenizer.json")
     });
     eprintln!("Loading tokenizer from {tokenizer_path:?}...");
-    let mut tokenizer = load_hf_bpe(&tokenizer_path).expect("Could not load tokenizer");
+    let data = std::fs::read(&tokenizer_path).expect("Could not read tokenizer.json");
+    // byte_fallback configs (Llama/gemma-style SentencePiece) dispatch to the
+    // SP encode path; everything else to ByteLevel BPE, as in benches/encode.
+    let tokenizer = load_hf_slice(&data).expect("Could not load tokenizer");
 
     let input = common::load_owt_input(None);
     let size_gb = input.len() as f64 / 1e9;
@@ -44,26 +47,59 @@ fn main() {
     // passes; the token count is its length.
     let mut out: Vec<u32> = Vec::with_capacity(input.len() / 4 + 16);
     common::madvise_hugepage_capacity(&mut out);
-    for pass in 0..passes {
-        out.clear();
-        let start = Instant::now();
-        if tokenizer_override.is_some() {
-            let pretokens = tokenizer.pretokenizer_type().pretokenize(buf);
-            tokenizer.memoized_encode_flat(pretokens, &mut out);
-        } else {
-            tokenizer.memoized_encode_flat(FastR50kPretokenizer::new(buf), &mut out);
+    // ENCODE_DUMP=path writes the final pass's tokens as little-endian u32s,
+    // for byte-exact A/B comparison across encode-path changes.
+    let dump_path = std::env::var("ENCODE_DUMP").ok();
+    match tokenizer {
+        HfTokenizer::Bpe(mut tokenizer) => {
+            for pass in 0..passes {
+                out.clear();
+                let start = Instant::now();
+                if tokenizer_override.is_some() {
+                    let pretokens = tokenizer.pretokenizer_type().pretokenize(buf);
+                    tokenizer.memoized_encode_flat(pretokens, &mut out);
+                } else {
+                    tokenizer.memoized_encode_flat(FastR50kPretokenizer::new(buf), &mut out);
+                }
+                report_pass(pass, out.len(), size_gb, start);
+            }
+            let (sl, sc, ll, lc, lkb, al, ac) = tokenizer.cache_mem_stats();
+            eprintln!(
+                "cache: short {sl} entries (cap {sc}), long {ll} (cap {lc}, {lkb} key bytes), arena {al} tokens (cap {ac})"
+            );
         }
-        let total_tokens = out.len();
-        let elapsed = start.elapsed().as_secs_f64();
-        let throughput_gb = size_gb / elapsed;
-
-        eprintln!(
-            "pass {pass}: {total_tokens} tokens in {elapsed:.2}s — {throughput_gb:.2} GB/s ({:.0} MB/s)",
-            throughput_gb * 1000.0
-        );
+        HfTokenizer::SentencePiece(tokenizer) => {
+            // Trailing partial UTF-8 char (from the ENCODE_MB byte cap) is
+            // dropped; SP encoding takes str input.
+            let text = match std::str::from_utf8(buf) {
+                Ok(text) => text,
+                Err(e) => std::str::from_utf8(&buf[..e.valid_up_to()]).unwrap(),
+            };
+            let mut state = gigatoken_rs::EncodeState::new();
+            for pass in 0..passes {
+                out.clear();
+                let start = Instant::now();
+                let out_ref = &mut out;
+                tokenizer.encode_raw_cb(&mut state, text, &mut |tokens| {
+                    out_ref.extend(tokens.iter().map(|t| t.0))
+                });
+                report_pass(pass, out.len(), size_gb, start);
+            }
+            eprintln!("cache: {} units", state.cache_size());
+        }
     }
-    let (sl, sc, ll, lc, lkb, al, ac) = tokenizer.cache_mem_stats();
+    if let Some(path) = dump_path {
+        let bytes: Vec<u8> = out.iter().flat_map(|t| t.to_le_bytes()).collect();
+        std::fs::write(&path, bytes).expect("Could not write ENCODE_DUMP");
+        eprintln!("dumped {} tokens to {path}", out.len());
+    }
+}
+
+fn report_pass(pass: usize, total_tokens: usize, size_gb: f64, start: Instant) {
+    let elapsed = start.elapsed().as_secs_f64();
+    let throughput_gb = size_gb / elapsed;
     eprintln!(
-        "cache: short {sl} entries (cap {sc}), long {ll} (cap {lc}, {lkb} key bytes), arena {al} tokens (cap {ac})"
+        "pass {pass}: {total_tokens} tokens in {elapsed:.2}s — {throughput_gb:.2} GB/s ({:.0} MB/s)",
+        throughput_gb * 1000.0
     );
 }

--- a/src/bpe/sentencepiece.rs
+++ b/src/bpe/sentencepiece.rs
@@ -270,6 +270,17 @@ pub struct SentencePieceBPE {
     /// immediately before that byte inside any vocab piece, so no merge can
     /// span the boundary. Empty (all zeros) for non-split bytes.
     pub(crate) split_safe: Vec<[u64; 4]>,
+    /// Decompositions of the vocab pieces that can cross a `▁▁▁word` unit
+    /// boundary, as `(pre, post)` around one interior ▁ — e.g. gemma's
+    /// `>▁</` yields `(">", "</")`. Under `SpaceRuns` the scanner skips a
+    /// split exactly where such a piece occurs spanning the candidate
+    /// boundary (a merge result is always a contiguous vocab piece, so
+    /// every other boundary is provably safe). Set by
+    /// `finalize_speed_paths`; empty under `EveryMark`/`None`.
+    pub(crate) cross_pieces: Vec<(Box<[u8]>, Box<[u8]>)>,
+    /// Bitset over the byte just before a candidate boundary (the last byte
+    /// of some `cross_pieces` pre) for a one-load rejection in the scanner.
+    pub(crate) cross_prev: [u64; 4],
 }
 
 /// How many distinct punctuation bytes the unit splitter checks for.
@@ -404,13 +415,26 @@ impl SentencePieceBPE {
         self.added_matcher = (!self.added_tokens.is_empty()).then(|| {
             aho_corasick::AhoCorasick::builder()
                 .match_kind(aho_corasick::MatchKind::LeftmostLongest)
+                // The scan visits every input byte; a DFA's one lookup per
+                // byte beats the contiguous NFA noticeably when the added
+                // vocabulary is large (gemma-3 carries 6.4k added tokens,
+                // and the scan was ~23% of its encode profile). Prefix
+                // sharing (<unusedNNNN>…) keeps the table small.
+                .kind(Some(aho_corasick::AhoCorasickKind::DFA))
                 .build(self.added_tokens.iter().map(|t| t.content.as_bytes()))
                 .expect("added-token automaton")
         });
 
+        self.cross_pieces = Vec::new();
+        self.cross_prev = [0u64; 4];
         self.word_split = if self.metaspace.as_ref().is_some_and(|ms| ms.split) {
             WordSplit::EveryMark
-        } else if self.vocab_units_are_merge_safe() {
+        } else if let Some(cross) = self.unit_crossing_pieces() {
+            for (pre, _) in &cross {
+                let b = *pre.last().expect("interior ▁ always has a predecessor");
+                self.cross_prev[(b >> 6) as usize] |= 1 << (b & 63);
+            }
+            self.cross_pieces = cross;
             WordSplit::SpaceRuns
         } else {
             WordSplit::None
@@ -453,28 +477,66 @@ impl SentencePieceBPE {
         }
     }
 
-    /// Whether every vocab piece stays inside one `▁▁▁word`-shaped unit: no
-    /// piece may contain a ▁ that follows a non-▁ char. When this holds, no
-    /// merge can cross a unit boundary and per-unit BPE equals global BPE.
-    fn vocab_units_are_merge_safe(&self) -> bool {
-        self.vocab.iter().all(|piece| {
+    /// The vocab pieces that can cross a `▁▁▁word`-shaped unit boundary — a
+    /// unit starts at each ▁ following a non-▁ char, so a piece crosses
+    /// exactly when it contains such an interior ▁ — decomposed as
+    /// `(pre, post)` around that ▁. `Some(vec![])` means units are
+    /// unconditionally safe (per-unit BPE equals global BPE); a non-empty
+    /// list means safe with the scanner's occurrence guard; `None` means a
+    /// crossing piece is too complex for the guard's byte-compare (a ▁ or a
+    /// raw space inside `pre`/`post`, whose raw-mode text form varies) or
+    /// there are too many, so whole-chunk merging must stay.
+    fn unit_crossing_pieces(&self) -> Option<Vec<(Box<[u8]>, Box<[u8]>)>> {
+        // Beyond this the per-boundary guard stops being "a handful of
+        // memcmps on a rare prev byte" and whole-chunk merging is safer.
+        const MAX_CROSS_PIECES: usize = 32;
+        let mut out: Vec<(Box<[u8]>, Box<[u8]>)> = Vec::new();
+        for piece in &self.vocab {
             let Ok(s) = std::str::from_utf8(piece) else {
                 // Byte-fallback pieces are single bytes; they can't hold a ▁.
-                return true;
+                continue;
             };
             let mut prev_is_mark = true; // leading ▁s are fine
-            for c in s.chars() {
+            for (pos, c) in s.char_indices() {
                 if c == SENTENCEPIECE_SPACE {
                     if !prev_is_mark {
-                        return false;
+                        // Interior ▁: the piece spans from `pre`'s unit into
+                        // the one starting at this mark.
+                        let (pre, rest) = s.split_at(pos);
+                        let post = &rest[SP_MARK.len()..];
+                        if pre.contains(SENTENCEPIECE_SPACE)
+                            || post.contains(SENTENCEPIECE_SPACE)
+                            || pre.contains(' ')
+                            || post.contains(' ')
+                            || out.len() == MAX_CROSS_PIECES
+                        {
+                            return None;
+                        }
+                        out.push((pre.as_bytes().into(), post.as_bytes().into()));
                     }
                     prev_is_mark = true;
                 } else {
                     prev_is_mark = false;
                 }
             }
-            true
-        })
+        }
+        Some(out)
+    }
+
+    /// Does some crossing vocab piece occur spanning the candidate unit
+    /// boundary at `mark_pos` (mark of `width` bytes)? Only such an
+    /// occurrence can let a merge cross the boundary; everywhere else the
+    /// split is exact.
+    #[inline(always)]
+    fn piece_spans_boundary(&self, bytes: &[u8], mark_pos: usize, width: usize) -> bool {
+        let prev = bytes[mark_pos - 1];
+        if self.cross_prev[(prev >> 6) as usize] & (1 << (prev & 63)) == 0 {
+            return false;
+        }
+        let after = &bytes[mark_pos + width..];
+        self.cross_pieces
+            .iter()
+            .any(|(pre, post)| bytes[..mark_pos].ends_with(pre) && after.starts_with(post))
     }
 
     /// Raw-fast-path eligibility: the normalizer sequence must reduce to
@@ -944,9 +1006,14 @@ impl SentencePieceBPE {
                         continue;
                     };
                     // SpaceRuns: only a mark that doesn't extend a run
-                    // starts a unit.
+                    // starts a unit — and not where a crossing vocab piece
+                    // spans the boundary (`cross_prev` is all-zero when
+                    // there are none, so the guard is one load + test).
                     let boundary = every_mark || mark_pos != last_mark_end;
-                    if boundary && mark_pos != unit_start {
+                    if boundary
+                        && mark_pos != unit_start
+                        && !self.piece_spans_boundary(bytes, mark_pos, width)
+                    {
                         self.encode_unit(
                             state,
                             &bytes[unit_start..mark_pos],

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -368,6 +368,8 @@ fn build_sentencepiece(tj: &TokenizerJson) -> Result<SentencePieceBPE> {
         added_matcher: None,
         split_bytes: [0; crate::bpe::sentencepiece::NUM_SPLIT_BYTES],
         split_safe: Vec::new(),
+        cross_pieces: Vec::new(),
+        cross_prev: [0; 4],
     };
     model.norm_added_tokens = norm_added_tokens
         .into_iter()

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -163,6 +163,64 @@ def test_prepend_replace_normalizer_matches_hf():
     _assert_parity(hf_tok, gigatoken_tok, _MATRIX_TEXTS)
 
 
+def test_boundary_crossing_pieces_match_hf():
+    """gemma-3/4 style: Replace-only normalizer, Split-on-space
+    (MergedWithPrevious) pre-tokenizer, and vocab pieces that cross word-unit
+    boundaries (an interior ▁ like ">▁</", and a trailing ▁ like "p▁"). The
+    unit scanner must skip a split exactly where such a piece occurs, so
+    per-unit BPE stays identical to HF's whole-chunk merge."""
+    vocab = {
+        "<unk>": 0,
+        "<s>": 1,
+        **{f"<0x{b:02X}>": 2 + b for b in range(256)},
+        "▁": 258,
+        "<": 259,
+        ">": 260,
+        "/": 261,
+        "s": 262,
+        "p": 263,
+        "a": 264,
+        "</": 265,
+        ">▁": 266,
+        ">▁</": 267,
+        "p▁": 268,
+        "sp": 269,
+        "▁sp": 270,
+        "▁a": 271,
+    }
+    merges = [
+        ("<", "/"),
+        (">", "▁"),
+        (">▁", "</"),
+        ("p", "▁"),
+        ("s", "p"),
+        ("▁", "sp"),
+        ("▁", "a"),
+    ]
+    texts = [
+        "sp> </sp",  # >▁</ spans a boundary: split must be skipped
+        "a> </a",
+        "> </",
+        "sp> <sp",  # prev byte matches but post doesn't: split is safe
+        "a> a",
+        "sp sp",  # p▁ (empty post) spans every "p "-boundary
+        "sp a sp",
+        "p p p",
+        "sp>  </sp",  # double space: run extension, no crossing occurrence
+        "> </ > </",
+        "sp▁a",  # literal ▁ in the input acts as a mark too
+        "sp>▁</sp",
+        "a  a",
+        " sp",
+        "sp ",
+    ]
+    hf_tok = HFTokenizer(BPE(vocab, merges, unk_token="<unk>", fuse_unk=True, byte_fallback=True))
+    hf_tok.normalizer = normalizers.Replace(" ", "▁")
+    hf_tok.pre_tokenizer = pre_tokenizers.Split(" ", behavior="merged_with_previous")
+    gigatoken_tok = Tokenizer(hf_tok)
+    _assert_parity(hf_tok, gigatoken_tok, texts)
+
+
 def test_unsupported_normalizer_errors():
     """Unknown normalizers must fail at load, not silently diverge."""
     hf_tok = HFTokenizer(BPE(_VOCAB, _MERGES, unk_token="<unk>", fuse_unk=True, byte_fallback=True))


### PR DESCRIPTION
## Problem

`google/gemma-3-4b-it` encoded at 12 MB/s single-threaded and `google/gemma-4-E4B-it` at 1–2 MB/s — 10–100x slower than comparable SentencePiece configs (TinyLlama: ~250 MB/s warm), with the pretoken cache completely unused (`cache: 0 units`, warm passes no faster than cold).

**Root cause:** gemma's 262k vocab contains exactly one piece with an interior ▁ — `>▁</`, an HTML fragment. The all-or-nothing `vocab_units_are_merge_safe()` check saw it and demoted the whole tokenizer to `WordSplit::None`: no word-unit splitting, no memoization, one uncached ranked merge per chunk. gemma-4-E4B was hit hardest because it (unlike gemma-3) has no `"\n"`-run added tokens, so an entire document becomes a single merge chunk, and the whole-buffer merge degrades further with input size.

## Fix

A merge result is always a contiguous vocab piece, so a unit boundary is only unsafe where a crossing piece **actually occurs** spanning it:

- Collect crossing pieces at load as `(pre, post)` decompositions around their interior ▁ (for gemma: the single entry `(">", "</")`).
- In the `SpaceRuns` scanner, skip a split only when the byte before the mark hits a suspect-byte bitset (one load + test; all-zero for vocabs with no crossing pieces) **and** some piece byte-matches around the boundary. The fused unit stays cacheable and per-unit BPE remains exactly global BPE.
- Configs whose crossing pieces contain marks/spaces inside `pre`/`post` (ambiguous raw-mode byte form) fall back to `WordSplit::None` exactly as before.

Two supporting changes:

- The SP added-token automaton is now built as a DFA: gemma-3 carries 6.4k added tokens and the contiguous-NFA scan was ~23% of its post-fix profile; the DFA is a consistent ~5% end-to-end win and neutral for small added vocabs.
- `benches/encode_st.rs` now dispatches `byte_fallback` configs to the SP path like `benches/encode.rs` (they previously failed to load), and gains `ENCODE_DUMP=path` to write encoded ids for byte-exact A/B validation.

## Results

Single-threaded OWT, 200 MB (M4 Max), cold/warm:

| Tokenizer | Before | After |
|---|---|---|
| gemma-3-4b-it | 12 MB/s | 132 / 200 MB/s |
| gemma-4-E4B-it | 1–2 MB/s | 152 / 285 MB/s |
| TinyLlama | 175 / 256 MB/s | unchanged (interleaved A/B, 5 pairs) |

Multithreaded (`benches/encode.rs`, 500 MB): gemma-3 0.14 → **0.92 GB/s**, gemma-4-E4B 0.03 → **0.99 GB/s** — both now in line with the other SP tokenizers.

## Correctness

- Token ids are byte-identical to the old path on 20 MB of OWT for all three tokenizers. gemma-4's old path was a whole-buffer global merge (the exactness ground truth), and the sample contains 27 real `> </` sites with the `>▁</` token forming 56 times in both outputs — the guard's suppress path is exercised and exact.
- New `test_boundary_crossing_pieces_match_hf` pins HF parity for a synthetic gemma-style config with crossing pieces, including the empty-post case (a trailing-▁ piece), which must suppress every split after that word.
- Full suites green: `cargo test --release` (84+82) and pytest (129 passed).