### PR TITLE
Support the moonshotai Kimi tokenizer line

### DIFF
--- a/gigatoken/_load/hf.py
+++ b/gigatoken/_load/hf.py
@@ -54,6 +54,45 @@ def load_hf_tokenizer(pretrained_model_name_or_path: str) -> transformers.PreTra
     return cast("transformers.PreTrainedTokenizerBase", tokenizer)
 
 
+def try_load_kimi(source: str | os.PathLike[str]) -> "tuple[object, dict[str, int]] | None":
+    """Load a moonshotai Kimi-style tokenizer — `tiktoken.model` ranks plus
+    the special tokens of a sibling tokenizer_config.json declaring the
+    moonshot `TikTokenTokenizer` class (the K2/VL/Moonlight repos ship no
+    tokenizer.json; they all share one rank file and the Kimi pretokenizer
+    from their remote code). Accepts a Hub repo id, a directory, or a path
+    to the tiktoken.model itself. Returns `(BPETokenizer, special_tokens)`,
+    or None when `source` is not such a tokenizer."""
+    import json
+
+    from gigatoken.gigatoken_rs import BPETokenizer, hub_file
+
+    path = Path(cast("str | os.PathLike[str]", source))
+    if path.is_file() and path.name == "tiktoken.model":
+        model, config = path, path.parent / "tokenizer_config.json"
+    elif path.is_dir():
+        model, config = path / "tiktoken.model", path / "tokenizer_config.json"
+    elif isinstance(source, str) and looks_like_repo_id(source):
+        try:
+            model = hub_file(source, "tiktoken.model")
+            config = hub_file(source, "tokenizer_config.json")
+        except Exception:
+            return None
+    else:
+        return None
+    if not (model.is_file() and config.is_file()):
+        return None
+    config_json = json.loads(config.read_bytes())
+    if config_json.get("tokenizer_class") != "TikTokenTokenizer":
+        # A tiktoken rank file with some other remote-code tokenizer class:
+        # its pretokenizer regex is unknown, so don't guess.
+        return None
+    specials = {
+        str(t["content"]): int(i)
+        for i, t in (config_json.get("added_tokens_decoder") or {}).items()
+    }
+    return BPETokenizer.from_kimi(model, config), specials
+
+
 def to_tokenizer_json(source: TokenizerJsonSource) -> str | bytes:
     """Resolve `source` to the contents of a HuggingFace tokenizer.json.
 

--- a/gigatoken/_tokenizer.py
+++ b/gigatoken/_tokenizer.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
-from gigatoken._load.hf import capture_named_special_tokens, to_tokenizer_json
+from gigatoken._load.hf import capture_named_special_tokens, to_tokenizer_json, try_load_kimi
 from gigatoken._parallel import resolve_parallel
 from gigatoken.gigatoken_rs import BPETokenizer, PadTruncate, SentencePieceTokenizer, load_hf_json
 
@@ -68,7 +68,18 @@ class Tokenizer:
         elif isinstance(tokenizer, _BACKEND_TYPES):
             self._backend = tokenizer
         else:
-            data = to_tokenizer_json(tokenizer)
+            try:
+                data = to_tokenizer_json(tokenizer)
+            except Exception:
+                # No tokenizer.json: a moonshot-style repo (Kimi/Moonlight)
+                # carries its vocab in tiktoken.model instead.
+                loaded = (
+                    try_load_kimi(tokenizer) if isinstance(tokenizer, (str, os.PathLike)) else None
+                )
+                if loaded is None:
+                    raise
+                self._backend, self._tiktoken_specials = loaded
+                return
             self._backend = load_hf_json(data)
             self._hf_json = data
             if not isinstance(tokenizer, (str, os.PathLike)):

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -154,6 +154,11 @@ class BPETokenizer:
     @staticmethod
     def from_tiktoken(path: str | Path) -> "BPETokenizer": ...
     @staticmethod
+    def from_kimi(model_path: str | Path, config_path: str | Path) -> "BPETokenizer":
+        """Load a moonshotai Kimi-style tokenizer: `tiktoken.model` ranks
+        plus the special tokens from a tokenizer_config.json, with the Kimi
+        pretokenizer (the K2-family repos ship no tokenizer.json)."""
+    @staticmethod
     def from_hf(path: str | Path) -> "BPETokenizer": ...
     def __repr__(self) -> str: ...
 

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1357,6 +1357,7 @@ mod tests {
             PretokenizerType::DeepSeekV3,
             PretokenizerType::O200k,
             PretokenizerType::Nemotron,
+            PretokenizerType::Kimi,
         ];
         let input = "Hello, 世界! café 12345\r\ncan't  stop".as_bytes();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,17 @@ impl BPETokenizer {
             workers: WorkerPool::new(),
         })
     }
+    /// Load a moonshotai Kimi-style tokenizer: `tiktoken.model` ranks plus
+    /// the special tokens from a tokenizer_config.json, with the Kimi
+    /// pretokenizer (the K2-family repos ship no tokenizer.json).
+    #[staticmethod]
+    fn from_kimi(model_path: PathBuf, config_path: PathBuf) -> PyResult<Self> {
+        Ok(Self {
+            tokenizer: load_tokenizer::tiktoken::load_kimi(&model_path, &config_path)?,
+            workers: WorkerPool::new(),
+        })
+    }
+
     #[staticmethod]
     fn from_hf(path: PathBuf) -> PyResult<Self> {
         Ok(Self {

--- a/src/load_tokenizer/tiktoken.rs
+++ b/src/load_tokenizer/tiktoken.rs
@@ -1,9 +1,11 @@
 use crate::bpe::Tokenizer;
-use eyre::{Context, Result};
+use crate::pretokenize::PretokenizerType;
+use eyre::{Context, Result, ensure};
 use std::path::Path;
 
-pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
-    use crate::bpe::Tokenizer;
+/// The base64-per-line mergeable ranks of a .tiktoken/tiktoken.model file,
+/// in rank order (merges are reconstructed from this list).
+fn load_tiktoken_ranks(file_path: impl AsRef<Path>) -> Result<Vec<Vec<u8>>> {
     use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
     use base64::prelude::*;
     use std::io::Read;
@@ -11,21 +13,21 @@ pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
     std::fs::File::open(&file_path)
         .with_context(|| format!("Failed to read {}", file_path.as_ref().display()))?
         .read_to_string(&mut buf)?;
-
-    // Tiktoken vocabs contain a list of the vocab in order, meaning one needs to reconstruct the merges from this list.
-
-    let rank_vocab: Vec<Vec<u8>> = buf
-        .lines()
+    buf.lines()
         .enumerate()
         .map(|(i, line)| {
-            let (base64_token, id_str) = line.split_once(' ').unwrap();
-            let id = id_str.trim().parse::<u32>().unwrap();
-            assert_eq!(id, i as u32);
-            let token_bytes: Vec<u8> = BASE64_STANDARD.decode(base64_token).unwrap();
-            token_bytes
+            let (base64_token, id_str) = line
+                .split_once(' ')
+                .ok_or_else(|| eyre::eyre!("line {i} has no rank field"))?;
+            let id = id_str.trim().parse::<u32>()?;
+            ensure!(id == i as u32, "rank {id} at line {i}: ranks must be dense");
+            Ok(BASE64_STANDARD.decode(base64_token)?)
         })
-        .collect();
+        .collect()
+}
 
+pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
+    let rank_vocab = load_tiktoken_ranks(file_path)?;
     let n_ranks = rank_vocab.len() as u32;
     let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
     // Tiktoken vocab files carry no special tokens; GPT-2-family vocabs
@@ -33,5 +35,52 @@ pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
     // ranks. Register it so tiktoken- and tokenizer.json-loaded tokenizers
     // encode and decode identically.
     tokenizer.add_special_token(b"<|endoftext|>".to_vec(), n_ranks.into());
+    Ok(tokenizer)
+}
+
+/// The fields of a HuggingFace tokenizer_config.json a tiktoken.model repo
+/// needs: the special tokens (there is no tokenizer.json to carry them).
+#[derive(serde::Deserialize)]
+struct TokenizerConfigJson {
+    #[serde(default)]
+    added_tokens_decoder: std::collections::BTreeMap<String, AddedTokenJson>,
+}
+
+#[derive(serde::Deserialize)]
+struct AddedTokenJson {
+    content: String,
+}
+
+/// Load a moonshotai Kimi-style tokenizer: a `tiktoken.model` rank file
+/// plus a `tokenizer_config.json` whose `added_tokens_decoder` carries the
+/// special tokens (the repos ship no tokenizer.json; the pretokenizer
+/// regex lives in their `tokenization_kimi.py` and is the [`Kimi`
+/// scheme](PretokenizerType::Kimi)). Every Kimi/Moonlight repo shares one
+/// rank file and differs only in this special-token map.
+pub fn load_kimi(
+    model_path: impl AsRef<Path>,
+    config_path: impl AsRef<Path>,
+) -> Result<Tokenizer> {
+    let rank_vocab = load_tiktoken_ranks(model_path)?;
+    let n_ranks = rank_vocab.len() as u32;
+    let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
+    tokenizer.set_pretokenizer_type(PretokenizerType::Kimi);
+    let config_path = config_path.as_ref();
+    let config: TokenizerConfigJson = sonic_rs::from_slice(
+        &std::fs::read(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?,
+    )
+    .map_err(|e| eyre::eyre!("Failed to parse {}: {e}", config_path.display()))?;
+    for (id, token) in &config.added_tokens_decoder {
+        let id = id.parse::<u32>().with_context(|| {
+            format!("added_tokens_decoder id {id:?} in {}", config_path.display())
+        })?;
+        ensure!(
+            id >= n_ranks,
+            "added token {:?} (id {id}) overlaps the {n_ranks} mergeable ranks",
+            token.content
+        );
+        tokenizer.add_special_token(token.content.clone().into_bytes(), id.into());
+    }
     Ok(tokenizer)
 }

--- a/src/pretokenize/fast/kimi.rs
+++ b/src/pretokenize/fast/kimi.rs
@@ -1,32 +1,35 @@
-//! Fast pretokenizer for the o200k_base regex (GPT-4o, gpt-oss):
-//! `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+//! Fast pretokenizer for the Kimi regex (moonshotai Kimi-K2 family, from
+//! `tokenization_kimi.py`):
+//! `[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+`
 //!
-//! See `o200k_family` for the shared scalar walker and mask-scanner
-//! boundary algebra (`CONTRACTIONS = true`, `DIGITS3 = true`).
+//! The o200k scheme with a leading `[\p{Han}]+` alternative, Han excluded
+//! from the letter brackets, and no `/` in the absorbed punct tail. See
+//! `o200k_family` (`CONTRACTIONS = true`, `DIGITS3 = true`,
+//! `SLASH = false`, `HAN = true`).
 
 use super::mask::{MaskScheme, MaskState};
 use super::o200k_family;
 use crate::pretokenize::Pretoken;
 
-pub(crate) struct O200kScheme;
+pub(crate) struct KimiScheme;
 
-impl MaskScheme for O200kScheme {
+impl MaskScheme for KimiScheme {
     #[inline(always)]
     fn advance(bytes: &[u8], pos: usize) -> usize {
-        o200k_family::advance_pos::<true, true, true, false>(bytes, pos)
+        o200k_family::advance_pos::<true, true, false, true>(bytes, pos)
     }
 
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        o200k_family::batch_masks::<true, true, true, false>(bytes, scan)
+        o200k_family::batch_masks::<true, true, false, true>(bytes, scan)
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { o200k_family::batch_masks_x86::<AVX512, true, true, true, false>(bytes, scan) }
+        unsafe { o200k_family::batch_masks_x86::<AVX512, true, true, false, true>(bytes, scan) }
     }
 }
 
@@ -34,12 +37,12 @@ impl MaskScheme for O200kScheme {
 /// runtime), iteration runs the shared o200k-family mask scanner (see
 /// `o200k_family::batch_masks`); elsewhere every token takes the scalar
 /// `advance_pos`.
-pub struct FastO200kPretokenizer<'a> {
+pub struct FastKimiPretokenizer<'a> {
     bytes: &'a [u8],
     state: MaskState,
 }
 
-impl<'a> FastO200kPretokenizer<'a> {
+impl<'a> FastKimiPretokenizer<'a> {
     #[inline]
     pub fn new(bytes: &'a [u8]) -> Self {
         Self::with_pos(bytes, 0)
@@ -58,36 +61,37 @@ impl<'a> FastO200kPretokenizer<'a> {
     }
 }
 
-impl<'a> Iterator for FastO200kPretokenizer<'a> {
+impl<'a> Iterator for FastKimiPretokenizer<'a> {
     type Item = Pretoken<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Pretoken<'a>> {
-        let (start, end) = self.state.next_span::<O200kScheme>(self.bytes)?;
+        let (start, end) = self.state.next_span::<KimiScheme>(self.bytes)?;
         Some(Pretoken(&self.bytes[start..end]))
     }
 }
 
-super::impl_mask_pretoken_spans!(FastO200kPretokenizer, O200kScheme);
+super::impl_mask_pretoken_spans!(FastKimiPretokenizer, KimiScheme);
 
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
     use std::io::Read;
 
-    /// The o200k pattern verbatim — no possessive quantifiers, so it runs
-    /// directly under fancy-regex.
-    const O200K_REF_REGEX: &str = r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+";
+    /// The Kimi pattern verbatim (from `tokenization_kimi.py`; only greedy
+    /// quantifiers, so it runs directly under fancy-regex, which shares
+    /// regex-syntax's `&&` class intersection).
+    const KIMI_REF_REGEX: &str = r"[\p{Han}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+";
 
     fn regex_tokens(s: &str) -> Vec<String> {
-        let re = fancy_regex::Regex::new(O200K_REF_REGEX).unwrap();
+        let re = fancy_regex::Regex::new(KIMI_REF_REGEX).unwrap();
         re.find_iter(s)
             .map(|m| m.unwrap().as_str().to_string())
             .collect()
     }
 
     fn fast_tokens(s: &str) -> Vec<String> {
-        FastO200kPretokenizer::new(s.as_bytes())
+        FastKimiPretokenizer::new(s.as_bytes())
             .map(|t| String::from_utf8_lossy(t.0).into_owned())
             .collect()
     }
@@ -105,74 +109,50 @@ pub(crate) mod tests {
         buf
     }
 
-    pub(crate) const SMALL_CASES: &[&str] = &[
-        "hello",
-        "Hello",
-        "HELLO",
-        "HeLLo",
-        "camelCase",
-        "PascalCase",
-        "HTTPResponse",
-        "HTTPresponse",
-        "parseHTMLDocument",
-        "XMLHttpRequest",
-        "aB",
-        "aBc",
-        "ABc",
-        "ABCdef GHIjkl",
-        " hello",
-        " Hello World",
-        "hello world",
-        "  hello",
-        "\thello",
-        "\tHello",
-        "\nhello",
-        "\n\nHello",
-        "!hello",
-        "!Hello",
-        "!!hello",
-        "?!x",
-        "don't",
-        "DON'T",
-        "Don'T",
-        "don'ts",
-        "can'ts more",
-        "they'LL go",
-        "it'S he'Ll",
-        "we'Ve THEY'RE",
-        "x'll'd",
-        "don't's",
-        "o'clock",
-        "don'x",
-        "x'lm",
-        "x'm'm",
-        "'sound",
-        "'Sound",
-        "'lx",
-        "'hello",
-        " 'hello",
-        " 's",
-        " 'S",
-        "x'0",
-        "3's",
-        "3'ts",
-        "123",
-        "1234",
-        "1234567",
-        " 123",
-        "  123",
-        "3rd",
-        "abc1234def",
-        "hello, world!",
-        "hi!\n\ndef",
-        "hi !!\n\ndef",
-        " !!!",
-        "a-b",
-        "a - b",
-        "...",
-        "a/b",
-        "a//b",
-        "http://x.com/path",
+    /// Han-specific cases on top of the shared o200k list: run splits at
+    /// script edges, the `[\r\n]*`-only tail (no `/` absorption), Han
+    /// numerals inside digit groups, and Han symbols inside punct runs.
+    pub(crate) const HAN_CASES: &[&str] = &[
+        "中文",
+        "中文模型",
+        " 中文",
+        "  中文",
+        "\t中文",
+        "\n中文",
+        "!中文",
+        "中English文",
+        "abc中文def",
+        "ABC中文",
+        "中文ABC",
+        "中'se",
+        "中's",
+        "中'S x",
+        "中文's",
+        "日本語のテキスト漢字かな",
+        "漢字とひらがな",
+        "中。文",
+        "中，文！",
+        "中文123",
+        "123中文",
+        "1〇2",
+        "〇〇",
+        "中〇文",
+        "1〇〇〇〇",
+        "1234〇",
+        " 〇",
+        "〇1",
+        "⼀⼁⼂",
+        "!⼀x",
+        " ⼀",
+        "中⼀文",
+        "a⼀b",
+        "々中",
+        "中々",
+        "〆切",
+        "㐀㿿",
+        "𠀀𠀁",
+        "中\u{16FF0}文",
+        "!\u{16FF0}",
         ".\n//x",
         "!\n/",
         "!\n/\n/x",
@@ -180,79 +160,30 @@ pub(crate) mod tests {
         "//\n/",
         "x/\n",
         "x\n/",
-        "hello\n",
-        "hello \n",
-        "hello \nx",
-        "hello\n x",
-        "hello  \n\n  ",
-        "x \n\n ",
-        "x  ",
-        "x \t",
-        "  \n  hello",
-        "\r\nhello",
-        "a\r\n",
-        "a\r\n ",
-        "a\n \n",
-        "a \n \t",
-        "\n\n",
-        "\n\n\t",
-        "   ",
-        " ",
-        "",
-        "café",
-        "Café",
-        "CAFÉ",
-        "cafÉ",
-        " café",
-        "\u{a0}word",
-        "voilà ¡hola!",
-        "ΑΒΓδε",
-        "αβΓΔ",
-        "Привет Мир",
-        "ПРИВЕТ мир",
-        "ẞßẞ",
-        "ǅungla ǄUNGLA ǆungla",
-        "١٢٣٤٥",
-        "1٢3x",
-        "١٢٣٤٥٦٧",
-        "tab\tsep\tvals",
-        "\x0bword",
-        "a\u{2028}b",
-        "a\u{2028}\n",
-        "price: $5.99!",
-        "'ſ",
-        "x'ſ fine",
-        "日本語のテキスト",
-        " 日本語",
-        "日本語ABC",
-        "abc日本語Def",
-        "e\u{301}f",
-        "cafe\u{301} de\u{301}composed",
-        "\u{301}leading mark",
-        "\u{301}\u{301}two marks",
-        " \u{301}abc",
-        "\t\u{301}abc",
-        "!\u{301}",
-        "!\u{301}!",
-        "!!\u{301}x",
-        "!!\u{301}X",
-        "1\u{301}2",
-        "'\u{301}s",
-        "A\u{301}B",
-        "a\u{301}B",
-        "x\u{301}'s",
-        "деВНАгарІ",
-        "देवनागरी में परीक्षण",
-        "עִבְרִית נִקּוּד",
-        "الْعَرَبِيَّة",
-        "a\u{20dd}b",
-        " \u{20dd}",
-        "\u{200b}\u{301}x",
+        "}\n///doc",
+        "*/\n/**",
+        "`\n//! bindings",
+        "path/to/file",
+        "http://x.com/path",
+        "中\n文",
+        "中\r\n文",
+        "中 文",
+        "中  文",
+        "中\n\n文",
+        "。\n中",
+        "中。\n\n/x",
     ];
 
     #[test]
-    fn o200k_small_cases() {
-        for case in SMALL_CASES {
+    fn kimi_small_cases() {
+        for case in crate::pretokenize::fast::o200k::tests::SMALL_CASES {
+            assert_eq!(
+                fast_tokens(case),
+                regex_tokens(case),
+                "Mismatch on case {case:?}"
+            );
+        }
+        for case in HAN_CASES {
             assert_eq!(
                 fast_tokens(case),
                 regex_tokens(case),
@@ -261,23 +192,26 @@ pub(crate) mod tests {
         }
     }
 
-    /// Random codepoint soup drawn from classes the scheme distinguishes,
-    /// compared against the reference regex.
+    /// Random codepoint soup drawn from classes the scheme distinguishes
+    /// (including the Han classes), compared against the reference regex.
     #[test]
-    fn o200k_matches_regex_random() {
+    fn kimi_matches_regex_random() {
         use rand::prelude::*;
         let pools: &[&[char]] = &[
-            &['a', 'z', 'é', 'ß', 'ж', 'ا', '한', '日'],      // lower/caseless
+            &['a', 'z', 'é', 'ß', 'ж', 'ا', '한', 'ひ', 'カ'],   // lower/caseless (non-Han)
             &['A', 'Z', 'É', 'Ж', 'Ǆ', 'ǅ'],                  // upper/title
-            &['1', '9', '٢', '½', 'Ⅷ', '๕'],                // numbers
+            &['1', '9', '٢', '½', 'Ⅷ', '๕'],                // numbers (non-Han)
             &[' ', '\t', '\n', '\r', '\u{a0}', '\u{2028}'],   // whitespace
             &['\u{301}', '\u{5bf}', '\u{93b}', '\u{20dd}'],   // marks
             &['.', ',', '!', '$', '\'', '«', '¡', '€', '☃', '/'], // punct/symbols
             &['\u{0}', '\u{ad}', '\u{200b}', '\u{e0001}'],    // other (C*)
             &['s', 't', 'm', 'd', 'l', 'v', 'r', 'e', 'S', 'T', 'L'], // suffix letters
+            &['中', '文', '日', '本', '語', '々', '〆', '㐀', '𠀀'], // Han letters
+            &['〇', '〡', '〢', '㆒'],                          // Han numerals (Nl)
+            &['⼀', '⼁', '⺀', '\u{16FF0}'],                   // Han symbols/marks (So/Mc)
         ];
-        let mut rng = StdRng::seed_from_u64(0x93E3_5EED);
-        for round in 0..3000 {
+        let mut rng = StdRng::seed_from_u64(0x93E3_5EEC);
+        for round in 0..6000 {
             let len = rng.random_range(1..40);
             let s: String = (0..len)
                 .map(|_| {
@@ -294,17 +228,17 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn o200k_matches_regex_owt() {
+    fn kimi_matches_regex_owt() {
         const SIZE: usize = 5_000_000;
         let input = load_owt_prefix(SIZE);
         let text = std::str::from_utf8(&input).unwrap();
         eprintln!(
-            "Testing o200k fast pretokenizer vs regex on {:.1} MB of OWT",
+            "Testing kimi fast pretokenizer vs regex on {:.1} MB of OWT",
             input.len() as f64 / 1e6
         );
 
-        let re = fancy_regex::Regex::new(O200K_REF_REGEX).unwrap();
-        let mut fast_iter = FastO200kPretokenizer::new(&input);
+        let re = fancy_regex::Regex::new(KIMI_REF_REGEX).unwrap();
+        let mut fast_iter = FastKimiPretokenizer::new(&input);
         let mut re_iter = re.find_iter(text);
         let mut token_idx: usize = 0;
         let mut recent: Vec<(String, String)> = Vec::new();

--- a/src/pretokenize/fast/mod.rs
+++ b/src/pretokenize/fast/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod o200k_family;
 
 pub mod cl100k;
 pub mod deepseek_v3;
+pub mod kimi;
 pub mod nemotron;
 pub mod o200k;
 pub mod olmo3;
@@ -21,6 +22,7 @@ pub mod r50k;
 
 pub use cl100k::FastCl100kPretokenizer;
 pub use deepseek_v3::FastDeepSeekV3Pretokenizer;
+pub use kimi::FastKimiPretokenizer;
 pub use nemotron::FastNemotronPretokenizer;
 pub use o200k::FastO200kPretokenizer;
 pub use olmo3::FastOlmo3Pretokenizer;

--- a/src/pretokenize/fast/nemotron.rs
+++ b/src/pretokenize/fast/nemotron.rs
@@ -14,20 +14,20 @@ pub(crate) struct NemotronScheme;
 impl MaskScheme for NemotronScheme {
     #[inline(always)]
     fn advance(bytes: &[u8], pos: usize) -> usize {
-        o200k_family::advance_pos::<false, false>(bytes, pos)
+        o200k_family::advance_pos::<false, false, true, false>(bytes, pos)
     }
 
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn batch_masks(bytes: &[u8], scan: usize) -> (u64, u64) {
-        o200k_family::batch_masks::<false, false>(bytes, scan)
+        o200k_family::batch_masks::<false, false, true, false>(bytes, scan)
     }
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn batch_masks_x86<const AVX512: bool>(bytes: &[u8], scan: usize) -> (u64, u64) {
         // SAFETY: the caller detected the tier (trait contract).
-        unsafe { o200k_family::batch_masks_x86::<AVX512, false, false>(bytes, scan) }
+        unsafe { o200k_family::batch_masks_x86::<AVX512, false, false, true, false>(bytes, scan) }
     }
 }
 

--- a/src/pretokenize/fast/o200k_family.rs
+++ b/src/pretokenize/fast/o200k_family.rs
@@ -1,13 +1,23 @@
 //! Shared implementation for the o200k regex family: o200k_base (GPT-4o,
-//! gpt-oss) and the Nemotron-3 variant. Their patterns share the shape
+//! gpt-oss), the Nemotron-3 variant, and the Kimi (moonshotai K2) variant.
+//! Their patterns share the shape
 //!
-//! `[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+SUF?|
+//! `HAN-RUN?|
+//!  [^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+SUF?|
 //!  [^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*SUF?|
-//!  \p{N}{1,3} or \p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+`
+//!  \p{N}{1,3} or \p{N}| ?[^\s\p{L}\p{N}]+TAIL|\s*[\r\n]+|\s+(?!\S)|\s+`
 //!
-//! where `SUF = (?i:'s|'t|'re|'ve|'m|'ll|'d)` exists only in o200k
-//! (`CONTRACTIONS`), and the digit group is `\p{N}{1,3}` for o200k vs
-//! `\p{N}` for Nemotron (`DIGITS3`).
+//! where `SUF = (?i:'s|'t|'re|'ve|'m|'ll|'d)` exists in o200k and Kimi
+//! (`CONTRACTIONS`), the digit group is `\p{N}{1,3}` for o200k/Kimi vs
+//! `\p{N}` for Nemotron (`DIGITS3`), the absorbed punct tail `TAIL` is
+//! `[\r\n/]*` for o200k/Nemotron vs `[\r\n]*` for Kimi (`SLASH`), and Kimi
+//! alone (`HAN`) prepends a `[\p{Han}]+` alternative while intersecting
+//! both letter brackets with `[^\p{Han}]` — Han chars form their own runs
+//! and never join letter runs, though a Han numeral (Nl) still counts
+//! toward a `\p{N}{1,3}` group entered on a non-Han digit and a Han symbol
+//! (So/Mc) still continues a `[^\s\p{L}\p{N}]+` punct run (the Han
+//! alternative only wins where a token starts; see
+//! [`crate::pretokenize::unicode::KimiCharClass`]).
 //!
 //! Differences from the cl100k family:
 //! - Letter runs are case-structured. Under leftmost-greedy backtracking
@@ -41,17 +51,30 @@
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 use super::mask::{self, AsciiMasks};
 use super::{decode_cp, is_ascii_ws, is_digit, is_letter, scan_numbers_max3};
-use crate::pretokenize::unicode::{O200kCharClass, o200k_class_of};
+use crate::pretokenize::unicode::{O200kCharClass, kimi_class_of, o200k_class_of};
 
 #[inline(always)]
 fn is_upper_ascii(b: u8) -> bool {
     b.wrapping_sub(b'A') < 26
 }
 
-/// Is this byte in the `[\r\n/]` tail class?
+/// Is this byte in the absorbed-tail class (`[\r\n/]` or `[\r\n]`)?
 #[inline(always)]
-fn is_tail_byte(b: u8) -> bool {
-    matches!(b, b'\r' | b'\n' | b'/')
+fn is_tail_byte<const SLASH: bool>(b: u8) -> bool {
+    b == b'\r' || b == b'\n' || (SLASH && b == b'/')
+}
+
+/// Classify `cp` for the scheme: its effective o200k class plus whether it
+/// is a `[\p{Han}]+` run member (always false off the Kimi scheme; one
+/// table load either way).
+#[inline(always)]
+fn family_class_of<const HAN: bool>(cp: u32) -> (O200kCharClass, bool) {
+    if HAN {
+        let k = kimi_class_of(cp);
+        (k.base(), k.is_han())
+    } else {
+        (o200k_class_of(cp), false)
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -82,20 +105,21 @@ fn ascii_letter_state(b: u8) -> CaseState {
     }
 }
 
-/// If the char at `pos` is a letter-run member (`\p{L}` or `\p{M}`),
-/// return (offset past it, initial scan state).
+/// If the char at `pos` is a letter-run member (`\p{L}` or `\p{M}`, minus
+/// Han under the Kimi scheme), return (offset past it, initial scan state).
 #[inline(always)]
-fn letter_run_first(bytes: &[u8], pos: usize) -> Option<(usize, CaseState)> {
+fn letter_run_first<const HAN: bool>(bytes: &[u8], pos: usize) -> Option<(usize, CaseState)> {
     let &b = bytes.get(pos)?;
     if is_letter(b) {
         return Some((pos + 1, ascii_letter_state(b)));
     }
     if b >= 0x80 {
         let (cp, l) = unsafe { decode_cp(bytes, pos) };
-        match o200k_class_of(cp) {
-            O200kCharClass::Upper => return Some((pos + l, CaseState::U { last_cl_end: 0 })),
-            O200kCharClass::Lower => return Some((pos + l, CaseState::L)),
-            O200kCharClass::Caseless | O200kCharClass::Mark => {
+        match family_class_of::<HAN>(cp) {
+            (_, true) => {}
+            (O200kCharClass::Upper, _) => return Some((pos + l, CaseState::U { last_cl_end: 0 })),
+            (O200kCharClass::Lower, _) => return Some((pos + l, CaseState::L)),
+            (O200kCharClass::Caseless | O200kCharClass::Mark, _) => {
                 return Some((pos + l, CaseState::U { last_cl_end: pos + l }));
             }
             _ => {}
@@ -113,7 +137,7 @@ fn letter_run_first(bytes: &[u8], pos: usize) -> Option<(usize, CaseState)> {
 /// (which the next `advance` then consumes whole): "AxxB" -> `Axx|B`
 /// for caseless x, "HTTPResponse" and "Z\u{5BF}\u{416}dz" one token.
 #[inline(always)]
-fn scan_case_run(bytes: &[u8], mut pos: usize, mut st: CaseState) -> usize {
+fn scan_case_run<const HAN: bool>(bytes: &[u8], mut pos: usize, mut st: CaseState) -> usize {
     let len = bytes.len();
     loop {
         while pos < len {
@@ -132,18 +156,19 @@ fn scan_case_run(bytes: &[u8], mut pos: usize, mut st: CaseState) -> usize {
         }
         if pos < len && unsafe { *bytes.get_unchecked(pos) } >= 0x80 {
             let (cp, l) = unsafe { decode_cp(bytes, pos) };
-            match o200k_class_of(cp) {
-                O200kCharClass::Upper => {
+            match family_class_of::<HAN>(cp) {
+                (_, true) => break,
+                (O200kCharClass::Upper, _) => {
                     if matches!(st, CaseState::L) {
                         return pos;
                     }
                     pos += l;
                 }
-                O200kCharClass::Lower => {
+                (O200kCharClass::Lower, _) => {
                     st = CaseState::L;
                     pos += l;
                 }
-                O200kCharClass::Caseless | O200kCharClass::Mark => {
+                (O200kCharClass::Caseless | O200kCharClass::Mark, _) => {
                     pos += l;
                     if let CaseState::U { ref mut last_cl_end } = st {
                         *last_cl_end = pos;
@@ -183,9 +208,10 @@ fn try_suffix<const CONTRACTIONS: bool>(bytes: &[u8], end: usize) -> usize {
 }
 
 /// `[^\s\p{L}\p{N}]+` from `pos` (punctuation, symbols, marks, controls —
-/// everything except letters, numbers, and whitespace).
+/// everything except letters, numbers, and whitespace; a Han symbol's
+/// effective class is Other, so it continues the run under Kimi too).
 #[inline(always)]
-fn scan_punct_from(bytes: &[u8], pos: usize) -> usize {
+fn scan_punct_from<const HAN: bool>(bytes: &[u8], pos: usize) -> usize {
     let len = bytes.len();
     let mut p = pos;
     loop {
@@ -202,7 +228,7 @@ fn scan_punct_from(bytes: &[u8], pos: usize) -> usize {
         if p < len {
             let (cp, l) = unsafe { decode_cp(bytes, p) };
             if matches!(
-                o200k_class_of(cp),
+                family_class_of::<HAN>(cp).0,
                 O200kCharClass::Other | O200kCharClass::Mark
             ) {
                 p += l;
@@ -213,11 +239,29 @@ fn scan_punct_from(bytes: &[u8], pos: usize) -> usize {
     }
 }
 
-/// `[\r\n/]*`: the tail absorbed after a punctuation run.
+/// The `[\r\n/]*` (or Kimi `[\r\n]*`) tail absorbed after a punct run.
 #[inline(always)]
-fn scan_tail(bytes: &[u8], mut pos: usize) -> usize {
-    while pos < bytes.len() && is_tail_byte(unsafe { *bytes.get_unchecked(pos) }) {
+fn scan_tail<const SLASH: bool>(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && is_tail_byte::<SLASH>(unsafe { *bytes.get_unchecked(pos) }) {
         pos += 1;
+    }
+    pos
+}
+
+/// `[\p{Han}]+` from `pos` (chars of any Han class — letters, numerals,
+/// symbols; the leading alternative consumes the maximal Han run).
+#[inline(always)]
+fn scan_han_run(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() {
+        let b = unsafe { *bytes.get_unchecked(pos) };
+        if b < 0x80 {
+            return pos;
+        }
+        let (cp, l) = unsafe { decode_cp(bytes, pos) };
+        if !kimi_class_of(cp).is_han() {
+            return pos;
+        }
+        pos += l;
     }
     pos
 }
@@ -277,7 +321,12 @@ fn digit_token_end<const DIGITS3: bool>(bytes: &[u8], first_end: usize) -> usize
 /// Advance past one token starting at `pos`. Returns the new position.
 /// `pos` must be < `bytes.len()`.
 #[inline(always)]
-pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
+pub(crate) fn advance_pos<
+    const CONTRACTIONS: bool,
+    const DIGITS3: bool,
+    const SLASH: bool,
+    const HAN: bool,
+>(
     bytes: &[u8],
     pos: usize,
 ) -> usize {
@@ -285,7 +334,7 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
 
     // Hot path 1: ASCII letter run (empty prefix)
     if is_letter(b0) {
-        let e = scan_case_run(bytes, pos + 1, ascii_letter_state(b0));
+        let e = scan_case_run::<HAN>(bytes, pos + 1, ascii_letter_state(b0));
         return try_suffix::<CONTRACTIONS>(bytes, e);
     }
 
@@ -295,7 +344,7 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
             return pos + 1; // trailing lone space (`\s+(?!\S)` at EOS)
         };
         if is_letter(b1) {
-            let e = scan_case_run(bytes, pos + 2, ascii_letter_state(b1));
+            let e = scan_case_run::<HAN>(bytes, pos + 2, ascii_letter_state(b1));
             return try_suffix::<CONTRACTIONS>(bytes, e);
         }
         if b1 < 0x80 {
@@ -305,27 +354,35 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
             if is_ascii_ws(b1) {
                 return ws_token_end(bytes, pos);
             }
-            // ` ?[^\s\p{L}\p{N}]+[\r\n/]*`
-            let p = scan_punct_from(bytes, pos + 2);
-            return scan_tail(bytes, p);
+            // ` ?[^\s\p{L}\p{N}]+` + tail
+            let p = scan_punct_from::<HAN>(bytes, pos + 2);
+            return scan_tail::<SLASH>(bytes, p);
         }
         let (cp, l) = unsafe { decode_cp(bytes, pos + 1) };
         let p1 = pos + 1 + l;
-        return match o200k_class_of(cp) {
-            O200kCharClass::Upper => try_suffix::<CONTRACTIONS>(
+        return match family_class_of::<HAN>(cp) {
+            // A Han letter can neither join a letter run nor (being \p{L})
+            // extend ` ?[^\s\p{L}\p{N}]+`: the space is a lone `\s+` token
+            // and the Han run starts after it. (Han symbols fall to the
+            // Other arm — they are ordinary punct-run members here — and
+            // Han numerals to the Number arm.)
+            (O200kCharClass::Caseless, true) => pos + 1,
+            (O200kCharClass::Upper, _) => try_suffix::<CONTRACTIONS>(
                 bytes,
-                scan_case_run(bytes, p1, CaseState::U { last_cl_end: 0 }),
+                scan_case_run::<HAN>(bytes, p1, CaseState::U { last_cl_end: 0 }),
             ),
-            O200kCharClass::Lower => {
-                try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, p1, CaseState::L))
+            (O200kCharClass::Lower, _) => {
+                try_suffix::<CONTRACTIONS>(bytes, scan_case_run::<HAN>(bytes, p1, CaseState::L))
             }
-            O200kCharClass::Caseless | O200kCharClass::Mark => try_suffix::<CONTRACTIONS>(
+            (O200kCharClass::Caseless | O200kCharClass::Mark, _) => try_suffix::<CONTRACTIONS>(
                 bytes,
-                scan_case_run(bytes, p1, CaseState::U { last_cl_end: p1 }),
+                scan_case_run::<HAN>(bytes, p1, CaseState::U { last_cl_end: p1 }),
             ),
-            O200kCharClass::Whitespace => ws_token_end(bytes, pos),
-            O200kCharClass::Number => pos + 1,
-            O200kCharClass::Other => scan_tail(bytes, scan_punct_from(bytes, p1)),
+            (O200kCharClass::Whitespace, _) => ws_token_end(bytes, pos),
+            (O200kCharClass::Number, _) => pos + 1,
+            (O200kCharClass::Other, _) => {
+                scan_tail::<SLASH>(bytes, scan_punct_from::<HAN>(bytes, p1))
+            }
         };
     }
 
@@ -333,28 +390,34 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
     if b0 >= 0x80 {
         let (cp, l) = unsafe { decode_cp(bytes, pos) };
         let p0 = pos + l;
-        return match o200k_class_of(cp) {
+        let (class, han) = family_class_of::<HAN>(cp);
+        // `[\p{Han}]+` is the leading alternative: any Han char (whatever
+        // its base class) starting a token starts a Han run.
+        if HAN && han {
+            return scan_han_run(bytes, p0);
+        }
+        return match class {
             O200kCharClass::Upper => try_suffix::<CONTRACTIONS>(
                 bytes,
-                scan_case_run(bytes, p0, CaseState::U { last_cl_end: 0 }),
+                scan_case_run::<HAN>(bytes, p0, CaseState::U { last_cl_end: 0 }),
             ),
             O200kCharClass::Lower => {
-                try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, p0, CaseState::L))
+                try_suffix::<CONTRACTIONS>(bytes, scan_case_run::<HAN>(bytes, p0, CaseState::L))
             }
             O200kCharClass::Caseless | O200kCharClass::Mark => try_suffix::<CONTRACTIONS>(
                 bytes,
-                scan_case_run(bytes, p0, CaseState::U { last_cl_end: p0 }),
+                scan_case_run::<HAN>(bytes, p0, CaseState::U { last_cl_end: p0 }),
             ),
             O200kCharClass::Number => digit_token_end::<DIGITS3>(bytes, p0),
             // Any non-letter/number char except \r\n may prefix a run
             class => {
-                if let Some((e, st)) = letter_run_first(bytes, p0) {
-                    return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+                if let Some((e, st)) = letter_run_first::<HAN>(bytes, p0) {
+                    return try_suffix::<CONTRACTIONS>(bytes, scan_case_run::<HAN>(bytes, e, st));
                 }
                 if class == O200kCharClass::Whitespace {
                     ws_token_end(bytes, pos)
                 } else {
-                    scan_tail(bytes, scan_punct_from(bytes, p0))
+                    scan_tail::<SLASH>(bytes, scan_punct_from::<HAN>(bytes, p0))
                 }
             }
         };
@@ -372,8 +435,8 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
 
     // Other ASCII whitespace (\t, \x0b, \x0c) may prefix a letter run
     if is_ascii_ws(b0) {
-        if let Some((e, st)) = letter_run_first(bytes, pos + 1) {
-            return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+        if let Some((e, st)) = letter_run_first::<HAN>(bytes, pos + 1) {
+            return try_suffix::<CONTRACTIONS>(bytes, scan_case_run::<HAN>(bytes, e, st));
         }
         return ws_token_end(bytes, pos);
     }
@@ -381,10 +444,10 @@ pub(crate) fn advance_pos<const CONTRACTIONS: bool, const DIGITS3: bool>(
     // ASCII punctuation/symbol/control (including `'`: o200k has no
     // standalone contraction alternative, so a leading apostrophe is
     // ordinary punctuation / a letter-run prefix: "'sound" is one token)
-    if let Some((e, st)) = letter_run_first(bytes, pos + 1) {
-        return try_suffix::<CONTRACTIONS>(bytes, scan_case_run(bytes, e, st));
+    if let Some((e, st)) = letter_run_first::<HAN>(bytes, pos + 1) {
+        return try_suffix::<CONTRACTIONS>(bytes, scan_case_run::<HAN>(bytes, e, st));
     }
-    scan_tail(bytes, scan_punct_from(bytes, pos + 1))
+    scan_tail::<SLASH>(bytes, scan_punct_from::<HAN>(bytes, pos + 1))
 }
 
 // -----------------------------------------------------------------------
@@ -444,8 +507,17 @@ struct OUni {
     /// wrongly-cleared bits (extending the scalar walk) or wrongly-set
     /// bits interior to a token starting inside the zone, both killed by
     /// MaskState's resume masking after the scalar overrun — the same
-    /// invariant the resid zones rely on.
+    /// invariant the resid zones rely on. Kimi routes Han symbols (So/Mc)
+    /// here too: punct-run members mid-run, Han-run chars at a token
+    /// start, so their class is run-contextual exactly like a mark's.
     mk: u64,
+    /// Han-letter bytes (Kimi only): their own run class, with the
+    /// boundary rule `han_leads & !prev-is-han`. Han numerals go through
+    /// `resid` (their `\p{N}{1,3}`-vs-Han-run role is contextual) and Han
+    /// symbols through `mk`.
+    han: u64,
+    /// Lead bits of the `han` chars.
+    han_leads: u64,
 }
 
 /// Boundary carries from the chars before the batch (o200k variant of the
@@ -463,6 +535,8 @@ struct OCarries {
     po: u64,
     pws: u64,
     pd: u64,
+    /// P1 is a Han letter (Kimi only).
+    phan: u64,
     /// P2 is punct-or-space, for a char lead at bit 0.
     c2_os: u64,
     /// Same test positioned at the first lead AFTER a straddling-in P1.
@@ -476,16 +550,20 @@ struct OCarries {
 }
 
 /// Was the tail-class byte at `scan - 1` absorbed by a punct run's
-/// `[\r\n/]*` tail (as opposed to being a fresh punct-run `/` or a
-/// ws-run newline)? Walks the tail-class run back (bounded) and
-/// classifies the byte before it. `None`: unresolved (over-long run, or a
-/// preceding mark whose own class is run-contextual).
+/// `[\r\n/]*` (Kimi: `[\r\n]*`) tail (as opposed to being a fresh
+/// punct-run `/` or a ws-run newline)? Walks the tail-class run back
+/// (bounded) and classifies the byte before it. `None`: unresolved
+/// (over-long run, or a preceding mark or Han symbol whose own class is
+/// run-contextual).
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
-fn prev_tail_absorbed(bytes: &[u8], scan: usize) -> Option<bool> {
-    debug_assert!(scan >= 1 && is_tail_byte(bytes[scan - 1]));
+fn prev_tail_absorbed<const SLASH: bool, const HAN: bool>(
+    bytes: &[u8],
+    scan: usize,
+) -> Option<bool> {
+    debug_assert!(scan >= 1 && is_tail_byte::<SLASH>(bytes[scan - 1]));
     let mut r = scan - 1;
     let mut steps = 0;
-    while r > 0 && is_tail_byte(bytes[r - 1]) {
+    while r > 0 && is_tail_byte::<SLASH>(bytes[r - 1]) {
         r -= 1;
         steps += 1;
         if steps > 8 {
@@ -528,10 +606,12 @@ fn prev_tail_absorbed(bytes: &[u8], scan: usize) -> Option<bool> {
                     k -= 1;
                 }
                 let (cp, _) = unsafe { decode_cp(bytes, k) };
-                match o200k_class_of(cp) {
-                    O200kCharClass::Other => Some(true),
-                    // A mark continues whatever run precedes it.
-                    O200kCharClass::Mark => None,
+                match family_class_of::<HAN>(cp) {
+                    (O200kCharClass::Other, false) => Some(true),
+                    // A mark continues whatever run precedes it; a Han
+                    // symbol is a punct-run member or a Han-run char
+                    // depending on where its token started.
+                    (O200kCharClass::Mark, _) | (O200kCharClass::Other, true) => None,
                     _ => Some(false),
                 }
             };
@@ -550,14 +630,15 @@ fn prev_tail_absorbed(bytes: &[u8], scan: usize) -> Option<bool> {
 
 /// Two-back "punct or space" test (`c2_os`) for the ASCII byte at `idx`.
 /// A slash may be an absorbed tail byte — a token end, neither punct-run
-/// member nor space — so it resolves through the walkback. `None`:
-/// unresolved (callers set `force_bad_lead`).
+/// member nor space — so it resolves through the walkback (only when the
+/// scheme absorbs slashes). `None`: unresolved (callers set
+/// `force_bad_lead`).
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(always)]
-fn c2_os_ascii(bytes: &[u8], idx: usize) -> Option<u64> {
+fn c2_os_ascii<const SLASH: bool, const HAN: bool>(bytes: &[u8], idx: usize) -> Option<u64> {
     let b2 = bytes[idx];
-    if b2 == b'/' {
-        return prev_tail_absorbed(bytes, idx + 1).map(|abs| u64::from(!abs));
+    if SLASH && b2 == b'/' {
+        return prev_tail_absorbed::<SLASH, HAN>(bytes, idx + 1).map(|abs| u64::from(!abs));
     }
     Some(u64::from(
         b2 == b' ' || (!is_letter(b2) && !is_digit(b2) && !is_ascii_ws(b2)),
@@ -569,13 +650,13 @@ fn c2_os_ascii(bytes: &[u8], idx: usize) -> Option<u64> {
 /// tail-class byte (those route through [`prev_tail_absorbed`] first).
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(always)]
-fn ascii_carries(bytes: &[u8], scan: usize) -> OCarries {
+fn ascii_carries<const SLASH: bool, const HAN: bool>(bytes: &[u8], scan: usize) -> OCarries {
     let b = bytes[scan - 1];
-    debug_assert!(!is_tail_byte(b));
+    debug_assert!(!is_tail_byte::<SLASH>(b));
     let bit = |c: bool| u64::from(c);
     let (l, d, w) = (is_letter(b), is_digit(b), is_ascii_ws(b));
     let (c2_os, c2_unresolved) = if scan >= 2 {
-        match c2_os_ascii(bytes, scan - 2) {
+        match c2_os_ascii::<SLASH, HAN>(bytes, scan - 2) {
             Some(v) => (v, false),
             None => (0, true),
         }
@@ -592,6 +673,7 @@ fn ascii_carries(bytes: &[u8], scan: usize) -> OCarries {
         po: bit(!l && !d && !w),
         pws: bit(w),
         pd: bit(d),
+        phan: 0,
         c2_os,
         b2b_in: 0,
         p_abs: false,
@@ -604,8 +686,8 @@ fn ascii_carries(bytes: &[u8], scan: usize) -> OCarries {
 /// zero and only the tail-continuation seed survives.
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(never)]
-fn tail_carries(bytes: &[u8], scan: usize) -> OCarries {
-    match prev_tail_absorbed(bytes, scan) {
+fn tail_carries<const SLASH: bool, const HAN: bool>(bytes: &[u8], scan: usize) -> OCarries {
+    match prev_tail_absorbed::<SLASH, HAN>(bytes, scan) {
         Some(true) => OCarries { p_abs: true, ..OCarries::default() },
         Some(false) => {
             let b = bytes[scan - 1];
@@ -649,7 +731,7 @@ fn tail_carries(bytes: &[u8], scan: usize) -> OCarries {
 /// `scan + 70 <= bytes.len()` (the batch classifiers' lookahead guard).
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(always)]
-unsafe fn classify_uni_o200k(bytes: &[u8], scan: usize, mut m: u64) -> OUni {
+unsafe fn classify_uni_o200k<const HAN: bool>(bytes: &[u8], scan: usize, mut m: u64) -> OUni {
     use super::decode_cp_inbounds;
     let mut u = OUni::default();
     while m != 0 {
@@ -672,29 +754,38 @@ unsafe fn classify_uni_o200k(bytes: &[u8], scan: usize, mut m: u64) -> OUni {
         // SAFETY: scan + 70 <= len (this fn's contract), i <= 63, so
         // scan + i + 4 <= len even for a 4-byte lead at bit 63.
         let (cp, _) = unsafe { decode_cp_inbounds(bytes, scan + i) };
-        match o200k_class_of(cp) {
-            O200kCharClass::Upper => {
+        match family_class_of::<HAN>(cp) {
+            // Han letters: their own run class (see OUni::han). Han
+            // numerals fall to the Number arm (whose resid already defers
+            // them: their Han-run-vs-digit-group role is contextual) and
+            // Han symbols to the Mark arm (same run-contextual deferral).
+            (O200kCharClass::Caseless, true) => {
+                u.han |= chm;
+                u.han_leads |= lead;
+            }
+            (O200kCharClass::Upper, _) => {
                 u.l |= chm;
                 u.u |= chm;
             }
-            O200kCharClass::Lower => u.l |= chm,
-            O200kCharClass::Caseless => {
+            (O200kCharClass::Lower, _) => u.l |= chm,
+            (O200kCharClass::Caseless, _) => {
                 u.l |= chm;
                 u.cl |= chm;
             }
-            O200kCharClass::Mark => {
-                // Contextual (letter-run joiner AND punct-run member):
+            (O200kCharClass::Mark, _) | (O200kCharClass::Other, true) => {
+                // Contextual (letter-run joiner AND punct-run member, or
+                // for Han symbols punct-run member AND Han-run char):
                 // punct-class for the neighbors' mask algebra, deferred
                 // (±4) for everything the context could change.
                 u.o |= chm;
                 u.mk |= chm;
             }
-            O200kCharClass::Number => {
+            (O200kCharClass::Number, _) => {
                 u.n |= chm;
                 u.resid |= chm; // char-counted grouping: scalar
             }
-            O200kCharClass::Other => u.o |= chm,
-            O200kCharClass::Whitespace => {
+            (O200kCharClass::Other, _) => u.o |= chm,
+            (O200kCharClass::Whitespace, _) => {
                 u.ws |= chm;
                 if i + l > 64 || l == 4 {
                     u.resid |= chm; // straddling-out ws stays a bad zone
@@ -735,7 +826,12 @@ struct OAsciiExtra {
     target_feature(enable = "bmi1,bmi2,lzcnt,popcnt")
 )]
 #[inline(never)]
-fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
+fn o200k_extended_masks<
+    const CONTRACTIONS: bool,
+    const DIGITS3: bool,
+    const SLASH: bool,
+    const HAN: bool,
+>(
     bytes: &[u8],
     scan: usize,
     am: AsciiMasks,
@@ -743,12 +839,16 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
 ) -> (u64, u64) {
     use super::decode_cp_inbounds;
 
-    /// The char containing byte `pos - 1`: its o200k class, lead index,
-    /// and end (exclusive) — [`mask::char_through`] with the o200k
-    /// classifier. Same safety contract (`pos > 0`, `pos + 3 <= len` when
-    /// `bytes[pos-1]` is non-ASCII; the batch guard covers callers).
+    /// The char containing byte `pos - 1`: its scheme class (plus Han
+    /// flag), lead index, and end (exclusive) — [`mask::char_through`]
+    /// with the scheme classifier. Same safety contract (`pos > 0`,
+    /// `pos + 3 <= len` when `bytes[pos-1]` is non-ASCII; the batch guard
+    /// covers callers).
     #[inline(always)]
-    unsafe fn char_through_o200k(bytes: &[u8], pos: usize) -> (O200kCharClass, usize, usize) {
+    unsafe fn char_through_o200k<const HAN: bool>(
+        bytes: &[u8],
+        pos: usize,
+    ) -> (O200kCharClass, bool, usize, usize) {
         let b = bytes[pos - 1];
         if b < 0x80 {
             let cls = if is_upper_ascii(b) {
@@ -762,7 +862,7 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
             } else {
                 O200kCharClass::Other
             };
-            return (cls, pos - 1, pos);
+            return (cls, false, pos - 1, pos);
         }
         let mut j = pos - 1;
         while j > 0 && bytes[j] & 0xC0 == 0x80 {
@@ -770,40 +870,42 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
         }
         // SAFETY: j < pos and pos + 3 <= len (contract), so j + 4 <= len.
         let (cp, l) = unsafe { decode_cp_inbounds(bytes, j) };
-        (o200k_class_of(cp), j, j + l)
+        let (cls, han) = family_class_of::<HAN>(cp);
+        (cls, han, j, j + l)
     }
 
     let mut cl = OUni::default();
     let cr = if scan == 0 {
         OCarries::default()
-    } else if bytes[scan - 1] < 0x80 && is_tail_byte(bytes[scan - 1]) {
-        tail_carries(bytes, scan)
+    } else if bytes[scan - 1] < 0x80 && is_tail_byte::<SLASH>(bytes[scan - 1]) {
+        tail_carries::<SLASH, HAN>(bytes, scan)
     } else if bytes[scan - 1] < 0x80 && (scan < 2 || bytes[scan - 2] < 0x80) {
-        ascii_carries(bytes, scan)
+        ascii_carries::<SLASH, HAN>(bytes, scan)
     } else {
         // A multi-byte char within two bytes of the batch start.
         // SAFETY: scan > 0, and the batch guard covers pos + 3 <= len.
-        let (c1, j1, e1) = unsafe { char_through_o200k(bytes, scan) };
+        let (c1, h1, j1, e1) = unsafe { char_through_o200k::<HAN>(bytes, scan) };
         let chm = if e1 > scan { (1u64 << (e1 - scan)) - 1 } else { 0 };
         cl.cont = chm;
         let (c2v, c2_defer) = if j1 == 0 {
             (0, false)
-        } else if bytes[j1 - 1] == b'/' {
+        } else if SLASH && bytes[j1 - 1] == b'/' {
             // An absorbed tail slash is a token end, not a punct-run char.
-            match prev_tail_absorbed(bytes, j1) {
+            match prev_tail_absorbed::<SLASH, HAN>(bytes, j1) {
                 Some(abs) => (u64::from(!abs), false),
                 None => (0, true),
             }
         } else {
             // SAFETY: j1 > 0, j1 < scan keeps the decode in the guard.
-            let c2c = unsafe { char_through_o200k(bytes, j1) }.0;
+            let (c2c, h2, _, _) = unsafe { char_through_o200k::<HAN>(bytes, j1) };
             (
                 u64::from(
                     bytes[j1 - 1] == b' '
-                        || matches!(c2c, O200kCharClass::Other | O200kCharClass::Mark),
+                        || (matches!(c2c, O200kCharClass::Other | O200kCharClass::Mark) && !h2),
                 ),
-                // A mark P2 makes the two-back test run-contextual.
-                c2c == O200kCharClass::Mark,
+                // A mark P2 makes the two-back test run-contextual; so
+                // does a Han symbol (punct-run member or Han-run char).
+                c2c == O200kCharClass::Mark || (h2 && c2c == O200kCharClass::Other),
             )
         };
         let mut c = OCarries::default();
@@ -816,31 +918,38 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
             c.force_bad_lead = true;
         }
         c.pd = u64::from(c1 == O200kCharClass::Number);
-        match c1 {
-            O200kCharClass::Upper => {
+        match (c1, h1) {
+            // A Han letter: p_han carry; its in-batch bytes join the han
+            // mask so in-batch followers see char adjacency.
+            (O200kCharClass::Caseless, true) => {
+                cl.han |= chm;
+                c.phan = 1;
+            }
+            (O200kCharClass::Upper, _) => {
                 cl.l |= chm;
                 cl.u |= chm;
                 c.pl = 1;
                 c.pu = 1;
             }
-            O200kCharClass::Lower => {
+            (O200kCharClass::Lower, _) => {
                 cl.l |= chm;
                 c.pl = 1;
             }
-            O200kCharClass::Caseless => {
+            (O200kCharClass::Caseless, _) => {
                 cl.l |= chm;
                 cl.cl |= chm;
                 c.pl = 1;
                 c.pcl = 1;
             }
-            O200kCharClass::Mark => {
-                // Contextual: defer the batch front to the scalar path.
+            (O200kCharClass::Mark, _) | (O200kCharClass::Other, true) => {
+                // Contextual (marks; Kimi Han symbols): defer the batch
+                // front to the scalar path.
                 cl.o |= chm;
                 cl.mk |= chm | 1; // bit 0 seeds the ±4 smear even when
-                // the mark sits entirely before the batch
+                // the char sits entirely before the batch
                 c.po = 1;
             }
-            O200kCharClass::Number => {
+            (O200kCharClass::Number, h) => {
                 cl.n |= chm;
                 // A digit char straddling INTO the batch: the leading
                 // ASCII digit run's `\p{N}{1,3}` phase started before the
@@ -848,12 +957,19 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
                 // continuation byte, not an ASCII digit). Defer via resid
                 // so the bad<<1 seed catches the run.
                 cl.resid |= chm;
+                if h {
+                    // A Han numeral P1: a following Han char's boundary
+                    // depends on whether P1 sat in a digit group or a Han
+                    // run — defer the batch front even when P1 lies
+                    // entirely before the batch.
+                    cl.resid |= 1;
+                }
             }
-            O200kCharClass::Other => {
+            (O200kCharClass::Other, _) => {
                 cl.o |= chm;
                 c.po = 1;
             }
-            O200kCharClass::Whitespace => {
+            (O200kCharClass::Whitespace, _) => {
                 cl.ws |= chm;
                 if e1 > scan {
                     cl.resid |= chm;
@@ -871,7 +987,7 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
     let mut uni = if am.hi != 0 {
         // SAFETY: the batch guard is exactly `classify_uni_o200k`'s
         // contract.
-        unsafe { classify_uni_o200k(bytes, scan, am.hi & !cl.cont) }
+        unsafe { classify_uni_o200k::<HAN>(bytes, scan, am.hi & !cl.cont) }
     } else {
         OUni::default()
     };
@@ -884,8 +1000,9 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
     uni.cont |= cl.cont;
     uni.resid |= cl.resid;
     uni.mk |= cl.mk;
+    uni.han |= cl.han;
 
-    o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, uni)
+    o200k_algebra::<CONTRACTIONS, DIGITS3, SLASH, HAN>(bytes, scan, am, ax, cr, uni)
 }
 
 /// The o200k family's shared u64 boundary algebra over per-byte class
@@ -894,7 +1011,12 @@ fn o200k_extended_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
 /// tails. `uni` is all-zero on the pure-ASCII path.
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(always)]
-fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
+fn o200k_algebra<
+    const CONTRACTIONS: bool,
+    const DIGITS3: bool,
+    const SLASH: bool,
+    const HAN: bool,
+>(
     bytes: &[u8],
     scan: usize,
     am: AsciiMasks,
@@ -911,6 +1033,7 @@ fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
         po,
         pws,
         pd,
+        phan,
         c2_os,
         b2b_in,
         p_abs,
@@ -927,11 +1050,12 @@ fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
     let ob = !(am.l | am.d | am.s | am.wt | am.n | am.hi) | uni.o;
     let ws_all = sb | wtb | am.n;
 
-    // --- Absorbed `[\r\n/]*` tails -----------------------------------------
+    // --- Absorbed `[\r\n/]*` (Kimi `[\r\n]*`) tails -------------------------
     // Seed: a newline right after a punct byte (a slash after a punct run
     // is already a run member, so tails always begin with a newline), or
-    // a tail continuing from before the batch. Smear through [\r\n/].
-    let tcls = am.n | ax.sl;
+    // a tail continuing from before the batch. Smear through the tail
+    // class.
+    let tcls = if SLASH { am.n | ax.sl } else { am.n };
     let abs_seed = (am.n & ((ob << 1) | po)) | (u64::from(p_abs) & tcls);
     let abs_t = if abs_seed == 0 { 0 } else { smear_up(abs_seed, tcls) };
     // Absorbed bytes are no longer punct-run members for any boundary rule.
@@ -1058,7 +1182,17 @@ fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
         runs_n &= !run_mask;
     }
 
-    let mut boundary = b_letters | b_digits | b_punct | b_ws;
+    // --- Han runs (Kimi): `[\p{Han}]+` --------------------------------------
+    // A boundary at every Han-letter lead whose previous char is not a Han
+    // letter. Han numerals/symbols sit in resid/mk bad zones, so any lead
+    // adjacent to those resolves on the scalar path.
+    let b_han = if HAN {
+        uni.han_leads & !((uni.han << 1) | phan)
+    } else {
+        0
+    };
+
+    let mut boundary = b_letters | b_digits | b_punct | b_ws | b_han;
 
     // --- Contractions: suffix `(?i:'s|'t|'re|'ve|'m|'ll|'d)?` ----------------
     // An apostrophe right after a letter-run char merges the suffix into
@@ -1136,13 +1270,13 @@ fn o200k_algebra<const CONTRACTIONS: bool, const DIGITS3: bool>(
 /// through the branchless ASCII carries.
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 #[inline(always)]
-fn ascii_batch_carries(bytes: &[u8], scan: usize) -> OCarries {
+fn ascii_batch_carries<const SLASH: bool, const HAN: bool>(bytes: &[u8], scan: usize) -> OCarries {
     if scan == 0 {
         OCarries::default()
-    } else if is_tail_byte(bytes[scan - 1]) {
-        tail_carries(bytes, scan)
+    } else if is_tail_byte::<SLASH>(bytes[scan - 1]) {
+        tail_carries::<SLASH, HAN>(bytes, scan)
     } else {
-        ascii_carries(bytes, scan)
+        ascii_carries::<SLASH, HAN>(bytes, scan)
     }
 }
 
@@ -1155,7 +1289,12 @@ fn ascii_batch_carries(bytes: &[u8], scan: usize) -> OCarries {
 /// them take [`o200k_extended_masks`].
 #[cfg(target_arch = "aarch64")]
 #[inline]
-pub(crate) fn batch_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
+pub(crate) fn batch_masks<
+    const CONTRACTIONS: bool,
+    const DIGITS3: bool,
+    const SLASH: bool,
+    const HAN: bool,
+>(
     bytes: &[u8],
     scan: usize,
 ) -> (u64, u64) {
@@ -1215,9 +1354,13 @@ pub(crate) fn batch_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
         } else {
             0
         };
-        let sl_any = vorrq_u8(vorrq_u8(slv[0], slv[1]), vorrq_u8(slv[2], slv[3]));
-        let sl64 = if vmaxvq_u8(sl_any) != 0 {
-            mask::movemask64(slv[0], slv[1], slv[2], slv[3])
+        let sl64 = if SLASH {
+            let sl_any = vorrq_u8(vorrq_u8(slv[0], slv[1]), vorrq_u8(slv[2], slv[3]));
+            if vmaxvq_u8(sl_any) != 0 {
+                mask::movemask64(slv[0], slv[1], slv[2], slv[3])
+            } else {
+                0
+            }
         } else {
             0
         };
@@ -1240,11 +1383,11 @@ pub(crate) fn batch_masks<const CONTRACTIONS: bool, const DIGITS3: bool>(
         {
             let mut am = am;
             am.hi = mask::movemask64(hiv[0], hiv[1], hiv[2], hiv[3]);
-            return o200k_extended_masks::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax);
+            return o200k_extended_masks::<CONTRACTIONS, DIGITS3, SLASH, HAN>(bytes, scan, am, ax);
         }
 
-        let cr = ascii_batch_carries(bytes, scan);
-        o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, OUni::default())
+        let cr = ascii_batch_carries::<SLASH, HAN>(bytes, scan);
+        o200k_algebra::<CONTRACTIONS, DIGITS3, SLASH, HAN>(bytes, scan, am, ax, cr, OUni::default())
     }
 }
 
@@ -1267,6 +1410,8 @@ pub(crate) unsafe fn batch_masks_x86<
     const AVX512: bool,
     const CONTRACTIONS: bool,
     const DIGITS3: bool,
+    const SLASH: bool,
+    const HAN: bool,
 >(
     bytes: &[u8],
     scan: usize,
@@ -1288,10 +1433,12 @@ pub(crate) unsafe fn batch_masks_x86<
     {
         // SAFETY: both detected tiers include the BMI1/BMI2/LZCNT/POPCNT
         // bit features `o200k_extended_masks` re-declares (fn contract).
-        return unsafe { o200k_extended_masks::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax) };
+        return unsafe {
+            o200k_extended_masks::<CONTRACTIONS, DIGITS3, SLASH, HAN>(bytes, scan, am, ax)
+        };
     }
-    let cr = ascii_batch_carries(bytes, scan);
-    o200k_algebra::<CONTRACTIONS, DIGITS3>(bytes, scan, am, ax, cr, OUni::default())
+    let cr = ascii_batch_carries::<SLASH, HAN>(bytes, scan);
+    o200k_algebra::<CONTRACTIONS, DIGITS3, SLASH, HAN>(bytes, scan, am, ax, cr, OUni::default())
 }
 
 /// The strict-uppercase and slash masks for `bytes[scan..scan+64]`,
@@ -1345,6 +1492,7 @@ fn ascii_extra_avx2(bytes: &[u8], scan: usize) -> OAsciiExtra {
 
 #[cfg(test)]
 mod tests {
+    use crate::pretokenize::fast::kimi::KimiScheme;
     use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
     use crate::pretokenize::fast::nemotron::NemotronScheme;
     use crate::pretokenize::fast::o200k::O200kScheme;
@@ -1369,12 +1517,13 @@ mod tests {
         out
     }
 
-    /// Scalar-vs-mask token streams for both family schemes.
+    /// Scalar-vs-mask token streams for all family schemes.
     #[track_caller]
     fn check_all(buf: &[u8]) {
         for (name, a, b) in [
             ("o200k", scalar_tokens::<O200kScheme>(buf), mask_tokens::<O200kScheme>(buf)),
             ("nemotron", scalar_tokens::<NemotronScheme>(buf), mask_tokens::<NemotronScheme>(buf)),
+            ("kimi", scalar_tokens::<KimiScheme>(buf), mask_tokens::<KimiScheme>(buf)),
         ] {
             if a != b {
                 let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
@@ -1430,6 +1579,7 @@ mod tests {
                 scalar_tokens::<NemotronScheme>(&buf),
                 mask_tokens::<NemotronScheme>(&buf),
             ),
+            ("kimi", scalar_tokens::<KimiScheme>(&buf), mask_tokens::<KimiScheme>(&buf)),
         ] {
             if a != b {
                 let i = a.iter().zip(&b).take_while(|(x, y)| x == y).count();
@@ -1491,6 +1641,9 @@ mod tests {
             "!x", "!X", "\tx", " x", " X", "?!", "\u{301}", "ſ", "'ſ", "'\u{301}",
             "\u{661}\u{662}", "\u{FF11}", "क", "\u{940}", "\u{1D54F}", "€", "™",
             "…\u{2028}", "AxB", "ABc", "aB", "\u{416}dz", "x'", "n't",
+            // Han classes (Kimi): letters, numerals (Nl), symbols (So/Mc)
+            "中", "中文", "々", "〆", "𠀀", "〇", "〡", "㆒", "⼀", "⺀",
+            "\u{16FF0}", "中's", "1〇", "中\n", "!⼀", "中⼀",
         ];
         let mut state = 0x243F6A8885A308D3u64;
         let mut rng = move || {
@@ -1519,6 +1672,7 @@ mod tests {
 
 #[cfg(test)]
 mod owt_tests {
+    use crate::pretokenize::fast::kimi::KimiScheme;
     use crate::pretokenize::fast::mask::{MaskScheme, MaskState};
     use crate::pretokenize::fast::nemotron::NemotronScheme;
     use crate::pretokenize::fast::o200k::O200kScheme;
@@ -1549,6 +1703,7 @@ mod owt_tests {
     fn check_streaming_all(bytes: &[u8]) {
         check_streaming::<O200kScheme>(bytes, "o200k");
         check_streaming::<NemotronScheme>(bytes, "nemotron");
+        check_streaming::<KimiScheme>(bytes, "kimi");
     }
 
     /// 100 MB of OWT, mask vs scalar.

--- a/src/pretokenize/mod.rs
+++ b/src/pretokenize/mod.rs
@@ -982,6 +982,7 @@ mod span_source_tests {
                 PretokenizerType::Qwen35,
                 PretokenizerType::Olmo3,
                 PretokenizerType::DeepSeekV3,
+                PretokenizerType::Kimi,
             ] {
                 check_source(pt.pretokenize(b), pt.pretokenize(b), "dispatch");
             }

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -1,8 +1,8 @@
 use crate::pretokenize::Pretoken;
 use crate::pretokenize::fast::{
-    FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastNemotronPretokenizer,
-    FastO200kPretokenizer, FastOlmo3Pretokenizer, FastQwen2Pretokenizer,
-    FastQwen35Pretokenizer, FastR50kPretokenizer,
+    FastCl100kPretokenizer, FastDeepSeekV3Pretokenizer, FastKimiPretokenizer,
+    FastNemotronPretokenizer, FastO200kPretokenizer, FastOlmo3Pretokenizer,
+    FastQwen2Pretokenizer, FastQwen35Pretokenizer, FastR50kPretokenizer,
 };
 
 /// Which pretokenization scheme (regex) a tokenizer uses.
@@ -16,6 +16,7 @@ pub enum PretokenizerType {
     DeepSeekV3, // Sequence of three Splits (digits, CJK, main); used by DeepSeek V3/V3.1/V4
     O200k,      // o200k_base: case-structured letter runs; GPT-4o, gpt-oss
     Nemotron,   // o200k without contractions, single-digit \p{N}; nvidia Nemotron-3
+    Kimi,       // o200k with [\p{Han}]+ runs and no `/` tail absorption; moonshotai Kimi-K2 line
 }
 
 /// The three Split regexes of the DeepSeek V3/V4 pre_tokenizer Sequence, as
@@ -58,6 +59,9 @@ impl PretokenizerType {
             }
             PretokenizerType::Nemotron => {
                 FastPretokenizerDispatch::Nemotron(FastNemotronPretokenizer::new(bytes))
+            }
+            PretokenizerType::Kimi => {
+                FastPretokenizerDispatch::Kimi(FastKimiPretokenizer::new(bytes))
             }
         }
     }
@@ -115,6 +119,7 @@ pub enum FastPretokenizerDispatch<'a> {
     DeepSeekV3(FastDeepSeekV3Pretokenizer<'a>),
     O200k(FastO200kPretokenizer<'a>),
     Nemotron(FastNemotronPretokenizer<'a>),
+    Kimi(FastKimiPretokenizer<'a>),
 }
 
 impl<'a> Iterator for FastPretokenizerDispatch<'a> {
@@ -131,6 +136,7 @@ impl<'a> Iterator for FastPretokenizerDispatch<'a> {
             FastPretokenizerDispatch::DeepSeekV3(it) => it.next(),
             FastPretokenizerDispatch::O200k(it) => it.next(),
             FastPretokenizerDispatch::Nemotron(it) => it.next(),
+            FastPretokenizerDispatch::Kimi(it) => it.next(),
         }
     }
 }
@@ -156,6 +162,7 @@ unsafe impl<'a> crate::pretokenize::PretokenSpans<'a> for FastPretokenizerDispat
             FastPretokenizerDispatch::DeepSeekV3(it) => it.fill_spans_keyed(batch, prefetch),
             FastPretokenizerDispatch::O200k(it) => it.fill_spans_keyed(batch, prefetch),
             FastPretokenizerDispatch::Nemotron(it) => it.fill_spans_keyed(batch, prefetch),
+            FastPretokenizerDispatch::Kimi(it) => it.fill_spans_keyed(batch, prefetch),
         }
     }
 }

--- a/src/pretokenize/unicode.rs
+++ b/src/pretokenize/unicode.rs
@@ -268,6 +268,12 @@ static O200K_CLASS_TABLE: std::sync::LazyLock<Box<[u8]>> =
     std::sync::LazyLock::new(build_o200k_class_table);
 
 fn build_o200k_class_table() -> Box<[u8]> {
+    pack_nibbles(&o200k_classes_unpacked())
+}
+
+/// One `O200kCharClass` byte per codepoint (the unpacked form both the
+/// o200k and Kimi table builders start from).
+fn o200k_classes_unpacked() -> Vec<u8> {
     use icu::properties::CodePointMapData;
     const N: usize = 0x110000;
     let mut classes = vec![O200kCharClass::Other as u8; N];
@@ -297,6 +303,11 @@ fn build_o200k_class_table() -> Box<[u8]> {
             .fill(O200kCharClass::Whitespace as u8);
     }
     classes
+}
+
+/// Pack one-byte-per-codepoint classes into 4-bit nibbles, 2 per byte.
+fn pack_nibbles(classes: &[u8]) -> Box<[u8]> {
+    classes
         .as_chunks::<2>().0.iter()
         .map(|c| c[0] | (c[1] << 4))
         .collect()
@@ -317,6 +328,110 @@ pub(crate) fn o200k_class_of(cp: u32) -> O200kCharClass {
         4 => O200kCharClass::Number,
         5 => O200kCharClass::Whitespace,
         _ => O200kCharClass::Other,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kimi character classes (o200k classes with Script=Han split out)
+// ---------------------------------------------------------------------------
+
+/// Character class for the Kimi (moonshotai K2 family) regex: the o200k
+/// classes with `\p{Han}` split out. The pattern gives Han runs their own
+/// leading alternative (`[\p{Han}]+`) and excludes Han from both letter
+/// brackets (`[...&&[^\p{Han}]]`), but the general-category rules are
+/// otherwise Han-blind: `\p{N}{1,3}` still counts a Han numeral and
+/// `[^\s\p{L}\p{N}]+` still spans a Han symbol mid-run. Each Han variant
+/// therefore records which base class the char behaves as outside a Han
+/// run ([`Self::base`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum KimiCharClass {
+    Upper = 0,
+    Lower = 1,
+    Caseless = 2,
+    Mark = 3,
+    Number = 4,
+    Whitespace = 5,
+    Other = 6,
+    /// Han letters (Lo, plus Lm like U+3005 々): the bulk of `\p{Han}`.
+    /// Never letter-run members; a maximal run of Han-class chars starting
+    /// a token is one `[\p{Han}]+` token.
+    Han = 7,
+    /// Han numerals (Nl: U+3007 〇, Suzhou numerals): `\p{N}` mid-number,
+    /// Han-run members otherwise.
+    HanNumber = 8,
+    /// Han symbols and marks (So: Kangxi radicals; Mc: U+16FF0/1 reading
+    /// marks, which `&&[^\p{Han}]` evicts from the letter brackets):
+    /// punct-run members mid-run, Han-run members at a token start.
+    HanOther = 9,
+}
+
+impl KimiCharClass {
+    /// The o200k class the char behaves as in non-Han-run contexts.
+    #[inline(always)]
+    pub(crate) fn base(self) -> O200kCharClass {
+        match self {
+            KimiCharClass::Upper => O200kCharClass::Upper,
+            KimiCharClass::Lower => O200kCharClass::Lower,
+            KimiCharClass::Caseless | KimiCharClass::Han => O200kCharClass::Caseless,
+            KimiCharClass::Mark => O200kCharClass::Mark,
+            KimiCharClass::Number | KimiCharClass::HanNumber => O200kCharClass::Number,
+            KimiCharClass::Whitespace => O200kCharClass::Whitespace,
+            KimiCharClass::Other | KimiCharClass::HanOther => O200kCharClass::Other,
+        }
+    }
+
+    /// Is the char in `\p{Han}` (a `[\p{Han}]+` run member)?
+    #[inline(always)]
+    pub(crate) fn is_han(self) -> bool {
+        self as u8 >= KimiCharClass::Han as u8
+    }
+}
+
+/// 4-bit class per codepoint, 2 codepoints per byte (~544 KiB total).
+static KIMI_CLASS_TABLE: std::sync::LazyLock<Box<[u8]>> =
+    std::sync::LazyLock::new(build_kimi_class_table);
+
+fn build_kimi_class_table() -> Box<[u8]> {
+    use icu::properties::CodePointMapData;
+    use icu::properties::props::Script;
+    let mut classes = o200k_classes_unpacked();
+    let script = CodePointMapData::<Script>::new();
+    for range in script.iter_ranges_for_value(Script::Han) {
+        for cp in *range.start()..=*range.end() {
+            let slot = &mut classes[cp as usize];
+            *slot = match *slot {
+                c if c == O200kCharClass::Number as u8 => KimiCharClass::HanNumber as u8,
+                // Marks land in HanOther: `&&[^\p{Han}]` evicts them from
+                // the letter brackets, leaving only their punct-run role.
+                c if c == O200kCharClass::Other as u8 || c == O200kCharClass::Mark as u8 => {
+                    KimiCharClass::HanOther as u8
+                }
+                // Letters (Lo/Lm); no Han char is Lu/Lt/Ll/Whitespace.
+                _ => KimiCharClass::Han as u8,
+            };
+        }
+    }
+    pack_nibbles(&classes)
+}
+
+/// Classify a codepoint for the Kimi scheme with one table load. `cp` must
+/// be a valid scalar value (guaranteed when decoded from valid UTF-8).
+#[inline(always)]
+pub(crate) fn kimi_class_of(cp: u32) -> KimiCharClass {
+    debug_assert!(cp < 0x110000);
+    let byte = unsafe { *KIMI_CLASS_TABLE.get_unchecked((cp >> 1) as usize) };
+    match (byte >> ((cp & 1) << 2)) & 0xF {
+        0 => KimiCharClass::Upper,
+        1 => KimiCharClass::Lower,
+        2 => KimiCharClass::Caseless,
+        3 => KimiCharClass::Mark,
+        4 => KimiCharClass::Number,
+        5 => KimiCharClass::Whitespace,
+        6 => KimiCharClass::Other,
+        7 => KimiCharClass::Han,
+        8 => KimiCharClass::HanNumber,
+        _ => KimiCharClass::HanOther,
     }
 }
 
@@ -375,6 +490,31 @@ mod tests {
                 O200kCharClass::Other
             };
             assert_eq!(o200k_class_of(cp), expected, "mismatch at U+{cp:04X}");
+        }
+    }
+
+    /// The Kimi table must refine the o200k table: identical off `\p{Han}`,
+    /// and on it a Han variant whose base is the o200k class.
+    #[test]
+    fn kimi_class_table_refines_o200k() {
+        use icu::properties::CodePointMapData;
+        use icu::properties::props::Script;
+        let script = CodePointMapData::<Script>::new();
+        for cp in 0..=char::MAX as u32 {
+            let Some(c) = char::from_u32(cp) else { continue };
+            let k = kimi_class_of(cp);
+            // Han marks base as Other (evicted from the letter brackets, so
+            // only their punct-run role remains); all else keeps its class.
+            let expected_base = match o200k_class_of(cp) {
+                O200kCharClass::Mark if k.is_han() => O200kCharClass::Other,
+                c => c,
+            };
+            assert_eq!(k.base(), expected_base, "base mismatch at U+{cp:04X}");
+            assert_eq!(
+                k.is_han(),
+                script.get(c) == Script::Han,
+                "Han mismatch at U+{cp:04X}"
+            );
         }
     }
 

--- a/tests/test_kimi.py
+++ b/tests/test_kimi.py
@@ -1,0 +1,130 @@
+"""End-to-end parity for the moonshotai Kimi tokenizer line.
+
+Every repo in the line ships the same tiktoken.model (no tokenizer.json)
+with the Kimi pretokenizer regex in its remote code; only the special
+tokens of tokenizer_config.json differ. The reference is tiktoken.Encoding
+built exactly as tokenization_kimi.py builds it.
+"""
+
+import json
+
+import pytest
+import tiktoken
+from tiktoken.load import load_tiktoken_bpe
+
+from hf_cache import hf_file
+
+from gigatoken import Tokenizer
+
+# The full Kimi/Moonlight line: one shared tiktoken.model, per-repo specials.
+KIMI_REPOS = [
+    "moonshotai/Kimi-K2-Base",
+    "moonshotai/Kimi-K2-Instruct",
+    "moonshotai/Kimi-K2-Instruct-0905",
+    "moonshotai/Kimi-K2-Thinking",
+    "moonshotai/Kimi-K2.5",
+    "moonshotai/Kimi-K2.6",
+    "moonshotai/Kimi-K2.7-Code",
+    "moonshotai/Kimi-Linear-48B-A3B-Instruct",
+    "moonshotai/Kimi-VL-A3B-Instruct",
+    "moonshotai/Moonlight-16B-A3B-Instruct",
+]
+
+# The pat_str of tokenization_kimi.py / tokenization_moonshot.py (identical
+# across the line).
+KIMI_PAT = "|".join(
+    [
+        r"""[\p{Han}]+""",
+        r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+        r"""[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]+[\p{Ll}\p{Lm}\p{Lo}\p{M}&&[^\p{Han}]]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?""",
+        r"""\p{N}{1,3}""",
+        r""" ?[^\s\p{L}\p{N}]+[\r\n]*""",
+        r"""\s*[\r\n]+""",
+        r"""\s+(?!\S)""",
+        r"""\s+""",
+    ]
+)
+
+TEXTS = [
+    "Hello, world! The quick brown fox jumps over the lazy dog.",
+    "I'll say we've done what they'd want, it's John's turn, WE'VE SHOUTED",
+    "人工智能正在改变世界。月之暗面公司发布了Kimi大模型，支持超长上下文。",
+    "使用Python调用API接口，每秒处理1000个请求。模型参数量达到1万亿。",
+    "日本語のテキスト。漢字とひらがなカタカナが混在。한국어 텍스트입니다.",
+    "1234567890 3.14159 v2.6 100,000,000 2026-07-18 一二三〇",
+    "path/to/file http://example.com/a/b a/\nb /usr/bin\n/ etc",
+    "}\n/// doc comment\n//! module doc\n*/\n/**\n.\n//x",
+    "def foo(x: int) -> int:\n    return x + 1\n",
+    "café résumé naïve Ñoño año Zürich İstanbul ﬁnancial",
+    "emoji: 🚀🌍🎉 mixed hello 世界 🌎 done",
+    "中English文 abc中文def A中B 中's 中'se ⼀⼁ 々中〇",
+    "   \n\n\t\r\n   ",
+]
+
+
+@pytest.fixture(scope="session", params=KIMI_REPOS)
+def repo_id(request) -> str:
+    return request.param
+
+
+@pytest.fixture(scope="session")
+def kimi_reference(repo_id) -> tiktoken.Encoding:
+    """The reference encoder, built exactly as tokenization_kimi.py does."""
+    ranks = load_tiktoken_bpe(str(hf_file(repo_id, "tiktoken.model")))
+    config = json.loads(hf_file(repo_id, "tokenizer_config.json").read_bytes())
+    specials = {
+        t["content"]: int(i) for i, t in config["added_tokens_decoder"].items()
+    }
+    return tiktoken.Encoding(
+        name=repo_id, pat_str=KIMI_PAT, mergeable_ranks=ranks, special_tokens=specials
+    )
+
+
+@pytest.fixture(scope="session")
+def kimi_tok(repo_id) -> Tokenizer:
+    return Tokenizer(repo_id)
+
+
+def test_loads_with_specials(repo_id, kimi_tok, kimi_reference):
+    """The repo loads from its id, with the config's special tokens."""
+    assert kimi_tok._special_tokens() == kimi_reference._special_tokens
+
+
+def test_parity_plain_text(kimi_tok, kimi_reference):
+    for text in TEXTS:
+        expected = kimi_reference.encode(text, allowed_special=set())
+        actual = kimi_tok.encode(text).tolist()
+        assert actual == expected, f"Mismatch on {text!r}"
+
+
+def test_parity_special_tokens(kimi_tok, kimi_reference):
+    """Special tokens in the input are matched atomically, like the
+    reference with allowed_special='all'."""
+    specials = sorted(kimi_reference._special_tokens)[:6]
+    text = "".join(f"before {s} after中文" for s in specials)
+    expected = kimi_reference.encode(text, allowed_special="all")
+    assert kimi_tok.encode(text).tolist() == expected
+
+
+def test_decode_roundtrip(kimi_tok, kimi_reference):
+    for text in TEXTS:
+        ids = kimi_reference.encode(text, allowed_special=set())
+        assert kimi_tok.decode(ids) == text.encode()
+
+
+def test_batch_matches_single(kimi_tok):
+    docs = [t.encode() for t in TEXTS]
+    batched = kimi_tok.encode_batch_list(docs)
+    singles = [kimi_tok.encode(d).tolist() for d in docs]
+    assert batched == singles
+
+
+def test_load_from_model_path_and_dir(kimi_reference):
+    """A tiktoken.model path or its directory load like the repo id."""
+    model_path = hf_file("moonshotai/Kimi-K2.6", "tiktoken.model")
+    hf_file("moonshotai/Kimi-K2.6", "tokenizer_config.json")
+    text = TEXTS[2]
+    expected = kimi_reference.encode(text, allowed_special=set())
+    for source in (model_path, model_path.parent):
+        tok = Tokenizer(source)
+        assert tok.encode(text).tolist() == expected


### PR DESCRIPTION
Adds full support for the moonshotai Kimi/Moonlight line (Kimi-K2 Base/Instruct/0905/Thinking, K2.5, K2.6, K2.7-Code, Kimi-Linear, Kimi-VL, Moonlight) — e.g. `Tokenizer("moonshotai/Kimi-K2.6")` now loads and encodes token-exactly.

## Background

These repos ship no `tokenizer.json`: a byte-identical `tiktoken.model` rank file across all 10 repos, per-repo special tokens in `tokenizer_config.json`, and the pretokenizer regex in remote code (`tokenization_kimi.py`). The pattern is the o200k scheme with three edits: a leading `[\p{Han}]+` alternative, Han evicted from both letter brackets (`[...&&[^\p{Han}]]`), and no `/` in the absorbed punct tail (`[\r\n]*`, not `[\r\n/]*`). Plain o200k gets surprisingly close (OWT encodes identically) but diverges on Rust-style `}\n///` doc comments and Han-adjacent contractions, so it needs its own scheme.

## Changes

- **`PretokenizerType::Kimi`** as a fourth o200k-family member via two new const generics on the shared scanner: `SLASH` (slash in the absorbed tail class) and `HAN`. o200k and Nemotron instantiate the old behavior; the pure-ASCII fast path is untouched by `HAN`.
- **`KimiCharClass`** (unicode.rs): o200k classes with Script=Han split out, built from ICU. The `[\p{Han}]+` alternative only wins where a token *starts* — mid-run, a Han numeral (`〇`, Nl) still counts inside `\p{N}{1,3}` and a Han symbol (Kangxi radicals So; the two Han-script marks U+16FF0/1) still continues a punct run. Han letters get a real mask-scanner boundary rule (`han_leads & !prev-is-han`); the two rare contextual classes defer to the scalar path via the existing resid/mk machinery.
- **Loader**: `load_tokenizer::tiktoken::load_kimi` + `BPETokenizer.from_kimi(model_path, config_path)` — ranks, Kimi scheme, specials from `added_tokens_decoder` (no `<|endoftext|>` stamped over `[BOS]` like the plain tiktoken loader would).
- **Python**: `Tokenizer(source)` falls back to the tiktoken.model format for repo ids, directories, and `tiktoken.model` paths, gated on `tokenizer_class == "TikTokenTokenizer"` so unknown tiktoken-based repos aren't silently mis-tokenized.

## Verification

Reference is `tiktoken.Encoding` built exactly as the remote code builds it (same pat_str + specials):

- `tests/test_kimi.py`: all 10 repos × (load/specials, plain-text parity, special-token parity, decode roundtrip, batch==single, path/dir loading).
- Token-exact at scale: 5079/5079 OWT docs, 89/89 repo source files (includes `\n///` shapes and a literal `<|im_end|>` in text), 20,000/20,000 adversarial fuzz strings over the Kimi-vs-o200k divergence constructs, and a zh-Wikipedia article.
- Scanner-internal: fast-vs-fancy_regex exact on the o200k small-case list, ~60 new Han cases, 6,000 rounds of Han codepoint soup, and 5 MB of OWT; mask-vs-scalar differential exact across the full ~12 GB OWT (2.37B tokens per scheme). New Han pieces added to the family fuzz pools.
- No regressions: full `cargo test --release` and Python suites pass. MT throughput ~5.4 GB/s on OWT (family-typical); pure-Chinese ST ~0.5 GB/s (all chars take the non-ASCII extended path).