### PR TITLE
Config-driven tokenizer dispatch; generalize the Kimi loader

### DIFF
--- a/gigatoken/_load/hf.py
+++ b/gigatoken/_load/hf.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias, cast
 
 from gigatoken._load.hub import download_hub_file, looks_like_repo_id
 
@@ -54,43 +54,103 @@ def load_hf_tokenizer(pretrained_model_name_or_path: str) -> transformers.PreTra
     return cast("transformers.PreTrainedTokenizerBase", tokenizer)
 
 
-def try_load_kimi(source: str | os.PathLike[str]) -> "tuple[object, dict[str, int]] | None":
-    """Load a moonshotai Kimi-style tokenizer — `tiktoken.model` ranks plus
-    the special tokens of a sibling tokenizer_config.json declaring the
-    moonshot `TikTokenTokenizer` class (the K2/VL/Moonlight repos ship no
-    tokenizer.json; they all share one rank file and the Kimi pretokenizer
-    from their remote code). Accepts a Hub repo id, a directory, or a path
-    to the tiktoken.model itself. Returns `(BPETokenizer, special_tokens)`,
-    or None when `source` is not such a tokenizer."""
+class TokenizerLine(NamedTuple):
+    """A tokenizer line whose repos ship no tokenizer.json, identified by the
+    tokenizer_config.json `tokenizer_class` and remote-code `auto_map` module.
+    The split regex of such a line lives only in its remote code — no shipped
+    file declares it — so each entry names the matching pretokenizer scheme
+    implemented in Rust (`PretokenizerType`)."""
+
+    tokenizer_class: str
+    auto_map_modules: tuple[str, ...]
+    vocab_file: str
+    pretokenizer: str
+
+
+# The registered lines. Add an entry (and, if needed, a Rust scheme) to
+# support a new non-tokenizer.json tokenizer family.
+TOKENIZER_LINES = (
+    # moonshotai Kimi/Moonlight (K2/K2.5/K2.6/K2.7, Linear, VL, Moonlight):
+    # one shared rank file, per-repo specials, Kimi split regex.
+    TokenizerLine(
+        tokenizer_class="TikTokenTokenizer",
+        auto_map_modules=("tokenization_kimi", "tokenization_moonshot"),
+        vocab_file="tiktoken.model",
+        pretokenizer="kimi",
+    ),
+)
+
+
+def _match_tokenizer_line(config: dict[str, object]) -> TokenizerLine | None:
+    """The registered line a tokenizer_config.json identifies, or None.
+
+    Matches on `tokenizer_class`, and when the config carries a remote-code
+    `auto_map`, also on its module name — the class name alone is just the
+    remote class's chosen name, which another org could reuse for a
+    different regex."""
+    auto_map = config.get("auto_map")
+    entry = auto_map.get("AutoTokenizer") if isinstance(auto_map, dict) else None
+    if isinstance(entry, (list, tuple)):
+        entry = next((e for e in entry if e), None)
+    module = str(entry).split(".")[0] if entry else None
+    for line in TOKENIZER_LINES:
+        if config.get("tokenizer_class") != line.tokenizer_class:
+            continue
+        if module is not None and module not in line.auto_map_modules:
+            continue
+        return line
+    return None
+
+
+def try_load_from_config(source: str | os.PathLike[str]) -> "tuple[object, dict[str, int]] | None":
+    """Config-driven dispatch: resolve `source`'s tokenizer_config.json and,
+    when it identifies a registered [`TokenizerLine`], load that line's vocab
+    file with its pretokenizer scheme and the config's special tokens.
+
+    Accepts a Hub repo id, a directory, or a path to a registered vocab file
+    itself (e.g. a tiktoken.model, with the config as its sibling). Returns
+    `(BPETokenizer, special_tokens)`, or None when the config is absent or
+    identifies no registered line — then the tokenizer.json path applies."""
     import json
 
     from gigatoken.gigatoken_rs import BPETokenizer, hub_file
 
     path = Path(cast("str | os.PathLike[str]", source))
-    if path.is_file() and path.name == "tiktoken.model":
-        model, config = path, path.parent / "tokenizer_config.json"
+    is_repo = False
+    if path.is_file() and any(path.name == line.vocab_file for line in TOKENIZER_LINES):
+        config = path.parent / "tokenizer_config.json"
     elif path.is_dir():
-        model, config = path / "tiktoken.model", path / "tokenizer_config.json"
+        config = path / "tokenizer_config.json"
     elif isinstance(source, str) and looks_like_repo_id(source):
+        is_repo = True
         try:
-            model = hub_file(source, "tiktoken.model")
             config = hub_file(source, "tokenizer_config.json")
         except Exception:
+            # No config in the repo (or it is unreachable): nothing to
+            # dispatch on; let the tokenizer.json path report the failure.
             return None
     else:
         return None
-    if not (model.is_file() and config.is_file()):
+    if not config.is_file():
         return None
     config_json = json.loads(config.read_bytes())
-    if config_json.get("tokenizer_class") != "TikTokenTokenizer":
-        # A tiktoken rank file with some other remote-code tokenizer class:
-        # its pretokenizer regex is unknown, so don't guess.
+    line = _match_tokenizer_line(config_json)
+    if line is None:
         return None
-    specials = {
-        str(t["content"]): int(i)
-        for i, t in (config_json.get("added_tokens_decoder") or {}).items()
-    }
-    return BPETokenizer.from_kimi(model, config), specials
+    if is_repo:
+        model = hub_file(cast(str, source), line.vocab_file)
+    elif path.is_dir():
+        model = path / line.vocab_file
+    elif path.name == line.vocab_file:
+        model = path
+    else:
+        # A vocab-file path of one line whose sibling config identifies
+        # another: trust the config and load its line's vocab file.
+        model = path.parent / line.vocab_file
+    if not model.is_file():
+        return None
+    specials = {str(t["content"]): int(i) for i, t in (config_json.get("added_tokens_decoder") or {}).items()}
+    return BPETokenizer.from_tiktoken_model(model, config, line.pretokenizer), specials
 
 
 def to_tokenizer_json(source: TokenizerJsonSource) -> str | bytes:

--- a/gigatoken/_tokenizer.py
+++ b/gigatoken/_tokenizer.py
@@ -6,7 +6,7 @@ import json
 import os
 from typing import TYPE_CHECKING, Any
 
-from gigatoken._load.hf import capture_named_special_tokens, to_tokenizer_json, try_load_kimi
+from gigatoken._load.hf import capture_named_special_tokens, to_tokenizer_json, try_load_from_config
 from gigatoken._parallel import resolve_parallel
 from gigatoken.gigatoken_rs import BPETokenizer, PadTruncate, SentencePieceTokenizer, load_hf_json
 
@@ -68,18 +68,16 @@ class Tokenizer:
         elif isinstance(tokenizer, _BACKEND_TYPES):
             self._backend = tokenizer
         else:
-            try:
-                data = to_tokenizer_json(tokenizer)
-            except Exception:
-                # No tokenizer.json: a moonshot-style repo (Kimi/Moonlight)
-                # carries its vocab in tiktoken.model instead.
-                loaded = (
-                    try_load_kimi(tokenizer) if isinstance(tokenizer, (str, os.PathLike)) else None
-                )
-                if loaded is None:
-                    raise
-                self._backend, self._tiktoken_specials = loaded
-                return
+            if isinstance(tokenizer, (str, os.PathLike)):
+                # Config-driven dispatch: tokenizer_config.json names the
+                # tokenizer implementation (tokenizer_class/auto_map); repos
+                # of a registered line (e.g. Kimi/Moonlight) ship no
+                # tokenizer.json and load from their line's vocab file.
+                loaded = try_load_from_config(tokenizer)
+                if loaded is not None:
+                    self._backend, self._tiktoken_specials = loaded
+                    return
+            data = to_tokenizer_json(tokenizer)
             self._backend = load_hf_json(data)
             self._hf_json = data
             if not isinstance(tokenizer, (str, os.PathLike)):

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -154,10 +154,12 @@ class BPETokenizer:
     @staticmethod
     def from_tiktoken(path: str | Path) -> "BPETokenizer": ...
     @staticmethod
-    def from_kimi(model_path: str | Path, config_path: str | Path) -> "BPETokenizer":
-        """Load a moonshotai Kimi-style tokenizer: `tiktoken.model` ranks
-        plus the special tokens from a tokenizer_config.json, with the Kimi
-        pretokenizer (the K2-family repos ship no tokenizer.json)."""
+    def from_tiktoken_model(model_path: str | Path, config_path: str | Path, pretokenizer: str) -> "BPETokenizer":
+        """Load from a tiktoken rank file plus a tokenizer_config.json
+        carrying the special tokens — the layout of repos that ship no
+        tokenizer.json (e.g. the moonshotai Kimi line) — with the named
+        pretokenizer scheme ("gpt2", "gpt4", "qwen2", "qwen35", "olmo3",
+        "deepseek_v3", "o200k", "nemotron", or "kimi")."""
     @staticmethod
     def from_hf(path: str | Path) -> "BPETokenizer": ...
     def __repr__(self) -> str: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,23 @@ impl BPETokenizer {
             workers: WorkerPool::new(),
         })
     }
-    /// Load a moonshotai Kimi-style tokenizer: `tiktoken.model` ranks plus
-    /// the special tokens from a tokenizer_config.json, with the Kimi
-    /// pretokenizer (the K2-family repos ship no tokenizer.json).
+    /// Load from a tiktoken rank file plus a tokenizer_config.json carrying
+    /// the special tokens — the layout of repos that ship no tokenizer.json
+    /// (e.g. the moonshotai Kimi line) — with the named pretokenizer scheme.
     #[staticmethod]
-    fn from_kimi(model_path: PathBuf, config_path: PathBuf) -> PyResult<Self> {
+    fn from_tiktoken_model(
+        model_path: PathBuf,
+        config_path: PathBuf,
+        pretokenizer: &str,
+    ) -> PyResult<Self> {
+        let scheme = pretokenize::PretokenizerType::from_name(pretokenizer).ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "unknown pretokenizer scheme {pretokenizer:?}; expected one of \
+                 gpt2, gpt4, qwen2, qwen35, olmo3, deepseek_v3, o200k, nemotron, kimi"
+            ))
+        })?;
         Ok(Self {
-            tokenizer: load_tokenizer::tiktoken::load_kimi(&model_path, &config_path)?,
+            tokenizer: load_tokenizer::tiktoken::load_tiktoken_model(&model_path, &config_path, scheme)?,
             workers: WorkerPool::new(),
         })
     }

--- a/src/load_tokenizer/tiktoken.rs
+++ b/src/load_tokenizer/tiktoken.rs
@@ -38,7 +38,7 @@ pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
     Ok(tokenizer)
 }
 
-/// The fields of a HuggingFace tokenizer_config.json a tiktoken.model repo
+/// The fields of a HuggingFace tokenizer_config.json a tiktoken-rank repo
 /// needs: the special tokens (there is no tokenizer.json to carry them).
 #[derive(serde::Deserialize)]
 struct TokenizerConfigJson {
@@ -51,20 +51,21 @@ struct AddedTokenJson {
     content: String,
 }
 
-/// Load a moonshotai Kimi-style tokenizer: a `tiktoken.model` rank file
-/// plus a `tokenizer_config.json` whose `added_tokens_decoder` carries the
-/// special tokens (the repos ship no tokenizer.json; the pretokenizer
-/// regex lives in their `tokenization_kimi.py` and is the [`Kimi`
-/// scheme](PretokenizerType::Kimi)). Every Kimi/Moonlight repo shares one
-/// rank file and differs only in this special-token map.
-pub fn load_kimi(
+/// Load a tokenizer from a tiktoken rank file plus a HuggingFace
+/// `tokenizer_config.json` whose `added_tokens_decoder` carries the special
+/// tokens — the layout of repos that ship no tokenizer.json (e.g. the
+/// moonshotai Kimi/Moonlight line's `tiktoken.model`). The pretokenizer
+/// scheme is passed by the caller: such repos define their split regex only
+/// in remote code, so no shipped file can name it.
+pub fn load_tiktoken_model(
     model_path: impl AsRef<Path>,
     config_path: impl AsRef<Path>,
+    pretokenizer: PretokenizerType,
 ) -> Result<Tokenizer> {
     let rank_vocab = load_tiktoken_ranks(model_path)?;
     let n_ranks = rank_vocab.len() as u32;
     let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
-    tokenizer.set_pretokenizer_type(PretokenizerType::Kimi);
+    tokenizer.set_pretokenizer_type(pretokenizer);
     let config_path = config_path.as_ref();
     let config: TokenizerConfigJson = sonic_rs::from_slice(
         &std::fs::read(config_path)

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -66,6 +66,25 @@ impl PretokenizerType {
         }
     }
 
+    /// The scheme named by a lowercase identifier, as used by loaders whose
+    /// source format carries no split regex (e.g. tiktoken-rank repos, whose
+    /// regex lives in remote code) and the Python bindings. Accepts each
+    /// variant's canonical name plus the common tiktoken aliases.
+    pub fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "gpt2" | "r50k" => PretokenizerType::GPT2,
+            "gpt4" | "cl100k" => PretokenizerType::GPT4,
+            "qwen2" => PretokenizerType::Qwen2,
+            "qwen35" => PretokenizerType::Qwen35,
+            "olmo3" => PretokenizerType::Olmo3,
+            "deepseek_v3" => PretokenizerType::DeepSeekV3,
+            "o200k" => PretokenizerType::O200k,
+            "nemotron" => PretokenizerType::Nemotron,
+            "kimi" => PretokenizerType::Kimi,
+            _ => return None,
+        })
+    }
+
     /// Identify the scheme from the ordered list of `Split` regexes found in
     /// a HuggingFace `tokenizer.json` pre_tokenizer. Returns `None` for
     /// unknown patterns.

--- a/tests/test_config_dispatch.py
+++ b/tests/test_config_dispatch.py
@@ -1,0 +1,80 @@
+"""Unit tests for the tokenizer_config.json-driven load dispatch.
+
+End-to-end loading of a registered line (repo id, directory, and vocab-file
+path) is covered by test_kimi.py; here the dispatch decisions themselves.
+"""
+
+import json
+
+import pytest
+
+from gigatoken._load.hf import TOKENIZER_LINES, _match_tokenizer_line, try_load_from_config
+
+KIMI_CONFIG = {
+    "tokenizer_class": "TikTokenTokenizer",
+    "auto_map": {"AutoTokenizer": ["tokenization_kimi.TikTokenTokenizer", None]},
+}
+
+
+def test_matches_registered_line():
+    line = _match_tokenizer_line(KIMI_CONFIG)
+    assert line is not None
+    assert line.vocab_file == "tiktoken.model"
+    assert line.pretokenizer == "kimi"
+
+
+def test_matches_all_registered_auto_map_modules():
+    for line in TOKENIZER_LINES:
+        for module in line.auto_map_modules:
+            config = {
+                "tokenizer_class": line.tokenizer_class,
+                "auto_map": {"AutoTokenizer": [f"{module}.{line.tokenizer_class}", None]},
+            }
+            assert _match_tokenizer_line(config) == line
+
+
+def test_matches_by_class_without_auto_map():
+    assert _match_tokenizer_line({"tokenizer_class": "TikTokenTokenizer"}) is not None
+
+
+def test_rejects_class_name_collision():
+    """Another org's remote-code class reusing the name TikTokenTokenizer
+    (different module, so possibly a different regex) must not match."""
+    config = {
+        "tokenizer_class": "TikTokenTokenizer",
+        "auto_map": {"AutoTokenizer": ["tokenization_other.TikTokenTokenizer", None]},
+    }
+    assert _match_tokenizer_line(config) is None
+
+
+def test_rejects_unregistered_class():
+    assert _match_tokenizer_line({"tokenizer_class": "PreTrainedTokenizerFast"}) is None
+    assert _match_tokenizer_line({}) is None
+
+
+def test_auto_map_string_form():
+    """auto_map values may be a plain string instead of a [fast, slow] pair."""
+    config = {
+        "tokenizer_class": "TikTokenTokenizer",
+        "auto_map": {"AutoTokenizer": "tokenization_kimi.TikTokenTokenizer"},
+    }
+    assert _match_tokenizer_line(config) is not None
+
+
+def test_dispatch_returns_none_for_unregistered_dir(tmp_path):
+    """A directory whose config identifies no registered line falls through
+    to the tokenizer.json path (None), without touching any vocab file."""
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({"tokenizer_class": "PreTrainedTokenizerFast"}))
+    assert try_load_from_config(tmp_path) is None
+
+
+def test_dispatch_returns_none_without_config(tmp_path):
+    assert try_load_from_config(tmp_path) is None
+    assert try_load_from_config(tmp_path / "missing") is None
+
+
+def test_unknown_scheme_rejected():
+    from gigatoken.gigatoken_rs import BPETokenizer
+
+    with pytest.raises(ValueError, match="unknown pretokenizer scheme"):
+        BPETokenizer.from_tiktoken_model("x", "y", "not-a-scheme")

--- a/tests/test_load_hf.py
+++ b/tests/test_load_hf.py
@@ -34,7 +34,17 @@ def hub_server(gpt2_tokenizer_path):
     class Handler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             requests.append((self.path, self.headers.get("Authorization")))
-            if self.path == "/openai-community/gpt2/resolve/main/tokenizer.json":
+            if self.path == "/openai-community/gpt2/resolve/main/tokenizer_config.json":
+                # Non-LFS files answer directly with 200 + x-repo-commit, no
+                # CDN redirect. The config-first dispatch fetches this before
+                # tokenizer.json; a plain class name routes to the json path.
+                body = b'{"tokenizer_class": "GPT2Tokenizer"}'
+                self.send_response(200)
+                self.send_header("x-repo-commit", commit)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif self.path == "/openai-community/gpt2/resolve/main/tokenizer.json":
                 self.send_response(302)
                 self.send_header("x-repo-commit", commit)
                 self.send_header("Location", "/cdn/tokenizer.json")
@@ -60,11 +70,12 @@ def hub_server(gpt2_tokenizer_path):
 
 
 def test_tokenizer_from_repo_id_downloads_into_cache(monkeypatch, tmp_path, hub_server):
-    """On a cache miss the file is fetched from the endpoint (no
-    huggingface_hub involved) and lands in the standard HF cache layout under
-    the commit from x-repo-commit; the token travels only to the resolve URL,
-    not to the redirect target; a reload is served from the cache with no
-    request. HF_HOME points at an empty directory so the fast path misses."""
+    """On a cache miss the files (the tokenizer_config.json dispatch probe,
+    then tokenizer.json) are fetched from the endpoint (no huggingface_hub
+    involved) and land in the standard HF cache layout under the commit from
+    x-repo-commit; the token travels only to the resolve URL, not to the
+    redirect target; a reload is served from the cache with no request.
+    HF_HOME points at an empty directory so the fast path misses."""
     endpoint, commit, requests = hub_server
     monkeypatch.delenv("HF_HUB_CACHE", raising=False)
     monkeypatch.setenv("HF_HOME", str(tmp_path))
@@ -74,6 +85,7 @@ def test_tokenizer_from_repo_id_downloads_into_cache(monkeypatch, tmp_path, hub_
     tokenizer = Tokenizer("openai-community/gpt2")
     assert tokenizer.decode(tokenizer.encode("Hello, world!")) == b"Hello, world!"
     assert requests == [
+        ("/openai-community/gpt2/resolve/main/tokenizer_config.json", "Bearer hf_testtoken"),
         ("/openai-community/gpt2/resolve/main/tokenizer.json", "Bearer hf_testtoken"),
         ("/cdn/tokenizer.json", None),
     ]
@@ -84,7 +96,7 @@ def test_tokenizer_from_repo_id_downloads_into_cache(monkeypatch, tmp_path, hub_
 
     tokenizer = Tokenizer("openai-community/gpt2")
     assert tokenizer.decode(tokenizer.encode("Hello, world!")) == b"Hello, world!"
-    assert len(requests) == 2, "second load must be served from the cache"
+    assert len(requests) == 3, "second load must be served from the cache"
 
 
 def test_tokenizer_from_repo_id_cache_fast_path(monkeypatch, tmp_path, gpt2_tokenizer_path):
@@ -101,6 +113,7 @@ def test_tokenizer_from_repo_id_cache_fast_path(monkeypatch, tmp_path, gpt2_toke
     snapshot = repo_dir / "snapshots" / commit
     snapshot.mkdir(parents=True)
     (snapshot / "tokenizer.json").write_bytes(gpt2_tokenizer_path.read_bytes())
+    (snapshot / "tokenizer_config.json").write_text('{"tokenizer_class": "GPT2Tokenizer"}')
 
     tokenizer = Tokenizer("openai-community/gpt2")
     assert tokenizer.decode(tokenizer.encode("Hello, world!")) == b"Hello, world!"


### PR DESCRIPTION
## Summary

- Loading from a repo id, directory, or vocab-file path now dispatches on `tokenizer_config.json` as the prime source: `try_load_from_config` resolves it first and routes on `tokenizer_class`/`auto_map`, replacing the exception-driven `try_load_kimi` fallback in `Tokenizer.__init__`.
- A `TOKENIZER_LINES` registry maps (`tokenizer_class`, `auto_map` module) to a vocab filename and pretokenizer scheme for tokenizer lines that ship no tokenizer.json (currently the moonshotai Kimi/Moonlight line). Configs matching no registered line fall through to the normal tokenizer.json path, so supporting a future family is a registry entry, not a new bespoke loader.
- Matching now also checks the `auto_map` module (`tokenization_kimi`/`tokenization_moonshot`): another org reusing the class name `TikTokenTokenizer` with an unknown regex no longer matches. Previously the gate was the class name alone.
- The Rust loader is generalized: `load_kimi`/`BPETokenizer.from_kimi` become `load_tiktoken_model`/`from_tiktoken_model(model_path, config_path, pretokenizer)` with the scheme named by string (`PretokenizerType::from_name`). The ranks + `added_tokens_decoder` loading was never Kimi-specific — only the hardcoded scheme was, and the split regex exists solely in each line's remote code, so no shipped file can declare it.

Cost of config-as-prime-source: a fresh repo load fetches `tokenizer_config.json` in addition to tokenizer.json (one extra Hub request, cached afterward).

## Testing

- New `tests/test_config_dispatch.py` unit-tests the line matching (auto_map module gate, string-form auto_map, name-collision rejection) and dispatch fall-through, plus the unknown-scheme error.
- `tests/test_load_hf.py`'s fake Hub server now serves a `tokenizer_config.json` (as the real gpt2 repo does) and asserts the new request sequence; the cache fast-path test seeds a cached config so it stays request-free.
- Full suite green: 1434 Python tests passed (8 skipped), Rust `cargo test --release` all green, including the 60 Kimi parity tests against the tiktoken reference.