### PR TITLE
Support fairseq-ordered vocabs, added-token lstrip/rstrip, and ByteLevel add_prefix_space

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -173,7 +173,7 @@ fn build_doc_chunks<'a>(
     docs: &[&'a [u8]],
     total: usize,
     target: usize,
-    added_tokens: &[&[u8]],
+    added_tokens: &[(&[u8], bool)],
     lpt: bool,
 ) -> Vec<EncodeChunk<'a>> {
     let (head_bytes, group_big, frag_big, tail_target) = if lpt {
@@ -246,7 +246,7 @@ fn push_fragment_chunks<'a>(
     head_len: usize,
     big: usize,
     tail_target: usize,
-    added_tokens: &[&[u8]],
+    added_tokens: &[(&[u8], bool)],
 ) {
     let mut first = true;
     for r in crate::pretokenize::safe_split_ranges(doc, big, added_tokens) {
@@ -757,7 +757,7 @@ pub(crate) fn encode_docs_ragged_with(
     lpt: bool,
 ) -> (Vec<u32>, Vec<i64>) {
     let total: usize = docs.iter().map(|d| d.len()).sum();
-    let added = proto.added_token_contents();
+    let added = proto.added_token_split_blockers();
     let chunks = build_doc_chunks(docs, total, chunk_target_bytes(total), &added, lpt);
     encode_chunks_gathered(workers, proto, &chunks, total)
 }
@@ -1040,8 +1040,8 @@ mod tests {
         use std::io::Read;
         let tokenizer_path = crate::test_hub::gpt2_tokenizer_json();
         let proto = load_hf_bpe(&tokenizer_path).expect("load GPT-2 tokenizer");
-        let added = proto.added_token_contents();
-        let sep: Vec<u8> = added.first().expect("GPT-2 has an added token").to_vec();
+        let added = proto.added_token_split_blockers();
+        let sep: Vec<u8> = added.first().expect("GPT-2 has an added token").0.to_vec();
 
         let path = std::env::home_dir().unwrap().join("data/owt_train.txt");
         let f = std::fs::File::open(&path).expect("open ~/data/owt_train.txt");
@@ -1153,7 +1153,7 @@ mod tests {
         let owned: Vec<Vec<u8>> = (0..20).map(|_| text(1 << 20)).collect();
         let docs: Vec<&[u8]> = owned.iter().map(|d| d.as_slice()).collect();
         let total: usize = docs.iter().map(|d| d.len()).sum();
-        let added = proto.added_token_contents();
+        let added = proto.added_token_split_blockers();
         let chunks = build_doc_chunks(&docs, total, chunk_target_bytes(total), &added, true);
         assert!(chunks.len() > 1, "test must exercise the parallel path");
 

--- a/src/bpe/mod.rs
+++ b/src/bpe/mod.rs
@@ -919,6 +919,20 @@ fn bpe_merge_symbols_ranked_small<S: std::hash::BuildHasher>(
     merges: &HashMap<u64, (TokenId, u32), S>,
     symbols: &mut Vec<TokenId>,
 ) {
+    let n = symbols.len();
+    let new_len = bpe_merge_symbols_ranked_slice(merges, &mut symbols[..n]);
+    symbols.truncate(new_len);
+}
+
+/// Slice core of [`bpe_merge_symbols_ranked_small`], shared with the ByteLevel
+/// tokenizer's stack-buffer miss path for rank-mapped vocabularies (fairseq
+/// heritage: RoBERTa/OPT, where vocab IDs are frequency-ordered and carry no
+/// rank information). Merges `symbols` in place and returns the surviving
+/// count; the caller truncates or slices to it.
+pub(crate) fn bpe_merge_symbols_ranked_slice<S: std::hash::BuildHasher>(
+    merges: &HashMap<u64, (TokenId, u32), S>,
+    symbols: &mut [TokenId],
+) -> usize {
     let get = |a: TokenId, b: TokenId| -> (TokenId, u32) {
         merges
             .get(&ranked_merge_key(a, b))
@@ -979,7 +993,7 @@ fn bpe_merge_symbols_ranked_small<S: std::hash::BuildHasher>(
         write += 1;
         i = next[i] as usize;
     }
-    symbols.truncate(write);
+    write
 }
 
 /// Apply BPE merges using explicit merge ranks for priority (lower rank = first).

--- a/src/bpe/mod.rs
+++ b/src/bpe/mod.rs
@@ -914,21 +914,10 @@ pub fn ranked_merge_key(a: TokenId, b: TokenId) -> u64 {
 
 /// Ranked-merge variant of [`bpe_merge_symbols_small`]: allocation-free BPE
 /// for short symbol sequences (the overwhelming majority of cache-missing
-/// units), with priority taken from the merge table's explicit rank.
-fn bpe_merge_symbols_ranked_small<S: std::hash::BuildHasher>(
-    merges: &HashMap<u64, (TokenId, u32), S>,
-    symbols: &mut Vec<TokenId>,
-) {
-    let n = symbols.len();
-    let new_len = bpe_merge_symbols_ranked_slice(merges, &mut symbols[..n]);
-    symbols.truncate(new_len);
-}
-
-/// Slice core of [`bpe_merge_symbols_ranked_small`], shared with the ByteLevel
-/// tokenizer's stack-buffer miss path for rank-mapped vocabularies (fairseq
-/// heritage: RoBERTa/OPT, where vocab IDs are frequency-ordered and carry no
-/// rank information). Merges `symbols` in place and returns the surviving
-/// count; the caller truncates or slices to it.
+/// units), with priority taken from the merge table's explicit rank. Also
+/// the stack-buffer miss path of the ByteLevel tokenizer for rank-mapped
+/// vocabularies (see `ranked_merges` there). Merges `symbols` in place and
+/// returns the surviving count; the caller truncates or slices to it.
 pub(crate) fn bpe_merge_symbols_ranked_slice<S: std::hash::BuildHasher>(
     merges: &HashMap<u64, (TokenId, u32), S>,
     symbols: &mut [TokenId],
@@ -1017,7 +1006,8 @@ pub fn bpe_merge_symbols_ranked<S: std::hash::BuildHasher>(
     // Short sequences (the overwhelming majority of word units) skip the
     // heap and its allocations entirely.
     if n <= SMALL_MERGE_MAX {
-        bpe_merge_symbols_ranked_small(merges, symbols);
+        let new_len = bpe_merge_symbols_ranked_slice(merges, symbols);
+        symbols.truncate(new_len);
         return;
     }
 

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -67,7 +67,7 @@ pub struct Tokenizer {
     pub(crate) pretokenizer_type: PretokenizerType,
     /// Added tokens (special and non-special), matched atomically in the raw
     /// input before pretokenization, like HuggingFace's AddedVocabulary.
-    added_tokens: Vec<AddedTok>,
+    added_tokens: Vec<AddedTokenDef>,
     /// Leftmost-longest Aho-Corasick automaton over `added_tokens` contents
     /// (pattern index == `added_tokens` index). A prebuilt automaton keeps the
     /// scan fast even when an added token starts with a byte that is common in
@@ -161,22 +161,13 @@ fn unpack_val_lanes(val: u64, ext: u64) -> [u32; 4] {
     ]
 }
 
-/// Overwrite the short-cache entry of every added-token content of 1..=15
-/// bytes that resolves in `vocab_inv` with that single ID, so a matching
-/// pretoken encodes as the added token rather than its merge decomposition.
-///
-/// This function IS the cache-seed sync invariant: the short cache's
-/// seed-level state is always "vocab seed, then these overwrites" — a pure
-/// function of `(vocab, added_tokens)` — because both
-/// [`Tokenizer::set_added_tokens`] (on the parent) and
-/// [`Tokenizer::fork_sized`] (after a fork's fresh reseed) apply the
-/// overwrites through this one body, so parent and forked workers always
-/// agree on every short pretoken.
 /// One piece of the added-token pipeline walk (see
 /// [`Tokenizer::for_each_piece`]): a between-occurrences text segment to
-/// pretokenize and encode, or an added token's ID to emit verbatim.
+/// pretokenize and encode (paired with its source byte offset, which only
+/// the verify-heavy differential reads), or an added token's ID to emit
+/// verbatim.
 enum Piece<'a> {
-    Segment(&'a [u8]),
+    Segment(&'a [u8], usize),
     Added(TokenId),
 }
 
@@ -187,29 +178,14 @@ pub(crate) type RankedMerges = HashMap<u64, (TokenId, u32), rustc_hash::FxBuildH
 
 /// One added token as configured by the loader: byte content, emitted ID, and
 /// HF `AddedToken` whitespace-stripping flags (`lstrip` absorbs whitespace
-/// before a match, `rstrip` absorbs whitespace after it).
+/// before a match, `rstrip` absorbs whitespace after it). Content is shared
+/// (`Arc`) so forks clone entries cheaply.
 #[derive(Clone, Debug)]
 pub struct AddedTokenDef {
-    pub content: Vec<u8>,
+    pub content: Arc<[u8]>,
     pub id: TokenId,
     pub lstrip: bool,
     pub rstrip: bool,
-}
-
-impl AddedTokenDef {
-    /// A plain added token with no stripping flags.
-    pub fn plain(content: Vec<u8>, id: TokenId) -> Self {
-        AddedTokenDef { content, id, lstrip: false, rstrip: false }
-    }
-}
-
-/// Internal added-token entry (shared content bytes for cheap forks).
-#[derive(Clone)]
-struct AddedTok {
-    content: Arc<[u8]>,
-    id: TokenId,
-    lstrip: bool,
-    rstrip: bool,
 }
 
 /// Byte offset after the leading Unicode whitespace of `bytes` (the set of
@@ -254,8 +230,19 @@ fn trim_ws_end(bytes: &[u8]) -> usize {
     end
 }
 
+/// Overwrite the short-cache entry of every added-token content of 1..=15
+/// bytes that resolves in `vocab_inv` with that single ID, so a matching
+/// pretoken encodes as the added token rather than its merge decomposition.
+///
+/// This function IS the cache-seed sync invariant: the short cache's
+/// seed-level state is always "vocab seed, then these overwrites" — a pure
+/// function of `(vocab, added_tokens)` — because both
+/// [`Tokenizer::set_added_tokens`] (on the parent) and
+/// [`Tokenizer::fork_sized`] (after a fork's fresh reseed) apply the
+/// overwrites through this one body, so parent and forked workers always
+/// agree on every short pretoken.
 fn apply_added_token_overwrites(
-    added_tokens: &[AddedTok],
+    added_tokens: &[AddedTokenDef],
     vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
     pretoken_cache: &mut ShortPretokenCache,
     token_arena: &mut Vec<TokenId>,
@@ -287,20 +274,15 @@ impl Tokenizer {
 
     /// Construct from an explicit-rank merge table (`ranked_merge_key(a, b)`
     /// → `(merged, rank)`), for vocabularies whose IDs do not follow merge
-    /// order (fairseq heritage: RoBERTa/OPT/DeBERTa). Every merge runs
-    /// through the ranked loops; the id-as-rank fast paths stay off.
+    /// order (see `ranked_merges`). Every merge runs through the ranked
+    /// loops; the id-as-rank fast paths stay off.
     pub fn new_ranked(
         ranked_merges: RankedMerges,
         vocab: Vec<Vec<u8>>,
         byte_remapping: Option<ByteRemapping>,
     ) -> Self {
         let vocab = vocab.into_iter().map(Into::into).collect();
-        Self::from_tables(
-            HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
-            Some(ranked_merges),
-            vocab,
-            byte_remapping,
-        )
+        Self::from_tables(HashMap::default(), Some(ranked_merges), vocab, byte_remapping)
     }
 
     /// Shared construction tail ([`Self::new`], [`Self::new_ranked`] and
@@ -735,9 +717,8 @@ impl Tokenizer {
         self.normalize_nfc = normalize_nfc;
     }
 
-    /// Enable HF `ByteLevel(add_prefix_space=true)` semantics (RoBERTa-style
-    /// exports): every non-empty added-token-split segment not already
-    /// starting with a space gets one prepended before pretokenization.
+    /// Enable HF `ByteLevel(add_prefix_space=true)` semantics (see the
+    /// `add_prefix_space` field).
     pub fn set_add_prefix_space(&mut self, add_prefix_space: bool) {
         self.add_prefix_space = add_prefix_space;
     }
@@ -800,15 +781,9 @@ impl Tokenizer {
     ///
     /// [`WorkerPool`]: crate::batch::WorkerPool
     pub fn set_added_tokens(&mut self, added_tokens: Vec<AddedTokenDef>) {
-        let mut added_tokens: Vec<AddedTok> = added_tokens
+        let mut added_tokens: Vec<AddedTokenDef> = added_tokens
             .into_iter()
             .filter(|t| !t.content.is_empty())
-            .map(|t| AddedTok {
-                content: t.content.into(),
-                id: t.id,
-                lstrip: t.lstrip,
-                rstrip: t.rstrip,
-            })
             .collect();
         added_tokens.sort_by_key(|t| std::cmp::Reverse(t.content.len()));
         self.added_matcher = (!added_tokens.is_empty()).then(|| {
@@ -882,17 +857,8 @@ impl Tokenizer {
             // [`Self::fork_sized`]), so parent and forked workers agree.
             Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
         }
-        let mut added: Vec<AddedTokenDef> = self
-            .added_tokens
-            .iter()
-            .map(|t| AddedTokenDef {
-                content: t.content.to_vec(),
-                id: t.id,
-                lstrip: t.lstrip,
-                rstrip: t.rstrip,
-            })
-            .collect();
-        added.push(AddedTokenDef::plain(content, id));
+        let mut added = self.added_tokens.clone();
+        added.push(AddedTokenDef { content: content.into(), id, lstrip: false, rstrip: false });
         self.set_added_tokens(added);
     }
 
@@ -912,38 +878,23 @@ impl Tokenizer {
     /// (priority equals the merged token's ID for tiktoken vocabularies;
     /// rank-mapped vocabularies keep their explicit rank order).
     pub fn merge_entries(&self) -> Vec<(&[u8], &[u8])> {
-        if let Some(rm) = self.ranked_merges.as_deref() {
-            let mut ranked: Vec<_> = rm.iter().collect();
-            ranked.sort_unstable_by_key(|&(_, &(_, rank))| rank);
-            return ranked
-                .into_iter()
-                .map(|(&key, _)| {
-                    (
-                        self.vocab[(key >> 32) as usize].as_ref(),
-                        self.vocab[(key & u32::MAX as u64) as usize].as_ref(),
-                    )
-                })
-                .collect();
-        }
-        let mut ranked: Vec<_> = self.merges.iter().collect();
-        ranked.sort_unstable_by_key(|&(_, merged)| merged);
+        let mut ranked: Vec<(u32, u32, u32)> = match self.ranked_merges.as_deref() {
+            Some(rm) => rm
+                .iter()
+                .map(|(&key, &(_, rank))| ((key >> 32) as u32, key as u32, rank))
+                .collect(),
+            None => self.merges.iter().map(|(&(a, b), &m)| (a.0, b.0, m.0)).collect(),
+        };
+        ranked.sort_unstable_by_key(|&(.., priority)| priority);
         ranked
             .into_iter()
-            .map(|(&(a, b), _)| {
+            .map(|(a, b, _)| {
                 (
-                    self.vocab[a.0 as usize].as_ref(),
-                    self.vocab[b.0 as usize].as_ref(),
+                    self.vocab[a as usize].as_ref(),
+                    self.vocab[b as usize].as_ref(),
                 )
             })
             .collect()
-    }
-
-    /// Contents of the added tokens, for callers that split documents at
-    /// byte-level boundaries (see `pretokenize::safe_split_ranges`): added
-    /// tokens are matched atomically before pretokenization, so a split must
-    /// never cut an occurrence in half.
-    pub fn added_token_contents(&self) -> Vec<&[u8]> {
-        self.added_tokens.iter().map(|t| t.content.as_ref()).collect()
     }
 
     /// Added-token contents paired with their `rstrip` flag, for
@@ -1001,7 +952,7 @@ impl Tokenizer {
                 prefix_buf.extend_from_slice(segment);
                 segment = &prefix_buf;
             }
-            f(self, Piece::Segment(segment));
+            f(self, Piece::Segment(segment, pos));
             match added {
                 Some((end, id, _, rstrip)) => {
                     f(self, Piece::Added(id));
@@ -1020,7 +971,7 @@ impl Tokenizer {
     pub fn encode_with_added_tokens(&mut self, bytes: &[u8], mut f: impl FnMut(&[TokenId])) {
         let pt = self.pretokenizer_type;
         self.for_each_piece(bytes, |this, piece| match piece {
-            Piece::Segment(segment) => this.memoized_encode(pt.pretokenize(segment), &mut f),
+            Piece::Segment(segment, _) => this.memoized_encode(pt.pretokenize(segment), &mut f),
             Piece::Added(id) => f(&[id]),
         });
     }
@@ -1032,7 +983,7 @@ impl Tokenizer {
     pub fn encode_with_added_tokens_flat(&mut self, bytes: &[u8], out: &mut Vec<u32>) {
         let pt = self.pretokenizer_type;
         self.for_each_piece(bytes, |this, piece| match piece {
-            Piece::Segment(segment) => this.memoized_encode_flat(pt.pretokenize(segment), out),
+            Piece::Segment(segment, _) => this.memoized_encode_flat(pt.pretokenize(segment), out),
             Piece::Added(id) => out.push(id.0),
         });
     }
@@ -1271,13 +1222,6 @@ impl Tokenizer {
         out.len()
     }
 
-    /// Cache-miss path of the probe/emit loop: BPE-encode `bytes`, record
-    /// it in the table `key` routes to (the short-pretoken table, or the
-    /// long map when `key == 0`), and append its tokens to `out`. `slot`
-    /// is the short-cache insert position reported by the failed
-    /// `get_or_slot` probe (meaningful only when `key != 0`); nothing
-    /// here touches the short cache before the insert, so it stays valid.
-    #[inline(never)]
     /// Outlined miss path for rank-mapped vocabularies: the same cache
     /// bookkeeping as [`Self::encode_pretoken_miss`], with every merge
     /// running through the explicit-rank loops.
@@ -1331,6 +1275,13 @@ impl Tokenizer {
         }
     }
 
+    /// Cache-miss path of the probe/emit loop: BPE-encode `bytes`, record
+    /// it in the table `key` routes to (the short-pretoken table, or the
+    /// long map when `key == 0`), and append its tokens to `out`. `slot`
+    /// is the short-cache insert position reported by the failed
+    /// `get_or_slot` probe (meaningful only when `key != 0`); nothing
+    /// here touches the short cache before the insert, so it stays valid.
+    #[inline(never)]
     fn encode_pretoken_miss(
         &mut self,
         bytes: &[u8],
@@ -1339,7 +1290,7 @@ impl Tokenizer {
         slot: usize,
         out: &mut Vec<u32>,
     ) {
-        // Rank-mapped vocabularies (fairseq heritage) take the outlined
+        // Rank-mapped vocabularies take the outlined
         // ranked miss path; the branch is one perfectly-predicted test for
         // everything else, keeping this function's codegen identical to a
         // build without ranked support.
@@ -1800,77 +1751,56 @@ mod verify_heavy {
     }
 
     /// Token-for-token comparison of the full cached public path
-    /// (`encode_with_added_tokens_flat`) against an uncached mirror of its
-    /// segment loop (added-token split + optional NFC + per-pretoken plain
-    /// merge). Panics with byte offset, pretoken bytes, and both id streams
-    /// on the first divergence.
+    /// (`encode_with_added_tokens_flat`) against a per-pretoken plain-merge
+    /// walk of the same piece stream. The piece walk itself
+    /// (`for_each_piece`) is shared with production — its added-token split
+    /// is covered independently by `join_differential`; what this checks is
+    /// the cache/probe/emit machinery against uncached plain merges.
+    /// Panics with byte offset, pretoken bytes, and both id streams on the
+    /// first divergence.
     fn compare_cached_vs_reference(tok: &mut Tokenizer, input: &[u8], label: &str, verbose: bool) {
         let mut cached: Vec<u32> = Vec::new();
         tok.encode_with_added_tokens_flat(input, &mut cached);
 
         let mut idx = 0usize;
-        let mut nfc_buf = String::new();
         let mut scratch: Vec<u32> = Vec::new();
-        let mut pos = 0usize;
-        loop {
-            let (mut seg_end, added) = match tok.find_added_token(input, pos) {
-                Some((s, e, i)) => {
-                    let t = &tok.added_tokens[i];
-                    (s, Some((e, t.id, t.lstrip, t.rstrip)))
+        tok.for_each_piece(input, |this, piece| match piece {
+            Piece::Segment(segment, pos) => {
+                let mut seg_off = 0usize;
+                for pretoken in this.pretokenizer_type.pretokenize(segment) {
+                    scratch.clear();
+                    plain_encode_pretoken(this, pretoken.0, &mut scratch);
+                    let got = cached.get(idx..idx + scratch.len());
+                    if got != Some(&scratch[..]) {
+                        // Approximate: NFC or a prepended prefix space can
+                        // shift lengths vs the raw input.
+                        let byte_off = pos + seg_off;
+                        let ctx_start = byte_off.saturating_sub(40).min(input.len());
+                        let ctx_end = (byte_off + pretoken.0.len() + 40).min(input.len());
+                        panic!(
+                            "{label}: encode mismatch at byte offset ~{byte_off} (input len {}), token index {idx}\n  \
+                             pretoken ({} bytes): {:?}\n  expected ids: {:?}\n  cached ids:   {:?}\n  context: {:?}",
+                            input.len(),
+                            pretoken.0.len(),
+                            String::from_utf8_lossy(pretoken.0),
+                            scratch,
+                            &cached[idx.min(cached.len())..(idx + scratch.len() + 4).min(cached.len())],
+                            String::from_utf8_lossy(&input[ctx_start..ctx_end]),
+                        );
+                    }
+                    idx += scratch.len();
+                    seg_off += pretoken.0.len();
                 }
-                None => (input.len(), None),
-            };
-            if let Some((_, _, true, _)) = added {
-                seg_end = pos + trim_ws_end(&input[pos..seg_end]);
             }
-            let mut segment = if tok.normalize_nfc {
-                nfc_segment(&input[pos..seg_end], &mut nfc_buf)
-            } else {
-                &input[pos..seg_end]
-            };
-            let mut prefix_buf;
-            if tok.add_prefix_space && !segment.is_empty() && segment[0] != b' ' {
-                prefix_buf = Vec::with_capacity(segment.len() + 1);
-                prefix_buf.push(b' ');
-                prefix_buf.extend_from_slice(segment);
-                segment = &prefix_buf;
+            Piece::Added(id) => {
+                assert_eq!(
+                    cached.get(idx).copied(),
+                    Some(id.0),
+                    "{label}: added-token id mismatch at token index {idx}"
+                );
+                idx += 1;
             }
-            let mut seg_off = 0usize;
-            for pretoken in tok.pretokenizer_type.pretokenize(segment) {
-                scratch.clear();
-                plain_encode_pretoken(tok, pretoken.0, &mut scratch);
-                let got = cached.get(idx..idx + scratch.len());
-                if got != Some(&scratch[..]) {
-                    let byte_off = pos + seg_off; // exact unless NFC changed lengths
-                    let ctx_start = byte_off.saturating_sub(40).min(input.len());
-                    let ctx_end = (byte_off + pretoken.0.len() + 40).min(input.len());
-                    panic!(
-                        "{label}: encode mismatch at byte offset ~{byte_off} (input len {}), token index {idx}\n  \
-                         pretoken ({} bytes): {:?}\n  expected ids: {:?}\n  cached ids:   {:?}\n  context: {:?}",
-                        input.len(),
-                        pretoken.0.len(),
-                        String::from_utf8_lossy(pretoken.0),
-                        scratch,
-                        &cached[idx.min(cached.len())..(idx + scratch.len() + 4).min(cached.len())],
-                        String::from_utf8_lossy(&input[ctx_start..ctx_end]),
-                    );
-                }
-                idx += scratch.len();
-                seg_off += pretoken.0.len();
-            }
-            match added {
-                Some((end, id, _, rstrip)) => {
-                    assert_eq!(
-                        cached.get(idx).copied(),
-                        Some(id.0),
-                        "{label}: added-token id mismatch at bytes {pos}..{end}"
-                    );
-                    idx += 1;
-                    pos = if rstrip { end + trim_ws_start(&input[end..]) } else { end };
-                }
-                None => break,
-            }
-        }
+        });
         assert_eq!(
             idx,
             cached.len(),

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1,7 +1,8 @@
 use crate::bpe::pretoken_cache::ShortPretokenCache;
 use crate::bpe::{
     ByteRemapping, MergeScratch, PairRankTable, SHORT_MERGE_MAX, bpe_merge_symbols_by_rank,
-    bpe_merge_symbols_short_scalar, bpe_merge_symbols_with_scratch, simple_bpe_merge,
+    bpe_merge_symbols_ranked, bpe_merge_symbols_ranked_slice, bpe_merge_symbols_short_scalar,
+    bpe_merge_symbols_with_scratch, simple_bpe_merge,
 };
 #[cfg(target_arch = "aarch64")]
 use crate::bpe::bpe_merge_symbols_short_neon;
@@ -33,6 +34,14 @@ pub struct Tokenizer {
     /// merge loop; `None` for vocabularies whose IDs don't fit its packed
     /// keys (those keep probing `merges`).
     pair_ranks: Option<Arc<PairRankTable>>,
+    /// Explicit merge priorities for rank-mapped vocabularies (fairseq
+    /// heritage: RoBERTa/OPT/DeBERTa, whose vocab IDs are frequency-ordered
+    /// and carry no rank information). When set, `merges` is empty,
+    /// `pair_ranks` is `None`, and every merge runs through the ranked loops
+    /// with priority read from this table (`ranked_merge_key(a, b)` →
+    /// `(merged, rank)`). `None` for id-as-rank vocabularies (everything
+    /// tiktoken-style), whose fast paths are untouched.
+    ranked_merges: Option<Arc<RankedMerges>>,
     pub(crate) vocab: Arc<Vec<Arc<[u8]>>>,
     pub(crate) vocab_inv: Arc<HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>>,
     pub(crate) byte_remapping: Option<ByteRemapping>,
@@ -58,7 +67,7 @@ pub struct Tokenizer {
     pub(crate) pretokenizer_type: PretokenizerType,
     /// Added tokens (special and non-special), matched atomically in the raw
     /// input before pretokenization, like HuggingFace's AddedVocabulary.
-    added_tokens: Vec<(Arc<[u8]>, TokenId)>,
+    added_tokens: Vec<AddedTok>,
     /// Leftmost-longest Aho-Corasick automaton over `added_tokens` contents
     /// (pattern index == `added_tokens` index). A prebuilt automaton keeps the
     /// scan fast even when an added token starts with a byte that is common in
@@ -69,6 +78,10 @@ pub struct Tokenizer {
     /// Apply NFC normalization to non-added-token segments before
     /// pretokenization, like HuggingFace's `NFC` normalizer (e.g. Qwen2).
     normalize_nfc: bool,
+    /// HF `ByteLevel(add_prefix_space=true)` (RoBERTa-style exports): every
+    /// non-empty added-token-split segment that does not already start with
+    /// a space gets one prepended before pretokenization.
+    add_prefix_space: bool,
     /// HF BPE `ignore_merges`: a pretoken whose whole byte string is a
     /// vocab entry encodes as that single ID without running the merge
     /// loop. Matters when the vocab has whole-word entries the merges
@@ -167,13 +180,88 @@ enum Piece<'a> {
     Added(TokenId),
 }
 
+/// Explicit merge-priority table for rank-mapped vocabularies:
+/// `ranked_merge_key(a, b)` → `(merged, rank)`. Same shape as the
+/// SentencePiece engine's merge table.
+pub(crate) type RankedMerges = HashMap<u64, (TokenId, u32), rustc_hash::FxBuildHasher>;
+
+/// One added token as configured by the loader: byte content, emitted ID, and
+/// HF `AddedToken` whitespace-stripping flags (`lstrip` absorbs whitespace
+/// before a match, `rstrip` absorbs whitespace after it).
+#[derive(Clone, Debug)]
+pub struct AddedTokenDef {
+    pub content: Vec<u8>,
+    pub id: TokenId,
+    pub lstrip: bool,
+    pub rstrip: bool,
+}
+
+impl AddedTokenDef {
+    /// A plain added token with no stripping flags.
+    pub fn plain(content: Vec<u8>, id: TokenId) -> Self {
+        AddedTokenDef { content, id, lstrip: false, rstrip: false }
+    }
+}
+
+/// Internal added-token entry (shared content bytes for cheap forks).
+#[derive(Clone)]
+struct AddedTok {
+    content: Arc<[u8]>,
+    id: TokenId,
+    lstrip: bool,
+    rstrip: bool,
+}
+
+/// Byte offset after the leading Unicode whitespace of `bytes` (the set of
+/// `str::trim_start`, which is what HF's `\s*` sees). Invalid UTF-8 stops the
+/// scan.
+fn trim_ws_start(bytes: &[u8]) -> usize {
+    let mut pos = 0;
+    while pos < bytes.len() {
+        let width = match bytes[pos] {
+            0x00..=0x7F => 1,
+            0xC0..=0xDF => 2,
+            0xE0..=0xEF => 3,
+            0xF0..=0xF7 => 4,
+            _ => break,
+        };
+        let Some(chunk) = bytes.get(pos..pos + width) else {
+            break;
+        };
+        match std::str::from_utf8(chunk) {
+            Ok(s) if s.chars().next().is_some_and(char::is_whitespace) => pos += width,
+            _ => break,
+        }
+    }
+    pos
+}
+
+/// Length of `bytes` after trimming trailing Unicode whitespace (the set of
+/// `str::trim_end`). Invalid UTF-8 stops the scan.
+fn trim_ws_end(bytes: &[u8]) -> usize {
+    let mut end = bytes.len();
+    while end > 0 {
+        // Back up over at most 3 continuation bytes to the character start.
+        let mut start = end - 1;
+        while start > 0 && (bytes[start] & 0xC0) == 0x80 && end - start < 4 {
+            start -= 1;
+        }
+        match std::str::from_utf8(&bytes[start..end]) {
+            Ok(s) if s.chars().next().is_some_and(char::is_whitespace) => end = start,
+            _ => break,
+        }
+    }
+    end
+}
+
 fn apply_added_token_overwrites(
-    added_tokens: &[(Arc<[u8]>, TokenId)],
+    added_tokens: &[AddedTok],
     vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
     pretoken_cache: &mut ShortPretokenCache,
     token_arena: &mut Vec<TokenId>,
 ) {
-    for (content, _) in added_tokens {
+    for tok in added_tokens {
+        let content = &tok.content;
         if !(1..=15).contains(&content.len()) {
             continue;
         }
@@ -194,16 +282,35 @@ impl Tokenizer {
         byte_remapping: Option<ByteRemapping>,
     ) -> Self {
         let vocab = vocab.into_iter().map(Into::into).collect();
-        Self::from_tables(merges, vocab, byte_remapping)
+        Self::from_tables(merges, None, vocab, byte_remapping)
     }
 
-    /// Shared construction tail ([`Self::new`] and [`Self::from_ranks`]):
-    /// derive `vocab_inv` and the pair-rank table from the finished
-    /// merges/vocab, seed the pretoken cache, and assemble the tokenizer
-    /// with default pipeline settings (GPT-2 pretokenization, no added
-    /// tokens, no NFC).
+    /// Construct from an explicit-rank merge table (`ranked_merge_key(a, b)`
+    /// → `(merged, rank)`), for vocabularies whose IDs do not follow merge
+    /// order (fairseq heritage: RoBERTa/OPT/DeBERTa). Every merge runs
+    /// through the ranked loops; the id-as-rank fast paths stay off.
+    pub fn new_ranked(
+        ranked_merges: RankedMerges,
+        vocab: Vec<Vec<u8>>,
+        byte_remapping: Option<ByteRemapping>,
+    ) -> Self {
+        let vocab = vocab.into_iter().map(Into::into).collect();
+        Self::from_tables(
+            HashMap::with_hasher(rustc_hash::FxBuildHasher {}),
+            Some(ranked_merges),
+            vocab,
+            byte_remapping,
+        )
+    }
+
+    /// Shared construction tail ([`Self::new`], [`Self::new_ranked`] and
+    /// [`Self::from_ranks`]): derive `vocab_inv` and the pair-rank table
+    /// from the finished merges/vocab, seed the pretoken cache, and
+    /// assemble the tokenizer with default pipeline settings (GPT-2
+    /// pretokenization, no added tokens, no NFC).
     fn from_tables(
         merges: HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
+        ranked_merges: Option<RankedMerges>,
         vocab: Vec<Arc<[u8]>>,
         byte_remapping: Option<ByteRemapping>,
     ) -> Self {
@@ -212,14 +319,19 @@ impl Tokenizer {
             .cloned()
             .zip((0..).map(TokenId::from))
             .collect();
-        let pair_ranks =
-            PairRankTable::build(&merges, byte_remapping.as_ref(), vocab.len()).map(Arc::new);
+        let ranked_merges = ranked_merges.map(Arc::new);
+        let pair_ranks = if ranked_merges.is_none() {
+            PairRankTable::build(&merges, byte_remapping.as_ref(), vocab.len()).map(Arc::new)
+        } else {
+            None
+        };
         let mut token_arena = Vec::new();
         let pretoken_cache = Self::seeded_pretoken_cache(
             &vocab,
             byte_remapping.as_ref(),
             pair_ranks.as_deref(),
             &merges,
+            ranked_merges.as_deref(),
             false,
             &vocab_inv,
             &mut token_arena,
@@ -228,6 +340,7 @@ impl Tokenizer {
         Tokenizer {
             merges: Arc::new(merges),
             pair_ranks,
+            ranked_merges,
             vocab_inv: Arc::new(vocab_inv),
             vocab: Arc::new(vocab),
             byte_remapping,
@@ -240,6 +353,7 @@ impl Tokenizer {
             added_tokens: Vec::new(),
             added_matcher: None,
             normalize_nfc: false,
+            add_prefix_space: false,
             ignore_merges: false,
         }
     }
@@ -281,6 +395,7 @@ impl Tokenizer {
         byte_remapping: Option<&ByteRemapping>,
         pair_ranks: Option<&PairRankTable>,
         merges: &HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
+        ranked_merges: Option<&RankedMerges>,
         ignore_merges: bool,
         vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
         token_arena: &mut Vec<TokenId>,
@@ -302,10 +417,11 @@ impl Tokenizer {
             // above), so insertion order is irrelevant and the
             // insert-if-absent check only skips redundant merges.
             if cache.get_or_slot(key, h).is_err() {
-                let n = Self::seed_symbols(
+                let n = Self::seed_symbols_any(
                     byte_remapping,
                     pair_ranks,
                     merges,
+                    ranked_merges,
                     ignore_merges,
                     vocab_inv,
                     bytes,
@@ -342,6 +458,79 @@ impl Tokenizer {
             }
         }
         Self::merge_short(byte_remapping, pair_ranks, merges, bytes, buf)
+    }
+
+    /// [`Self::seed_symbols`] for either merge-table shape: dispatches to
+    /// the ranked variant when `ranked_merges` is set. Load-time call sites
+    /// (cache seeding, flag flips) go through this; the per-pretoken miss
+    /// path dispatches once per pretoken instead (see
+    /// [`Self::encode_pretoken_miss`]), keeping the id-as-rank miss
+    /// codegen identical to a build without ranked support.
+    #[inline]
+    fn seed_symbols_any(
+        byte_remapping: Option<&ByteRemapping>,
+        pair_ranks: Option<&PairRankTable>,
+        merges: &HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
+        ranked_merges: Option<&RankedMerges>,
+        ignore_merges: bool,
+        vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
+        bytes: &[u8],
+        buf: &mut [TokenId; SHORT_MERGE_MAX],
+    ) -> usize {
+        match ranked_merges {
+            Some(rm) => Self::seed_symbols_ranked(
+                byte_remapping,
+                rm,
+                ignore_merges,
+                vocab_inv,
+                bytes,
+                buf,
+            ),
+            None => Self::seed_symbols(
+                byte_remapping,
+                pair_ranks,
+                merges,
+                ignore_merges,
+                vocab_inv,
+                bytes,
+                buf,
+            ),
+        }
+    }
+
+    /// Ranked-merge-table variant of [`Self::seed_symbols`].
+    fn seed_symbols_ranked(
+        byte_remapping: Option<&ByteRemapping>,
+        ranked_merges: &RankedMerges,
+        ignore_merges: bool,
+        vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
+        bytes: &[u8],
+        buf: &mut [TokenId; SHORT_MERGE_MAX],
+    ) -> usize {
+        if ignore_merges {
+            if let Some(&id) = vocab_inv.get(bytes) {
+                buf[0] = id;
+                return 1;
+            }
+        }
+        let n = bytes.len();
+        debug_assert!((1..SHORT_MERGE_MAX).contains(&n));
+        match byte_remapping {
+            Some(br) => {
+                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
+                    *dst = br.mapping[b as usize];
+                }
+            }
+            None => {
+                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
+                    *dst = TokenId(b as u32);
+                }
+            }
+        }
+        if n < 2 {
+            return n;
+        }
+        bpe_merge_symbols_ranked_slice(ranked_merges, &mut buf[..n])
     }
 
     /// BPE-encode one short pretoken (1..=15 bytes) into `buf`, returning
@@ -443,7 +632,7 @@ impl Tokenizer {
         }
 
         let byte_remapping = ByteRemapping::from_byte_vocab(&vocab)?;
-        Ok(Self::from_tables(merges, vocab, byte_remapping))
+        Ok(Self::from_tables(merges, None, vocab, byte_remapping))
     }
 
     /// Create a new tokenizer sharing the same model data but with a
@@ -486,6 +675,7 @@ impl Tokenizer {
             self.byte_remapping.as_ref(),
             self.pair_ranks.as_deref(),
             &self.merges,
+            self.ranked_merges.as_deref(),
             self.ignore_merges,
             &self.vocab_inv,
             &mut token_arena,
@@ -505,6 +695,7 @@ impl Tokenizer {
         Tokenizer {
             merges: Arc::clone(&self.merges),
             pair_ranks: self.pair_ranks.clone(),
+            ranked_merges: self.ranked_merges.clone(),
             vocab: Arc::clone(&self.vocab),
             vocab_inv: Arc::clone(&self.vocab_inv),
             byte_remapping: self.byte_remapping.clone(),
@@ -520,6 +711,7 @@ impl Tokenizer {
             added_tokens: self.added_tokens.clone(),
             added_matcher: self.added_matcher.clone(),
             normalize_nfc: self.normalize_nfc,
+            add_prefix_space: self.add_prefix_space,
             ignore_merges: self.ignore_merges,
         }
     }
@@ -541,6 +733,13 @@ impl Tokenizer {
     /// pretokenization (HF `normalizer: {"type": "NFC"}`).
     pub fn set_normalize_nfc(&mut self, normalize_nfc: bool) {
         self.normalize_nfc = normalize_nfc;
+    }
+
+    /// Enable HF `ByteLevel(add_prefix_space=true)` semantics (RoBERTa-style
+    /// exports): every non-empty added-token-split segment not already
+    /// starting with a space gets one prepended before pretokenization.
+    pub fn set_add_prefix_space(&mut self, add_prefix_space: bool) {
+        self.add_prefix_space = add_prefix_space;
     }
 
     /// Enable HF BPE `ignore_merges` semantics: a pretoken whose whole
@@ -571,10 +770,11 @@ impl Tokenizer {
             }
             let key = pack_pretoken_key(bytes).expect("length checked <= 15");
             let h = pretoken_key_hash(key);
-            let n = Self::seed_symbols(
+            let n = Self::seed_symbols_any(
                 self.byte_remapping.as_ref(),
                 self.pair_ranks.as_deref(),
                 &self.merges,
+                self.ranked_merges.as_deref(),
                 ignore_merges,
                 &self.vocab_inv,
                 bytes,
@@ -599,17 +799,22 @@ impl Tokenizer {
     /// added-token set (see [`WorkerPool`]).
     ///
     /// [`WorkerPool`]: crate::batch::WorkerPool
-    pub fn set_added_tokens(&mut self, added_tokens: Vec<(Vec<u8>, TokenId)>) {
-        let mut added_tokens: Vec<(Arc<[u8]>, TokenId)> = added_tokens
+    pub fn set_added_tokens(&mut self, added_tokens: Vec<AddedTokenDef>) {
+        let mut added_tokens: Vec<AddedTok> = added_tokens
             .into_iter()
-            .filter(|(content, _)| !content.is_empty())
-            .map(|(content, id)| (content.into(), id))
+            .filter(|t| !t.content.is_empty())
+            .map(|t| AddedTok {
+                content: t.content.into(),
+                id: t.id,
+                lstrip: t.lstrip,
+                rstrip: t.rstrip,
+            })
             .collect();
-        added_tokens.sort_by_key(|(content, _)| std::cmp::Reverse(content.len()));
+        added_tokens.sort_by_key(|t| std::cmp::Reverse(t.content.len()));
         self.added_matcher = (!added_tokens.is_empty()).then(|| {
             aho_corasick::AhoCorasick::builder()
                 .match_kind(aho_corasick::MatchKind::LeftmostLongest)
-                .build(added_tokens.iter().map(|(c, _)| c.as_ref()))
+                .build(added_tokens.iter().map(|t| t.content.as_ref()))
                 .expect("added-token automaton construction cannot fail")
         });
         let outgoing = std::mem::replace(&mut self.added_tokens, added_tokens);
@@ -618,17 +823,19 @@ impl Tokenizer {
         // this replaces existing entries and never inserts), then apply
         // the incoming overwrites through the shared sync-invariant body
         // (see `apply_added_token_overwrites`).
-        for (content, _) in &outgoing {
+        for tok in &outgoing {
+            let content = &tok.content;
             if !(1..=15).contains(&content.len()) || self.vocab_inv.get(content).is_none() {
                 continue;
             }
             let key = pack_pretoken_key(content).expect("length checked <= 15");
             let h = pretoken_key_hash(key);
             let mut buf = [TokenId(0); SHORT_MERGE_MAX];
-            let n = Self::seed_symbols(
+            let n = Self::seed_symbols_any(
                 self.byte_remapping.as_ref(),
                 self.pair_ranks.as_deref(),
                 &self.merges,
+                self.ranked_merges.as_deref(),
                 self.ignore_merges,
                 &self.vocab_inv,
                 content,
@@ -675,12 +882,17 @@ impl Tokenizer {
             // [`Self::fork_sized`]), so parent and forked workers agree.
             Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
         }
-        let mut added: Vec<(Vec<u8>, TokenId)> = self
+        let mut added: Vec<AddedTokenDef> = self
             .added_tokens
             .iter()
-            .map(|(c, i)| (c.to_vec(), *i))
+            .map(|t| AddedTokenDef {
+                content: t.content.to_vec(),
+                id: t.id,
+                lstrip: t.lstrip,
+                rstrip: t.rstrip,
+            })
             .collect();
-        added.push((content, id));
+        added.push(AddedTokenDef::plain(content, id));
         self.set_added_tokens(added);
     }
 
@@ -697,8 +909,22 @@ impl Tokenizer {
     }
 
     /// Merge rules as `(left, right)` byte pairs in merge-priority order
-    /// (priority equals the merged token's ID for tiktoken vocabularies).
+    /// (priority equals the merged token's ID for tiktoken vocabularies;
+    /// rank-mapped vocabularies keep their explicit rank order).
     pub fn merge_entries(&self) -> Vec<(&[u8], &[u8])> {
+        if let Some(rm) = self.ranked_merges.as_deref() {
+            let mut ranked: Vec<_> = rm.iter().collect();
+            ranked.sort_unstable_by_key(|&(_, &(_, rank))| rank);
+            return ranked
+                .into_iter()
+                .map(|(&key, _)| {
+                    (
+                        self.vocab[(key >> 32) as usize].as_ref(),
+                        self.vocab[(key & u32::MAX as u64) as usize].as_ref(),
+                    )
+                })
+                .collect();
+        }
         let mut ranked: Vec<_> = self.merges.iter().collect();
         ranked.sort_unstable_by_key(|&(_, merged)| merged);
         ranked
@@ -717,16 +943,26 @@ impl Tokenizer {
     /// tokens are matched atomically before pretokenization, so a split must
     /// never cut an occurrence in half.
     pub fn added_token_contents(&self) -> Vec<&[u8]> {
-        self.added_tokens.iter().map(|(c, _)| c.as_ref()).collect()
+        self.added_tokens.iter().map(|t| t.content.as_ref()).collect()
+    }
+
+    /// Added-token contents paired with their `rstrip` flag, for
+    /// `pretokenize::safe_split_ranges`: an rstrip occurrence must not end
+    /// exactly at a chunk boundary, or the whitespace it would absorb lands
+    /// at the start of the next chunk and encodes as plain text.
+    pub fn added_token_split_blockers(&self) -> Vec<(&[u8], bool)> {
+        self.added_tokens
+            .iter()
+            .map(|t| (t.content.as_ref(), t.rstrip))
+            .collect()
     }
 
     /// Find the leftmost added-token occurrence at or after `from`, taking
     /// the longest token when several match at the same position. Returns
-    /// `(start, end, id)`.
-    fn find_added_token(&self, bytes: &[u8], from: usize) -> Option<(usize, usize, TokenId)> {
+    /// `(start, end, index into added_tokens)`.
+    fn find_added_token(&self, bytes: &[u8], from: usize) -> Option<(usize, usize, usize)> {
         let m = self.added_matcher.as_ref()?.find(&bytes[from..])?;
-        let id = self.added_tokens[m.pattern().as_usize()].1;
-        Some((from + m.start(), from + m.end(), id))
+        Some((from + m.start(), from + m.end(), m.pattern().as_usize()))
     }
 
     /// Shared piece walk of the added-token pipeline: split out added-token
@@ -739,22 +975,38 @@ impl Tokenizer {
     fn for_each_piece(&mut self, bytes: &[u8], mut f: impl FnMut(&mut Self, Piece<'_>)) {
         let normalize_nfc = self.normalize_nfc;
         let mut nfc_buf = String::new();
+        let mut prefix_buf = Vec::new();
         let mut pos = 0;
         while pos < bytes.len() {
-            let (seg_end, added) = match self.find_added_token(bytes, pos) {
-                Some((start, end, id)) => (start, Some((end, id))),
+            let (mut seg_end, added) = match self.find_added_token(bytes, pos) {
+                Some((start, end, idx)) => {
+                    let t = &self.added_tokens[idx];
+                    (start, Some((end, t.id, t.lstrip, t.rstrip)))
+                }
                 None => (bytes.len(), None),
             };
-            let segment = if normalize_nfc {
+            // An lstrip added token absorbs the whitespace before it (HF's
+            // `\s*` on the left of the match); drop it from the segment.
+            if let Some((_, _, true, _)) = added {
+                seg_end = pos + trim_ws_end(&bytes[pos..seg_end]);
+            }
+            let mut segment = if normalize_nfc {
                 nfc_segment(&bytes[pos..seg_end], &mut nfc_buf)
             } else {
                 &bytes[pos..seg_end]
             };
+            if self.add_prefix_space && !segment.is_empty() && segment[0] != b' ' {
+                prefix_buf.clear();
+                prefix_buf.push(b' ');
+                prefix_buf.extend_from_slice(segment);
+                segment = &prefix_buf;
+            }
             f(self, Piece::Segment(segment));
             match added {
-                Some((end, id)) => {
+                Some((end, id, _, rstrip)) => {
                     f(self, Piece::Added(id));
-                    pos = end;
+                    // An rstrip added token absorbs the whitespace after it.
+                    pos = if rstrip { end + trim_ws_start(&bytes[end..]) } else { end };
                 }
                 None => break,
             }
@@ -1026,6 +1278,59 @@ impl Tokenizer {
     /// `get_or_slot` probe (meaningful only when `key != 0`); nothing
     /// here touches the short cache before the insert, so it stays valid.
     #[inline(never)]
+    /// Outlined miss path for rank-mapped vocabularies: the same cache
+    /// bookkeeping as [`Self::encode_pretoken_miss`], with every merge
+    /// running through the explicit-rank loops.
+    #[cold]
+    #[inline(never)]
+    fn encode_pretoken_miss_ranked(
+        &mut self,
+        bytes: &[u8],
+        key: u128,
+        h: u64,
+        slot: usize,
+        out: &mut Vec<u32>,
+    ) {
+        let rm = self.ranked_merges.clone().expect("caller checked ranked_merges");
+        if key != 0 {
+            let mut buf = [TokenId(0); SHORT_MERGE_MAX];
+            let n = Self::seed_symbols_ranked(
+                self.byte_remapping.as_ref(),
+                &rm,
+                self.ignore_merges,
+                &self.vocab_inv,
+                bytes,
+                &mut buf,
+            );
+            let symbols = &buf[..n];
+            let (val, ext) = Self::pack_val(symbols, &mut self.token_arena);
+            self.pretoken_cache.insert_at(slot, key, h, val, ext);
+            out.extend_from_slice(token_ids_as_u32s(symbols));
+        } else {
+            // Mirrors the long-pretoken arm of `encode_pretoken_miss`,
+            // including the no-whole-pretoken-shortcut rule documented
+            // there.
+            let symbols = &mut self.symbol_scratch;
+            symbols.clear();
+            if self.ignore_merges
+                && let Some(&id) = self.vocab_inv.get(bytes)
+            {
+                symbols.push(id);
+            } else {
+                match self.byte_remapping.as_ref() {
+                    Some(br) => symbols.extend(bytes.iter().map(|&b| br.mapping[b as usize])),
+                    None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
+                }
+                bpe_merge_symbols_ranked(&rm, symbols);
+            }
+            let len = symbols.len() as u32;
+            let offset = self.token_arena.len() as u32;
+            self.token_arena.extend_from_slice(symbols);
+            self.pretoken_cache_long.insert(bytes.into(), (offset, len));
+            out.extend_from_slice(token_ids_as_u32s(symbols));
+        }
+    }
+
     fn encode_pretoken_miss(
         &mut self,
         bytes: &[u8],
@@ -1034,6 +1339,13 @@ impl Tokenizer {
         slot: usize,
         out: &mut Vec<u32>,
     ) {
+        // Rank-mapped vocabularies (fairseq heritage) take the outlined
+        // ranked miss path; the branch is one perfectly-predicted test for
+        // everything else, keeping this function's codegen identical to a
+        // build without ranked support.
+        if self.ranked_merges.is_some() {
+            return self.encode_pretoken_miss_ranked(bytes, key, h, slot, out);
+        }
         if key != 0 {
             // Short pretoken (≤ 15 bytes, the overwhelming majority of
             // misses): straight to byte symbols and the merge loop
@@ -1501,15 +1813,28 @@ mod verify_heavy {
         let mut scratch: Vec<u32> = Vec::new();
         let mut pos = 0usize;
         loop {
-            let (seg_end, added) = match tok.find_added_token(input, pos) {
-                Some((s, e, id)) => (s, Some((e, id))),
+            let (mut seg_end, added) = match tok.find_added_token(input, pos) {
+                Some((s, e, i)) => {
+                    let t = &tok.added_tokens[i];
+                    (s, Some((e, t.id, t.lstrip, t.rstrip)))
+                }
                 None => (input.len(), None),
             };
-            let segment = if tok.normalize_nfc {
+            if let Some((_, _, true, _)) = added {
+                seg_end = pos + trim_ws_end(&input[pos..seg_end]);
+            }
+            let mut segment = if tok.normalize_nfc {
                 nfc_segment(&input[pos..seg_end], &mut nfc_buf)
             } else {
                 &input[pos..seg_end]
             };
+            let mut prefix_buf;
+            if tok.add_prefix_space && !segment.is_empty() && segment[0] != b' ' {
+                prefix_buf = Vec::with_capacity(segment.len() + 1);
+                prefix_buf.push(b' ');
+                prefix_buf.extend_from_slice(segment);
+                segment = &prefix_buf;
+            }
             let mut seg_off = 0usize;
             for pretoken in tok.pretokenizer_type.pretokenize(segment) {
                 scratch.clear();
@@ -1534,14 +1859,14 @@ mod verify_heavy {
                 seg_off += pretoken.0.len();
             }
             match added {
-                Some((end, id)) => {
+                Some((end, id, _, rstrip)) => {
                     assert_eq!(
                         cached.get(idx).copied(),
                         Some(id.0),
                         "{label}: added-token id mismatch at bytes {pos}..{end}"
                     );
                     idx += 1;
-                    pos = end;
+                    pos = if rstrip { end + trim_ws_start(&input[end..]) } else { end };
                 }
                 None => break,
             }
@@ -1566,7 +1891,7 @@ mod verify_heavy {
     /// built WITHOUT `find_added_token`, so the Aho-Corasick split itself
     /// is under test, not just mirrored.
     fn join_differential(tok: &mut Tokenizer, corpus: &[u8], label: &str) {
-        let Some((sep, sep_id)) = tok.added_tokens.first().map(|(c, i)| (c.to_vec(), *i)) else {
+        let Some((sep, sep_id)) = tok.added_tokens.first().map(|t| (t.content.to_vec(), t.id)) else {
             eprintln!("{label}: no added tokens registered; skipping join differential");
             return;
         };
@@ -1574,7 +1899,8 @@ mod verify_heavy {
         // mask every added-token occurrence so pieces are separator-free
         // and the expected stream can be built without find_added_token.
         let mut corpus: Vec<u8> = corpus.to_vec();
-        for (content, _) in tok.added_tokens.clone() {
+        for t in tok.added_tokens.clone() {
+            let content = &t.content;
             let hits: Vec<usize> = memchr::memmem::find_iter(&corpus, &content[..]).collect();
             for pos in hits {
                 corpus[pos] = b'~';
@@ -1599,7 +1925,7 @@ mod verify_heavy {
             if tok
                 .added_tokens
                 .iter()
-                .any(|(c, _)| memchr::memmem::find(piece, c).is_some())
+                .any(|t| memchr::memmem::find(piece, &t.content).is_some())
             {
                 continue;
             }

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -591,8 +591,8 @@ fn detect_pretokenizer_type(
 }
 
 /// Whether a `ByteLevel` pre-tokenizer anywhere in the chain sets
-/// `add_prefix_space` (RoBERTa-style exports): each added-token-split
-/// segment then gets a leading space prepended before pretokenization.
+/// `add_prefix_space` (see the `Tokenizer::add_prefix_space` field for the
+/// semantics).
 fn detect_add_prefix_space(pre_tokenizer: &Option<PreTokenizerJson>) -> bool {
     fn walk(pt: &PreTokenizerJson) -> bool {
         (pt.kind == "ByteLevel" && pt.add_prefix_space == Some(true))
@@ -703,7 +703,7 @@ fn build_bpe(tj: &TokenizerJson) -> Result<bpe::tiktoken::Tokenizer> {
     // Llama-3, ...). Fairseq-heritage vocabs (RoBERTa/OPT/DeBERTa) order IDs
     // by corpus frequency instead; those carry their explicit list position
     // as the rank.
-    let id_order_ok = entries.windows(2).all(|w| w[0].2 <= w[1].2);
+    let id_order_ok = entries.is_sorted_by_key(|&(_, _, merged)| merged);
     let mut tokenizer = if id_order_ok {
         let mut merges: HashMap<(TokenId, TokenId), TokenId, FxBuildHasher> =
             HashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
@@ -732,7 +732,7 @@ fn build_bpe(tj: &TokenizerJson) -> Result<bpe::tiktoken::Tokenizer> {
         tj.added_tokens
             .iter()
             .map(|t| bpe::tiktoken::AddedTokenDef {
-                content: t.content.as_bytes().to_vec(),
+                content: t.content.as_bytes().into(),
                 id: TokenId::from(t.id),
                 lstrip: t.lstrip,
                 rstrip: t.rstrip,
@@ -813,12 +813,7 @@ mod tests {
         merges: &[(&str, &str)],
         added_tokens_json: &str,
     ) -> Vec<u8> {
-        byte_level_json_with_pretok(
-            extra_vocab,
-            merges,
-            added_tokens_json,
-            "{\"type\": \"ByteLevel\"}",
-        )
+        byte_level_json_with_pretok(extra_vocab, merges, added_tokens_json, r#"{"type": "ByteLevel"}"#)
     }
 
     fn byte_level_json_with_pretok(
@@ -894,8 +889,8 @@ mod tests {
     /// to a match, like HF's AddedVocabulary.
     #[test]
     fn test_added_token_lstrip_rstrip() {
-        let added = "{\"id\": 400, \"content\": \"<m>\", \"lstrip\": true, \"special\": true}, \
-                     {\"id\": 401, \"content\": \"<r>\", \"rstrip\": true, \"special\": true}";
+        let added = r#"{"id": 400, "content": "<m>", "lstrip": true, "special": true},
+                     {"id": 401, "content": "<r>", "rstrip": true, "special": true}"#;
         let json = byte_level_json(&[], &[], added);
         let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
             panic!("expected ByteLevel BPE");
@@ -923,12 +918,12 @@ mod tests {
     /// segments (adjacent added tokens, leading added token) do not.
     #[test]
     fn test_byte_level_add_prefix_space() {
-        let added = "{\"id\": 400, \"content\": \"<m>\", \"lstrip\": true, \"special\": true}";
+        let added = r#"{"id": 400, "content": "<m>", "lstrip": true, "special": true}"#;
         let json = byte_level_json_with_pretok(
             &[],
             &[],
             added,
-            "{\"type\": \"ByteLevel\", \"add_prefix_space\": true}",
+            r#"{"type": "ByteLevel", "add_prefix_space": true}"#,
         );
         let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
             panic!("expected ByteLevel BPE");

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -590,6 +590,17 @@ fn detect_pretokenizer_type(
     })
 }
 
+/// Whether a `ByteLevel` pre-tokenizer anywhere in the chain sets
+/// `add_prefix_space` (RoBERTa-style exports): each added-token-split
+/// segment then gets a leading space prepended before pretokenization.
+fn detect_add_prefix_space(pre_tokenizer: &Option<PreTokenizerJson>) -> bool {
+    fn walk(pt: &PreTokenizerJson) -> bool {
+        (pt.kind == "ByteLevel" && pt.add_prefix_space == Some(true))
+            || pt.pretokenizers.iter().any(walk)
+    }
+    pre_tokenizer.as_ref().is_some_and(walk)
+}
+
 // ---------------------------------------------------------------------------
 // GPT-2 / ByteLevel BPE loader
 // ---------------------------------------------------------------------------
@@ -662,8 +673,7 @@ fn build_bpe(tj: &TokenizerJson) -> Result<bpe::tiktoken::Tokenizer> {
 
     // Build merges from the merge list. Each merge "a b" means:
     // look up token IDs for "a" and "b", the merged token is vocab[concat(a,b)].
-    let mut merges: HashMap<(TokenId, TokenId), TokenId, FxBuildHasher> =
-        HashMap::with_capacity_and_hasher(tj.model.merges.len(), FxBuildHasher);
+    let mut entries: Vec<(TokenId, TokenId, TokenId)> = Vec::with_capacity(tj.model.merges.len());
     for [str_a, str_b] in &tj.model.merges {
         let bytes_a = unicode_to_bytes(str_a, &u2b);
         let bytes_b = unicode_to_bytes(str_b, &u2b);
@@ -681,25 +691,52 @@ fn build_bpe(tj: &TokenizerJson) -> Result<bpe::tiktoken::Tokenizer> {
             Some(&id) => id,
             None => continue,
         };
-        merges.entry((id_a, id_b)).or_insert(id_merged);
+        entries.push((id_a, id_b, id_merged));
     }
 
     let byte_remapping = bpe::ByteRemapping::from_byte_vocab(&vocab)?;
+    let vocab: Vec<Vec<u8>> = vocab.into_iter().map(|a| a.to_vec()).collect();
 
-    let mut tokenizer = bpe::tiktoken::Tokenizer::new(
-        merges,
-        vocab.into_iter().map(|a| a.to_vec()).collect(),
-        byte_remapping,
-    );
+    // The fast merge loops take the merged token's ID as the merge priority,
+    // which is only correct when the merge list produces IDs in rank order
+    // (true for every tiktoken-style vocab: GPT-2, cl100k, o200k, Qwen,
+    // Llama-3, ...). Fairseq-heritage vocabs (RoBERTa/OPT/DeBERTa) order IDs
+    // by corpus frequency instead; those carry their explicit list position
+    // as the rank.
+    let id_order_ok = entries.windows(2).all(|w| w[0].2 <= w[1].2);
+    let mut tokenizer = if id_order_ok {
+        let mut merges: HashMap<(TokenId, TokenId), TokenId, FxBuildHasher> =
+            HashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
+        for (id_a, id_b, id_merged) in entries {
+            merges.entry((id_a, id_b)).or_insert(id_merged);
+        }
+        bpe::tiktoken::Tokenizer::new(merges, vocab, byte_remapping)
+    } else {
+        let mut merges: bpe::tiktoken::RankedMerges =
+            HashMap::with_capacity_and_hasher(entries.len(), FxBuildHasher);
+        for (rank, (id_a, id_b, id_merged)) in entries.into_iter().enumerate() {
+            merges
+                .entry(bpe::ranked_merge_key(id_a, id_b))
+                .or_insert((id_merged, rank as u32));
+        }
+        bpe::tiktoken::Tokenizer::new_ranked(merges, vocab, byte_remapping)
+    };
     tokenizer.set_pretokenizer_type(detect_pretokenizer_type(&tj.pre_tokenizer)?);
     tokenizer.set_normalize_nfc(detect_nfc_normalizer(&tj.normalizer)?);
+    tokenizer.set_add_prefix_space(detect_add_prefix_space(&tj.pre_tokenizer));
     tokenizer.set_ignore_merges(tj.model.ignore_merges);
     // All added tokens (special and non-special) are matched atomically in the
-    // raw input by HF's AddedVocabulary; mirror that.
+    // raw input by HF's AddedVocabulary; mirror that, including the
+    // whitespace-stripping flags.
     tokenizer.set_added_tokens(
         tj.added_tokens
             .iter()
-            .map(|t| (t.content.as_bytes().to_vec(), TokenId::from(t.id)))
+            .map(|t| bpe::tiktoken::AddedTokenDef {
+                content: t.content.as_bytes().to_vec(),
+                id: TokenId::from(t.id),
+                lstrip: t.lstrip,
+                rstrip: t.rstrip,
+            })
             .collect(),
     );
     Ok(tokenizer)
@@ -765,6 +802,147 @@ mod tests {
         eprintln!("Encoded: {:?}", ids);
         let decoded = tokenizer.decode(&ids);
         assert_eq!(decoded, b"Hello world");
+    }
+
+    /// Build a minimal ByteLevel tokenizer.json: the 256 byte tokens (ID ==
+    /// byte value), plus `extra_vocab` entries and `merges` given as raw
+    /// text (converted to the GPT-2 unicode encoding here), plus raw
+    /// `added_tokens` JSON.
+    fn byte_level_json(
+        extra_vocab: &[(&str, u32)],
+        merges: &[(&str, &str)],
+        added_tokens_json: &str,
+    ) -> Vec<u8> {
+        byte_level_json_with_pretok(
+            extra_vocab,
+            merges,
+            added_tokens_json,
+            "{\"type\": \"ByteLevel\"}",
+        )
+    }
+
+    fn byte_level_json_with_pretok(
+        extra_vocab: &[(&str, u32)],
+        merges: &[(&str, &str)],
+        added_tokens_json: &str,
+        pre_tokenizer_json: &str,
+    ) -> Vec<u8> {
+        let (b2u, _) = build_byte_unicode_tables();
+        let esc = |s: String| -> String { s.replace('\\', "\\\\").replace('"', "\\\"") };
+        let enc = |s: &str| -> String { esc(s.bytes().map(|b| b2u[b as usize]).collect()) };
+        let mut vocab_entries: Vec<String> = (0u16..=255)
+            .map(|b| format!("\"{}\": {}", esc(b2u[b as usize].to_string()), b))
+            .collect();
+        for (text, id) in extra_vocab {
+            vocab_entries.push(format!("\"{}\": {}", enc(text), id));
+        }
+        let merges_entries: Vec<String> = merges
+            .iter()
+            .map(|(a, b)| format!("[\"{}\", \"{}\"]", enc(a), enc(b)))
+            .collect();
+        format!(
+            "{{\"added_tokens\": [{}], \"pre_tokenizer\": {}, \
+             \"model\": {{\"type\": \"BPE\", \"vocab\": {{{}}}, \"merges\": [{}]}}}}",
+            added_tokens_json,
+            pre_tokenizer_json,
+            vocab_entries.join(", "),
+            merges_entries.join(", ")
+        )
+        .into_bytes()
+    }
+
+    fn encode_bpe(tok: &mut bpe::tiktoken::Tokenizer, text: &str) -> Vec<u32> {
+        let mut out = Vec::new();
+        tok.encode_with_added_tokens_flat(text.as_bytes(), &mut out);
+        out
+    }
+
+    /// Merge priority must follow the merge list's order even when the
+    /// merged token IDs do not (fairseq-heritage vocabs: RoBERTa/OPT).
+    #[test]
+    fn test_rank_mapped_merges_follow_list_order() {
+        // Rank 0 produces ID 350, rank 1 produces ID 300: IDs are NOT in
+        // rank order, so id-as-rank would apply "a"+"b" (300) before
+        // "b"+"c" (350) and produce [300, 99] on "abc".
+        let json = byte_level_json(
+            &[("bc", 350), ("ab", 300)],
+            &[("b", "c"), ("a", "b")],
+            "",
+        );
+        let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
+            panic!("expected ByteLevel BPE");
+        };
+        assert_eq!(encode_bpe(&mut tok, "abc"), vec![97, 350]);
+        // Rank order also decides between two live candidates mid-word.
+        assert_eq!(encode_bpe(&mut tok, "ab"), vec![300]);
+        assert_eq!(encode_bpe(&mut tok, "bc"), vec![350]);
+
+        // Same merges with IDs in rank order stay on the id-as-rank fast
+        // path and agree.
+        let json = byte_level_json(
+            &[("bc", 300), ("ab", 350)],
+            &[("b", "c"), ("a", "b")],
+            "",
+        );
+        let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
+            panic!("expected ByteLevel BPE");
+        };
+        assert_eq!(encode_bpe(&mut tok, "abc"), vec![97, 300]);
+    }
+
+    /// `lstrip`/`rstrip` added-token flags absorb the whitespace adjacent
+    /// to a match, like HF's AddedVocabulary.
+    #[test]
+    fn test_added_token_lstrip_rstrip() {
+        let added = "{\"id\": 400, \"content\": \"<m>\", \"lstrip\": true, \"special\": true}, \
+                     {\"id\": 401, \"content\": \"<r>\", \"rstrip\": true, \"special\": true}";
+        let json = byte_level_json(&[], &[], added);
+        let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
+            panic!("expected ByteLevel BPE");
+        };
+        // lstrip: the whitespace before the match is absorbed, including
+        // multi-char and non-ASCII whitespace; whitespace after it is not.
+        assert_eq!(encode_bpe(&mut tok, "a <m> b"), vec![97, 400, 32, 98]);
+        assert_eq!(encode_bpe(&mut tok, "a \t\n<m>"), vec![97, 400]);
+        assert_eq!(
+            encode_bpe(&mut tok, "a\u{a0}<m>"),
+            vec![97, 400],
+            "U+00A0 is `\\s` whitespace and must be absorbed"
+        );
+        // rstrip: the whitespace after the match is absorbed.
+        assert_eq!(encode_bpe(&mut tok, "a <r> b"), vec![97, 32, 401, 98]);
+        assert_eq!(encode_bpe(&mut tok, "<r>\n\n\nb"), vec![401, 98]);
+        // Back-to-back: <r>'s rstrip consumes the gap before <m>.
+        assert_eq!(encode_bpe(&mut tok, "<r> <m>"), vec![401, 400]);
+        // No flags on plain text.
+        assert_eq!(encode_bpe(&mut tok, "a b"), vec![97, 32, 98]);
+    }
+
+    /// `ByteLevel(add_prefix_space=true)` (RoBERTa-style exports): every
+    /// non-empty added-token-split segment gets a leading space; empty
+    /// segments (adjacent added tokens, leading added token) do not.
+    #[test]
+    fn test_byte_level_add_prefix_space() {
+        let added = "{\"id\": 400, \"content\": \"<m>\", \"lstrip\": true, \"special\": true}";
+        let json = byte_level_json_with_pretok(
+            &[],
+            &[],
+            added,
+            "{\"type\": \"ByteLevel\", \"add_prefix_space\": true}",
+        );
+        let HfTokenizer::Bpe(mut tok) = load_hf_slice(&json).unwrap() else {
+            panic!("expected ByteLevel BPE");
+        };
+        // "ab" -> " ab" (one pretoken), already-spaced input unchanged.
+        assert_eq!(encode_bpe(&mut tok, "ab"), vec![32, 97, 98]);
+        assert_eq!(encode_bpe(&mut tok, " ab"), vec![32, 97, 98]);
+        // Each segment around an added token gets its own prefix; the empty
+        // segment between adjacent tokens gets none (HF parity, verified
+        // against tokenizers on obi/deid_roberta_i2b2).
+        assert_eq!(encode_bpe(&mut tok, "a<m>b"), vec![32, 97, 400, 32, 98]);
+        assert_eq!(encode_bpe(&mut tok, "<m><m>"), vec![400, 400]);
+        // lstrip trim happens before the prefix is applied.
+        assert_eq!(encode_bpe(&mut tok, "x <m> y"), vec![32, 120, 400, 32, 121]);
     }
 
     #[test]

--- a/src/pretokenize/mod.rs
+++ b/src/pretokenize/mod.rs
@@ -613,12 +613,11 @@ pub fn safe_split_ranges(
     let max_blocker = blockers.iter().map(|f| f.needle().len()).max().unwrap_or(0);
     // rstrip tokens can only end at a boundary when their last byte is the
     // alphanumeric byte before the boundary space.
-    let end_blockers: Vec<memchr::memmem::Finder> = added_tokens
+    let end_blockers: Vec<&[u8]> = added_tokens
         .iter()
         .filter(|(t, rstrip)| *rstrip && t.last().is_some_and(u8::is_ascii_alphanumeric))
-        .map(|(t, _)| memchr::memmem::Finder::new(t))
+        .map(|&(t, _)| t)
         .collect();
-    let max_end_blocker = end_blockers.iter().map(|f| f.needle().len()).max().unwrap_or(0);
     // Whether an added-token occurrence spans the cut between `p - 1` and
     // `p`. Such an occurrence must start within `max_blocker - 1` bytes
     // before `p`, so searching a window of that radius is exhaustive.
@@ -631,13 +630,7 @@ pub fn safe_split_ranges(
         })
     };
     // Whether an rstrip added-token occurrence ends exactly at `p`.
-    let ends_rstrip_token = |p: usize| -> bool {
-        let lo = p.saturating_sub(max_end_blocker);
-        end_blockers.iter().any(|f| {
-            f.find_iter(&bytes[lo..p])
-                .any(|s| lo + s + f.needle().len() == p)
-        })
-    };
+    let ends_rstrip_token = |p: usize| end_blockers.iter().any(|t| bytes[..p].ends_with(t));
     let len = bytes.len();
     let target = target.max(1);
     let mut out = Vec::new();
@@ -649,7 +642,7 @@ pub fn safe_split_ranges(
                 && bytes[probe - 1].is_ascii_alphanumeric()
                 && bytes[probe + 1].is_ascii_alphabetic()
                 && !(max_blocker > 0 && cuts_added_token(probe))
-                && !(max_end_blocker > 0 && ends_rstrip_token(probe))
+                && !(!end_blockers.is_empty() && ends_rstrip_token(probe))
             {
                 out.push(start..probe);
                 start = probe;
@@ -758,13 +751,9 @@ mod test {
         check_scheme!("deepseek_v3", FastDeepSeekV3Pretokenizer::new);
     }
 
-    /// Boundaries must never cut an occurrence of a space-containing added
-    /// token, while splitting still proceeds elsewhere in the document.
-    #[test]
-    fn test_safe_split_ranges_avoids_added_tokens() {
-        let special: &[u8] = b"<|multi word special|>";
-        // Deterministic LCG so word lengths vary and split probes hit the
-        // special token at every possible phase.
+    /// Deterministic LCG word soup so word lengths vary and split probes
+    /// hit `special` (followed by `sep`) at every possible phase.
+    fn lcg_words(special: &[u8], sep: &[u8], period: usize) -> Vec<u8> {
         let mut rng = 0x9e3779b97f4a7c15u64;
         let mut next = move || {
             rng = rng
@@ -776,10 +765,20 @@ mod test {
         let mut input = Vec::new();
         for _ in 0..4000 {
             input.extend_from_slice(words[next() % words.len()]);
-            if next() % 9 == 0 {
+            if next() % period == 0 {
                 input.extend_from_slice(special);
+                input.extend_from_slice(sep);
             }
         }
+        input
+    }
+
+    /// Boundaries must never cut an occurrence of a space-containing added
+    /// token, while splitting still proceeds elsewhere in the document.
+    #[test]
+    fn test_safe_split_ranges_avoids_added_tokens() {
+        let special: &[u8] = b"<|multi word special|>";
+        let input = lcg_words(special, b"", 9);
 
         let ranges = safe_split_ranges(&input, 300, &[(special, false)]);
         assert!(ranges.len() > 50, "expected many splits, got {}", ranges.len());
@@ -814,24 +813,7 @@ mod test {
     #[test]
     fn test_safe_split_ranges_avoids_rstrip_token_ends() {
         let special: &[u8] = b"TOK1";
-        // Deterministic LCG so word lengths vary and split probes land right
-        // after the special token at every possible phase.
-        let mut rng = 0x9e3779b97f4a7c15u64;
-        let mut next = move || {
-            rng = rng
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            (rng >> 33) as usize
-        };
-        let words: [&[u8]; 5] = [b"alpha ", b"be ", b"gamma7 ", b"x ", b"delta "];
-        let mut input = Vec::new();
-        for _ in 0..4000 {
-            input.extend_from_slice(words[next() % words.len()]);
-            if next() % 6 == 0 {
-                input.extend_from_slice(special);
-                input.extend_from_slice(b" ");
-            }
-        }
+        let input = lcg_words(special, b" ", 6);
         let ends_at = |p: usize| p >= special.len() && &input[p - special.len()..p] == special;
 
         let ranges = safe_split_ranges(&input, 200, &[(special, true)]);

--- a/src/pretokenize/mod.rs
+++ b/src/pretokenize/mod.rs
@@ -583,25 +583,42 @@ impl Pretokenize for [u8] {
 /// three ASCII bytes also cannot sit inside a multi-byte UTF-8 character.
 ///
 /// `added_tokens` are the byte sequences matched atomically *before*
-/// pretokenization (see `Tokenizer::encode_with_added_tokens`); a candidate
-/// boundary is rejected when an occurrence of one straddles it, since the
-/// halves would otherwise be BPE-encoded as plain text. Only tokens that
-/// contain a space can ever straddle a boundary (every boundary sits on a
-/// space byte), so for typical vocabularies the check costs nothing. If no
-/// occurrence crosses a boundary, greedy leftmost-longest matching restarted
-/// there reproduces the single-pass matches: the matcher's only state is its
-/// scan position, and no match can carry it across the boundary.
+/// pretokenization (see `Tokenizer::encode_with_added_tokens`), each paired
+/// with its `rstrip` flag; a candidate boundary is rejected when an
+/// occurrence of one straddles it, since the halves would otherwise be
+/// BPE-encoded as plain text. Only tokens that contain a space can ever
+/// straddle a boundary (every boundary sits on a space byte), so for typical
+/// vocabularies the check costs nothing. If no occurrence crosses a
+/// boundary, greedy leftmost-longest matching restarted there reproduces the
+/// single-pass matches: the matcher's only state is its scan position, and
+/// no match can carry it across the boundary.
+///
+/// An `rstrip` token absorbs the whitespace after its match, so a boundary
+/// is also rejected when such an occurrence ends exactly at it — the space
+/// opening the next chunk would encode as plain text instead of being
+/// absorbed. (`lstrip` needs no counterpart: a boundary space preceding a
+/// match lands at the start of the next chunk and is trimmed identically
+/// there, and a boundary can never sit inside a longer whitespace run
+/// because the byte before it must be alphanumeric.)
 pub fn safe_split_ranges(
     bytes: &[u8],
     target: usize,
-    added_tokens: &[&[u8]],
+    added_tokens: &[(&[u8], bool)],
 ) -> Vec<std::ops::Range<usize>> {
     let blockers: Vec<memchr::memmem::Finder> = added_tokens
         .iter()
-        .filter(|t| t.contains(&b' '))
-        .map(memchr::memmem::Finder::new)
+        .filter(|(t, _)| t.contains(&b' '))
+        .map(|(t, _)| memchr::memmem::Finder::new(t))
         .collect();
     let max_blocker = blockers.iter().map(|f| f.needle().len()).max().unwrap_or(0);
+    // rstrip tokens can only end at a boundary when their last byte is the
+    // alphanumeric byte before the boundary space.
+    let end_blockers: Vec<memchr::memmem::Finder> = added_tokens
+        .iter()
+        .filter(|(t, rstrip)| *rstrip && t.last().is_some_and(u8::is_ascii_alphanumeric))
+        .map(|(t, _)| memchr::memmem::Finder::new(t))
+        .collect();
+    let max_end_blocker = end_blockers.iter().map(|f| f.needle().len()).max().unwrap_or(0);
     // Whether an added-token occurrence spans the cut between `p - 1` and
     // `p`. Such an occurrence must start within `max_blocker - 1` bytes
     // before `p`, so searching a window of that radius is exhaustive.
@@ -611,6 +628,14 @@ pub fn safe_split_ranges(
         blockers.iter().any(|f| {
             f.find_iter(&bytes[lo..hi])
                 .any(|s| lo + s < p && lo + s + f.needle().len() > p)
+        })
+    };
+    // Whether an rstrip added-token occurrence ends exactly at `p`.
+    let ends_rstrip_token = |p: usize| -> bool {
+        let lo = p.saturating_sub(max_end_blocker);
+        end_blockers.iter().any(|f| {
+            f.find_iter(&bytes[lo..p])
+                .any(|s| lo + s + f.needle().len() == p)
         })
     };
     let len = bytes.len();
@@ -624,6 +649,7 @@ pub fn safe_split_ranges(
                 && bytes[probe - 1].is_ascii_alphanumeric()
                 && bytes[probe + 1].is_ascii_alphabetic()
                 && !(max_blocker > 0 && cuts_added_token(probe))
+                && !(max_end_blocker > 0 && ends_rstrip_token(probe))
             {
                 out.push(start..probe);
                 start = probe;
@@ -755,7 +781,7 @@ mod test {
             }
         }
 
-        let ranges = safe_split_ranges(&input, 300, &[special]);
+        let ranges = safe_split_ranges(&input, 300, &[(special, false)]);
         assert!(ranges.len() > 50, "expected many splits, got {}", ranges.len());
         assert_eq!(ranges.first().unwrap().start, 0);
         assert_eq!(ranges.last().unwrap().end, input.len());
@@ -779,6 +805,47 @@ mod test {
         assert!(
             unaware[1..].iter().any(|r| cuts_occurrence(r.start)),
             "test input never places a naive boundary inside the special token"
+        );
+    }
+
+    /// A boundary must never sit right after an rstrip added-token
+    /// occurrence: the boundary space would open the next chunk as plain
+    /// text instead of being absorbed by the token's rstrip.
+    #[test]
+    fn test_safe_split_ranges_avoids_rstrip_token_ends() {
+        let special: &[u8] = b"TOK1";
+        // Deterministic LCG so word lengths vary and split probes land right
+        // after the special token at every possible phase.
+        let mut rng = 0x9e3779b97f4a7c15u64;
+        let mut next = move || {
+            rng = rng
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            (rng >> 33) as usize
+        };
+        let words: [&[u8]; 5] = [b"alpha ", b"be ", b"gamma7 ", b"x ", b"delta "];
+        let mut input = Vec::new();
+        for _ in 0..4000 {
+            input.extend_from_slice(words[next() % words.len()]);
+            if next() % 6 == 0 {
+                input.extend_from_slice(special);
+                input.extend_from_slice(b" ");
+            }
+        }
+        let ends_at = |p: usize| p >= special.len() && &input[p - special.len()..p] == special;
+
+        let ranges = safe_split_ranges(&input, 200, &[(special, true)]);
+        assert!(ranges.len() > 50, "expected many splits, got {}", ranges.len());
+        for r in &ranges[1..] {
+            assert!(!ends_at(r.start), "boundary {} follows an rstrip token", r.start);
+        }
+
+        // The input must actually tempt the splitter: without the rstrip
+        // flag, some boundary lands right after an occurrence.
+        let unaware = safe_split_ranges(&input, 200, &[(special, false)]);
+        assert!(
+            unaware[1..].iter().any(|r| ends_at(r.start)),
+            "test input never places a naive boundary after the rstrip token"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes the three ByteLevel-BPE parity gaps surfaced by the top-1000 HF model sweep, moving 19 tokenizer groups (42 models) from mismatch to exact vs HF `tokenizers` — 131/132 comparable groups (454/455 models) now validate exact. The only remaining non-exact group is MobileLLaMA, where gigatoken matches raw sentencepiece byte-for-byte and the delta is transformers' legacy SP conversion.

### Fairseq-ordered vocabs (RoBERTa, OPT, DeBERTa, BLIP2, CLAP, Blenderbot)
These vocabs order IDs by corpus frequency, so merge priority cannot be the merged token's ID. The loader now checks that merged IDs are non-decreasing over the merge list; when they aren't, it builds an explicit-rank table (`ranked_merge_key(a,b) → (merged, rank)`) and cache misses run through the SP-style ranked merge loops (`bpe_merge_symbols_ranked{,_slice}`).

### Added-token `lstrip`/`rstrip` (Phi-4 line, ModernBERT `[MASK]`, granite-embedding, jina-v5)
Matches in the ByteLevel pipeline now absorb adjacent Unicode whitespace like HF's AddedVocabulary (UTF-8-aware, `str::trim`-equivalent set). `safe_split_ranges` additionally takes `(bytes, rstrip)` blockers so a parallel chunk boundary never lands right after an alnum-ending rstrip occurrence; lstrip needs no counterpart (a boundary space opens the next chunk and trims identically there — argued in the doc comment).

### `ByteLevel(add_prefix_space=true)` (RoBERTa-style exports)
Every non-empty added-token-split segment not starting with a space gets one prepended; empty segments (adjacent added tokens) get none; lstrip trimming precedes the prepend. Semantics pinned empirically against HF on `obi/deid_roberta_i2b2`.

## Performance

The id-as-rank fast paths (PairRankTable, NEON short merge) are untouched; the miss path dispatches once per pretoken into an outlined `#[cold]` ranked body, so hot codegen for id-ordered vocabularies is structurally identical to main. Interleaved A/B vs main (min-of-N MB/s, ST gpt2/qwen2.5/phi-4 cold+warm at 1 GB, MT gpt2/phi-4 at 2–6 GB): all deltas within the measured A/A noise floor (±1%+); gpt2 cold best-case identical to the MB/s. Token streams are byte-identical to main on all three ST configs.

## Testing

- 182/182 Rust tests pass (`cargo nextest run --release`), including new unit tests for ranked merge ordering, lstrip/rstrip absorption (incl. non-ASCII whitespace and back-to-back tokens), add_prefix_space segment semantics, and the rstrip split-boundary blocker.
- Python parity battery (edge cases + first-64 added tokens in context + 2 MB OWT, `add_special_tokens=False`): 20/21 previously-mismatching sweep representatives now exact; 11/11 previously-exact sanity models (Qwen 2.5/3/3.5/VL, Llama-3.2, gemma-4, gpt2, gpt-oss, whisper, Kimi K2.6) unchanged.