### PR TITLE
Refuse unsupported tokenizer model families by name

### DIFF
--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -200,7 +200,50 @@ pub enum HfTokenizer {
     SentencePiece(SentencePieceBPE),
 }
 
+/// Probes `model.type` alone, so an unsupported model family (WordPiece,
+/// Unigram, ...) is refused by name BEFORE the full BPE-shaped schema is
+/// applied —
+/// those files are valid JSON with a different `model.vocab`/`merges`
+/// shape, and the full parse would report a misleading deserializer error
+/// ("missing field `merges`", "invalid type: sequence, expected a map").
+#[derive(Deserialize)]
+struct ModelTypeProbe {
+    #[serde(default)]
+    model: Option<ModelTypeOnly>,
+}
+
+#[derive(Deserialize)]
+struct ModelTypeOnly {
+    #[serde(rename = "type")]
+    model_type: Option<String>,
+    /// Family markers for untyped legacy files (pre-0.9 `tokenizers`
+    /// omitted `model.type`): `unk_id` only exists on Unigram models
+    /// (e.g. t5-small, xlm-roberta) and `max_input_chars_per_word` only on
+    /// WordPiece (e.g. bert-base-uncased). `continuing_subword_prefix`
+    /// would NOT work for WordPiece detection: BPE serializes it too (the
+    /// original gpt2 upload has `"continuing_subword_prefix": ""`).
+    unk_id: Option<u64>,
+    max_input_chars_per_word: Option<u64>,
+}
+
 fn parse_tokenizer_json(data: &[u8]) -> Result<TokenizerJson> {
+    if let Ok(ModelTypeProbe { model: Some(m) }) = sonic_rs::from_slice::<ModelTypeProbe>(data) {
+        let family = match m.model_type.as_deref() {
+            Some("BPE") => None,
+            Some(other) => Some(other.to_string()),
+            None if m.unk_id.is_some() => Some("Unigram (untyped legacy file)".to_string()),
+            None if m.max_input_chars_per_word.is_some() => {
+                Some("WordPiece (untyped legacy file)".to_string())
+            }
+            None => None, // untyped BPE (pre-0.9 GPT-2-style files)
+        };
+        if let Some(family) = family {
+            return Err(eyre::eyre!(
+                "Unsupported model type \"{family}\": gigatoken supports BPE tokenizers \
+                 (byte-level, or SentencePiece-style with byte_fallback)"
+            ));
+        }
+    }
     // Inline the deserializer's own message (offending field, position,
     // snippet): the first line is often all that surfaces in test summaries
     // and short tracebacks.
@@ -764,6 +807,39 @@ mod tests {
         let json = br#"{"model": {"vocab": {"a": 0}, "merges": []}}"#;
         let tj = parse_tokenizer_json(json).unwrap();
         assert_eq!(tj.model.model_type, "BPE");
+    }
+
+    /// Unsupported model families must be refused by name, not with the
+    /// deserializer's shape error for the BPE schema (WordPiece has no
+    /// `merges`; Unigram's vocab is a `[piece, score]` list, not a map).
+    #[test]
+    fn test_unsupported_model_type_named_in_error() {
+        let wordpiece = br#"{"model": {"type": "WordPiece", "unk_token": "[UNK]",
+            "vocab": {"[UNK]": 0, "hello": 1}}}"#;
+        let unigram = br#"{"model": {"type": "Unigram", "unk_id": 0,
+            "vocab": [["<unk>", 0.0], ["hello", -3.1]]}}"#;
+        // Pre-0.9 tokenizers files omit model.type; the family is inferred
+        // from its marker fields (t5-small / bert-base-uncased shapes).
+        let untyped_unigram = br#"{"model": {"unk_id": 0, "vocab": [["<unk>", 0.0]]}}"#;
+        let untyped_wordpiece: &[u8] = b"{\"model\": {\"unk_token\": \"[UNK]\",
+            \"continuing_subword_prefix\": \"##\", \"max_input_chars_per_word\": 100,
+            \"vocab\": {\"[UNK]\": 0}}}";
+        for (json, name) in [
+            (&wordpiece[..], "WordPiece"),
+            (&unigram[..], "Unigram"),
+            (&untyped_unigram[..], "Unigram (untyped legacy file)"),
+            (&untyped_wordpiece[..], "WordPiece (untyped legacy file)"),
+        ] {
+            let err = match parse_tokenizer_json(json) {
+                Ok(_) => panic!("expected {name} to be refused"),
+                Err(e) => e.to_string(),
+            };
+            assert!(
+                err.contains(&format!("Unsupported model type \"{name}\"")),
+                "unhelpful {name} error: {err}"
+            );
+            assert!(!err.contains("missing field"), "shape error leaked: {err}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Follow-up from the top-1000 sweep (#18): loading a WordPiece or Unigram tokenizer.json produced raw deserializer errors that read as file corruption:

```
Failed to parse tokenizer JSON: missing field `merges` at line 1 column 466246          # all-MiniLM (WordPiece)
Failed to parse tokenizer JSON: invalid type: sequence, expected a map at column 9096716 # xlm-roberta (Unigram)
```

These families cover 138 of the top-1000 models (79 tokenizer groups), so the misleading message is the first thing many users would hit. The loader now probes `model.type` with a minimal struct before applying the full BPE-shaped schema and refuses by name:

```
Unsupported model type "WordPiece": gigatoken supports BPE tokenizers (byte-level, or SentencePiece-style with byte_fallback)
```

Untyped legacy files (pre-0.9 `tokenizers` omitted `model.type` — t5-small, xlm-roberta, bert-base-uncased) are classified by family-specific marker fields: `unk_id` → Unigram, `max_input_chars_per_word` → WordPiece. Notably `continuing_subword_prefix` does NOT work as a WordPiece marker: BPE serializes it too, and the original gpt2 upload (also untyped) carries `"continuing_subword_prefix": ""` — caught by the test suite when gpt2 briefly got refused during development.

Verified end-to-end: all-MiniLM/bge/bert (typed + untyped WordPiece) and xlm-roberta/t5/e5 (typed + untyped Unigram) get the named refusal; gpt2 (untyped BPE), Qwen3, and Llama-3.2 load unchanged. 184/184 tests pass, including a new unit test covering all four refusal shapes.