### PR TITLE
Match HF drop semantics for byte-gap BPE vocabs

### DIFF
--- a/src/bpe/mod.rs
+++ b/src/bpe/mod.rs
@@ -46,8 +46,28 @@ use std::collections::HashMap;
 pub struct ByteRemapping {
     /// Maps each byte value to the token ID of its single-byte vocab entry.
     /// The IDs need not be < 256 (e.g. DeepSeek puts its byte tokens at
-    /// 3..=258, after the special tokens).
+    /// 3..=258, after the special tokens). Under [`MissingBytePolicy::Drop`],
+    /// bytes with no vocab entry hold [`Self::DROPPED`] instead.
     mapping: Vec<TokenId>,
+    /// True when any `mapping` entry is [`Self::DROPPED`]; the remap loops
+    /// branch to a compacting variant only in that case, so complete vocabs
+    /// keep the straight-line loop.
+    has_drops: bool,
+}
+
+/// What [`ByteRemapping::from_byte_vocab`] does about a byte value that can
+/// appear in valid UTF-8 but has no single-byte vocab entry.
+#[derive(Clone, Copy)]
+pub enum MissingBytePolicy {
+    /// Refuse to build the table (tiktoken-style vocabs, where every byte
+    /// must be representable).
+    Error,
+    /// Encode the byte to nothing — HF `tokenizers` semantics for a BPE
+    /// model with `unk_token: null`, which silently skips symbols missing
+    /// from the vocab when building a word. The skipped symbol's neighbors
+    /// then merge with each other: tencent/Hy3 has no `\r` entry and
+    /// encodes `"\r\n\r\n"` exactly like `"\n\n"` — one merged token.
+    Drop,
 }
 
 /// Whether `b` can appear anywhere in a valid UTF-8 byte stream. `0xC0`/`0xC1`
@@ -58,20 +78,32 @@ fn is_valid_utf8_byte(b: u8) -> bool {
 }
 
 impl ByteRemapping {
+    /// Sentinel `mapping` entry for a byte with no vocab token under
+    /// [`MissingBytePolicy::Drop`]: the remap loops emit nothing for it.
+    const DROPPED: u32 = u32::MAX;
+
     /// Build the byte → token-ID table by scanning `vocab` for single-byte
     /// entries (lowest ID wins). Returns `None` when the mapping is the
-    /// identity (token ID == byte value), and an error if some byte value
-    /// that can appear in valid UTF-8 has no single-byte token.
+    /// identity (token ID == byte value); a byte value that can appear in
+    /// valid UTF-8 but has no single-byte token is handled per `missing`.
     ///
     /// A vocab may legitimately omit single-byte tokens for the bytes that
     /// never occur in valid UTF-8 (`0xC0`, `0xC1`, and `0xF5..=0xFF` — overlong
     /// and out-of-range lead bytes). Byte-level vocabularies trained only on
     /// UTF-8 text — e.g. ModernBERT / GPT-NeoX — drop them. Since such a byte
-    /// can never reach the merge loop from valid input, its absence is not an
-    /// error; we fill it with a placeholder ID so the table can never yield an
-    /// out-of-range `TokenId` even if fed malformed bytes.
-    pub fn from_byte_vocab(vocab: &[impl AsRef<[u8]>]) -> Result<Option<Self>> {
-        const UNSET: u32 = u32::MAX;
+    /// can never reach the merge loop from valid input, its absence is never
+    /// an error; when those are the only gaps we fill them with a placeholder
+    /// ID so the table can never yield an out-of-range `TokenId` even if fed
+    /// malformed bytes. Once a valid-UTF-8 byte is missing under `Drop`, ALL
+    /// gaps become [`Self::DROPPED`] instead — HF drops every unmapped
+    /// symbol alike, and only these vocabs pay the compacting remap loop.
+    pub fn from_byte_vocab(
+        vocab: &[impl AsRef<[u8]>],
+        missing: MissingBytePolicy,
+    ) -> Result<Option<Self>> {
+        // An unset entry doubles as the drop sentinel: under `Drop`, the
+        // gaps are already exactly the bytes that must encode to nothing.
+        const UNSET: u32 = ByteRemapping::DROPPED;
         let mut mapping = vec![TokenId::from(UNSET); 256];
         for (id, entry) in vocab.iter().enumerate() {
             if let &[b] = entry.as_ref()
@@ -80,27 +112,96 @@ impl ByteRemapping {
                 mapping[b as usize] = TokenId::from(id as u32);
             }
         }
-        if let Some(missing) = mapping
+        let gapped = mapping
             .iter()
             .enumerate()
-            .position(|(b, t)| t.0 == UNSET && is_valid_utf8_byte(b as u8))
-        {
-            return Err(anyhow!(
-                "Byte remapping failed: no single-byte vocab entry for byte {missing:#04x}"
-            ));
-        }
-        // Fill the tolerated (never-in-UTF-8) gaps with a safe placeholder so
-        // an unexpected malformed byte indexes a valid token instead of OOB.
-        for t in mapping.iter_mut() {
-            if t.0 == UNSET {
-                *t = TokenId::from(0);
+            .position(|(b, t)| t.0 == UNSET && is_valid_utf8_byte(b as u8));
+        let has_drops = match (gapped, missing) {
+            (Some(b), MissingBytePolicy::Error) => {
+                return Err(anyhow!(
+                    "Byte remapping failed: no single-byte vocab entry for byte {b:#04x}"
+                ));
             }
-        }
+            (Some(_), MissingBytePolicy::Drop) => true,
+            // Only never-in-UTF-8 gaps (if any): fill with a safe placeholder
+            // so an unexpected malformed byte indexes a valid token instead
+            // of OOB. Keeps complete-modulo-invalid vocabs on the
+            // non-compacting remap loops.
+            (None, _) => {
+                for t in mapping.iter_mut() {
+                    if t.0 == UNSET {
+                        *t = TokenId::from(0);
+                    }
+                }
+                false
+            }
+        };
         Ok(mapping
             .iter()
             .enumerate()
             .any(|(b, t)| t.0 != b as u32)
-            .then_some(ByteRemapping { mapping }))
+            .then_some(ByteRemapping { mapping, has_drops }))
+    }
+
+    /// Remap a short pretoken's bytes into `buf`, returning the symbol
+    /// count. Equal to `bytes.len()` except under drop semantics, where
+    /// unmapped bytes are skipped (possibly yielding 0 symbols).
+    #[inline]
+    pub(crate) fn remap_short(&self, bytes: &[u8], buf: &mut [TokenId]) -> usize {
+        if !self.has_drops {
+            for (dst, &b) in buf[..bytes.len()].iter_mut().zip(bytes) {
+                *dst = self.mapping[b as usize];
+            }
+            bytes.len()
+        } else {
+            let mut n = 0;
+            for &b in bytes {
+                let t = self.mapping[b as usize];
+                if t.0 != Self::DROPPED {
+                    buf[n] = t;
+                    n += 1;
+                }
+            }
+            n
+        }
+    }
+
+    /// Remap a pretoken's bytes onto the end of `symbols` (the long-pretoken
+    /// scratch path), skipping unmapped bytes under drop semantics.
+    #[inline]
+    pub(crate) fn remap_extend(&self, bytes: &[u8], symbols: &mut Vec<TokenId>) {
+        if !self.has_drops {
+            symbols.extend(bytes.iter().map(|&b| self.mapping[b as usize]));
+        } else {
+            symbols.extend(bytes.iter().filter_map(|&b| {
+                let t = self.mapping[b as usize];
+                (t.0 != Self::DROPPED).then_some(t)
+            }));
+        }
+    }
+
+    /// [`Self::remap_short`] over an optional remapping: the identity map
+    /// (token ID == byte value) when `br` is `None`.
+    #[inline]
+    pub(crate) fn remap_short_any(br: Option<&Self>, bytes: &[u8], buf: &mut [TokenId]) -> usize {
+        match br {
+            Some(br) => br.remap_short(bytes, buf),
+            None => {
+                for (dst, &b) in buf[..bytes.len()].iter_mut().zip(bytes) {
+                    *dst = TokenId::from(b as u32);
+                }
+                bytes.len()
+            }
+        }
+    }
+
+    /// [`Self::remap_extend`] over an optional remapping.
+    #[inline]
+    pub(crate) fn remap_extend_any(br: Option<&Self>, bytes: &[u8], symbols: &mut Vec<TokenId>) {
+        match br {
+            Some(br) => br.remap_extend(bytes, symbols),
+            None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
+        }
     }
 }
 
@@ -184,8 +285,17 @@ impl PairRankTable {
         // Arc-shared grid. A vocab with byte tokens above the grid keeps
         // correctness — its round-1 lookups just fall through to the flat
         // table.
-        let max_initial = byte_remapping
-            .map_or(255, |br| br.mapping.iter().map(|t| t.0).max().unwrap_or(0));
+        // DROPPED sentinels are not token IDs and never reach the merge
+        // loop; letting them through would drive the grid sizing to 2^32
+        // the moment the clamp below is widened.
+        let max_initial = byte_remapping.map_or(255, |br| {
+            br.mapping
+                .iter()
+                .map(|t| t.0)
+                .filter(|&t| t != ByteRemapping::DROPPED)
+                .max()
+                .unwrap_or(0)
+        });
         let dense_log2 = (32 - max_initial.leading_zeros()).clamp(11, 11);
         let mut dense = vec![u32::MAX; 1usize << (2 * dense_log2)].into_boxed_slice();
 
@@ -1102,6 +1212,60 @@ pub use tiktoken::Tokenizer;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 257 entries: a dummy multi-byte token at ID 0, then every single
+    /// byte at ID `byte + 1` — shifted so the mapping is never the
+    /// identity. The given bytes' slots hold a multi-byte filler instead,
+    /// keeping every other byte at its `byte + 1` ID.
+    fn shifted_byte_vocab(without: &[u8]) -> Vec<Vec<u8>> {
+        std::iter::once(b"dummy".to_vec())
+            .chain((0u16..256).map(|b| {
+                if without.contains(&(b as u8)) {
+                    format!("gap{b}").into_bytes()
+                } else {
+                    vec![b as u8]
+                }
+            }))
+            .collect()
+    }
+
+    #[test]
+    fn byte_gap_policies() {
+        // The error must name the valid-UTF-8 gap even when a tolerated
+        // never-in-UTF-8 gap (0xC0) has a smaller byte value.
+        let gap_hi = shifted_byte_vocab(&[0xC0, 0xC2]);
+        let Err(err) = ByteRemapping::from_byte_vocab(&gap_hi, MissingBytePolicy::Error) else {
+            panic!("expected a gapped vocab to be refused under Error");
+        };
+        assert!(err.to_string().contains("0xc2"), "{err}");
+
+        let gap_cr = shifted_byte_vocab(&[b'\r']);
+        assert!(ByteRemapping::from_byte_vocab(&gap_cr, MissingBytePolicy::Error).is_err());
+        let br = ByteRemapping::from_byte_vocab(&gap_cr, MissingBytePolicy::Drop)
+            .unwrap()
+            .expect("shifted IDs are not the identity");
+        assert!(br.has_drops);
+        let mut buf = [TokenId::from(0u32); 8];
+        assert_eq!(br.remap_short(b"a\rb", &mut buf), 2);
+        assert_eq!(buf[0].0, b'a' as u32 + 1);
+        assert_eq!(buf[1].0, b'b' as u32 + 1);
+        assert_eq!(br.remap_short(b"\r\r", &mut buf), 0);
+        let mut symbols = Vec::new();
+        br.remap_extend(b"\rx\r", &mut symbols);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].0, b'x' as u32 + 1);
+
+        // Gaps only at never-in-UTF-8 bytes: tolerated under both policies
+        // with the placeholder fill, never the compacting loops.
+        let invalid_only = shifted_byte_vocab(&[0xC0]);
+        for policy in [MissingBytePolicy::Error, MissingBytePolicy::Drop] {
+            let br = ByteRemapping::from_byte_vocab(&invalid_only, policy)
+                .unwrap()
+                .expect("shifted IDs are not the identity");
+            assert!(!br.has_drops);
+            assert_eq!(br.remap_short(b"ab", &mut buf), 2);
+        }
+    }
 
     /// Minimal deterministic RNG (xorshift64*) so the differential tests
     /// need no dev-dependency.

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1,6 +1,7 @@
 use crate::bpe::pretoken_cache::ShortPretokenCache;
 use crate::bpe::{
-    ByteRemapping, MergeScratch, PairRankTable, SHORT_MERGE_MAX, bpe_merge_symbols_by_rank,
+    ByteRemapping, MergeScratch, MissingBytePolicy, PairRankTable, SHORT_MERGE_MAX,
+    bpe_merge_symbols_by_rank,
     bpe_merge_symbols_ranked, bpe_merge_symbols_ranked_slice, bpe_merge_symbols_short_scalar,
     bpe_merge_symbols_with_scratch, simple_bpe_merge,
 };
@@ -495,20 +496,8 @@ impl Tokenizer {
                 return 1;
             }
         }
-        let n = bytes.len();
-        debug_assert!((1..SHORT_MERGE_MAX).contains(&n));
-        match byte_remapping {
-            Some(br) => {
-                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
-                    *dst = br.mapping[b as usize];
-                }
-            }
-            None => {
-                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
-                    *dst = TokenId(b as u32);
-                }
-            }
-        }
+        debug_assert!((1..SHORT_MERGE_MAX).contains(&bytes.len()));
+        let n = ByteRemapping::remap_short_any(byte_remapping, bytes, buf);
         if n < 2 {
             return n;
         }
@@ -528,20 +517,8 @@ impl Tokenizer {
         bytes: &[u8],
         buf: &mut [TokenId; SHORT_MERGE_MAX],
     ) -> usize {
-        let n = bytes.len();
-        debug_assert!((1..SHORT_MERGE_MAX).contains(&n));
-        match byte_remapping {
-            Some(br) => {
-                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
-                    *dst = br.mapping[b as usize];
-                }
-            }
-            None => {
-                for (dst, &b) in buf[..n].iter_mut().zip(bytes) {
-                    *dst = TokenId(b as u32);
-                }
-            }
-        }
+        debug_assert!((1..SHORT_MERGE_MAX).contains(&bytes.len()));
+        let n = ByteRemapping::remap_short_any(byte_remapping, bytes, buf);
         if n < 2 {
             return n;
         }
@@ -613,7 +590,7 @@ impl Tokenizer {
             merges.insert((tokenized[0], tokenized[1]), TokenId::from(token_idx));
         }
 
-        let byte_remapping = ByteRemapping::from_byte_vocab(&vocab)?;
+        let byte_remapping = ByteRemapping::from_byte_vocab(&vocab, MissingBytePolicy::Error)?;
         Ok(Self::from_tables(merges, None, vocab, byte_remapping))
     }
 
@@ -1261,10 +1238,7 @@ impl Tokenizer {
             {
                 symbols.push(id);
             } else {
-                match self.byte_remapping.as_ref() {
-                    Some(br) => symbols.extend(bytes.iter().map(|&b| br.mapping[b as usize])),
-                    None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
-                }
+                ByteRemapping::remap_extend_any(self.byte_remapping.as_ref(), bytes, symbols);
                 bpe_merge_symbols_ranked(&rm, symbols);
             }
             let len = symbols.len() as u32;
@@ -1341,10 +1315,7 @@ impl Tokenizer {
             {
                 symbols.push(id);
             } else {
-                match self.byte_remapping.as_ref() {
-                    Some(br) => symbols.extend(bytes.iter().map(|&b| br.mapping[b as usize])),
-                    None => symbols.extend(bytes.iter().map(|&b| TokenId::from(b as u32))),
-                }
+                ByteRemapping::remap_extend_any(self.byte_remapping.as_ref(), bytes, symbols);
                 match self.pair_ranks.as_deref() {
                     Some(table) => bpe_merge_symbols_by_rank(
                         &|a, b| table.rank(a, b),
@@ -1412,10 +1383,8 @@ mod test_util {
     /// loop over the merges HashMap (no pair-rank table, no cache, no
     /// short-merge kernels).
     pub(super) fn plain_encode_pretoken(tok: &Tokenizer, pretoken: &[u8], out: &mut Vec<u32>) {
-        let mut symbols: Vec<TokenId> = match tok.byte_remapping.as_ref() {
-            Some(br) => pretoken.iter().map(|&b| br.mapping[b as usize]).collect(),
-            None => pretoken.iter().map(|&b| TokenId::from(b as u32)).collect(),
-        };
+        let mut symbols: Vec<TokenId> = Vec::new();
+        ByteRemapping::remap_extend_any(tok.byte_remapping.as_ref(), pretoken, &mut symbols);
         crate::bpe::bpe_merge_symbols(&tok.merges, &mut symbols);
         out.extend(symbols.iter().map(|t| t.0));
     }
@@ -1919,10 +1888,8 @@ mod verify_heavy {
 
         // Uncached reference: remap bytes and run the plain merge loop.
         let encode_reference = |pretoken: Pretoken| -> Vec<TokenId> {
-            let mut symbols: Vec<TokenId> = match tokenizer.byte_remapping.as_ref() {
-                Some(br) => pretoken.iter().map(|&b| br.mapping[b as usize]).collect(),
-                None => pretoken.iter().map(|&b| TokenId::from(b as u32)).collect(),
-            };
+            let mut symbols: Vec<TokenId> = Vec::new();
+            ByteRemapping::remap_extend_any(tokenizer.byte_remapping.as_ref(), pretoken.0, &mut symbols);
             crate::bpe::bpe_merge_symbols(&tokenizer.merges, &mut symbols);
             symbols
         };

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -104,6 +104,10 @@ struct Model {
     /// DeepSeek V3, Llama 3).
     #[serde(default)]
     ignore_merges: bool,
+    /// HF BPE `unk_token`; decides byte-gap handling (see the
+    /// `MissingBytePolicy` choice at the `from_byte_vocab` call).
+    #[serde(default)]
+    unk_token: Option<String>,
 }
 
 fn legacy_bpe_type() -> String {
@@ -737,7 +741,15 @@ fn build_bpe(tj: &TokenizerJson) -> Result<bpe::tiktoken::Tokenizer> {
         entries.push((id_a, id_b, id_merged));
     }
 
-    let byte_remapping = bpe::ByteRemapping::from_byte_vocab(&vocab)?;
+    // With no unk token, HF BPE drops unmapped symbols instead of erroring
+    // (tencent/Hy3 ships no `\r` entry); with one, a byte-gap vocab would
+    // need unk substitution (never seen on a byte-level BPE) — keep the
+    // load error for that combination.
+    let missing = match tj.model.unk_token {
+        None => bpe::MissingBytePolicy::Drop,
+        Some(_) => bpe::MissingBytePolicy::Error,
+    };
+    let byte_remapping = bpe::ByteRemapping::from_byte_vocab(&vocab, missing)?;
     let vocab: Vec<Vec<u8>> = vocab.into_iter().map(|a| a.to_vec()).collect();
 
     // The fast merge loops take the merged token's ID as the merge priority,

--- a/tests/test_byte_gap_vocab.py
+++ b/tests/test_byte_gap_vocab.py
@@ -1,0 +1,120 @@
+"""Byte-gap vocabs (tencent/Hy3 style): a BPE model with `unk_token: null`
+whose vocab lacks single-byte entries for some bytes (Hy3 ships none for
+`\\r` or the never-in-UTF-8 bytes). HF `tokenizers` silently drops the
+unmapped symbol when building a word — so the dropped byte's neighbors merge
+with each other afterwards — and we must match, not refuse to load.
+
+The synthetic configs borrow Hy3's real pre_tokenizer chain so both sides
+split identically (a bare ByteLevel would not: gigatoken maps it to the GPT-2
+scheme regardless of `use_regex`).
+"""
+
+import json
+
+import pytest
+from tokenizers import Tokenizer as HFTokenizer
+
+import gigatoken
+from hf_cache import hf_file
+
+# a-z single-char tokens; no entries for \r, \x00, 0xC3/0xA9 (é), digits, ...
+LETTERS = {chr(c): i for i, c in enumerate(range(ord("a"), ord("z") + 1))}
+
+PROBES = [
+    "ab",
+    "a\rb",  # \r pretokenizes alone and encodes to nothing
+    "aéb",  # é's bytes drop INSIDE the pretoken: a and b must still merge
+    "\x00ab",  # \x00 joins the following letters, drops, and ab merges
+    "c\rd",
+    "aé\rb",
+    "\r",
+    "\r\r\r",
+    "",
+    "123",  # no digit tokens: a whole pretoken of drops
+    # long pretokens (> 15 bytes) take the scratch-Vec arm
+    "x" * 20 + "éab",
+    "é" * 10,
+    ("ab" * 10) + "é" + ("cd" * 10),
+]
+
+
+@pytest.fixture(scope="module")
+def hy3_config():
+    return json.loads(hf_file("tencent/Hy3", "tokenizer.json").read_text())
+
+
+def _write_config(tmp_path, hy3_config, vocab, merges, unk_token=None):
+    cfg = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [],
+        "normalizer": None,
+        "pre_tokenizer": hy3_config["pre_tokenizer"],
+        "post_processor": None,
+        "decoder": None,
+        "model": {
+            "type": "BPE",
+            "dropout": None,
+            "unk_token": unk_token,
+            "continuing_subword_prefix": None,
+            "end_of_word_suffix": None,
+            "fuse_unk": False,
+            "byte_fallback": False,
+            "ignore_merges": False,
+            "vocab": vocab,
+            "merges": merges,
+        },
+    }
+    path = tmp_path / "tokenizer.json"
+    path.write_text(json.dumps(cfg))
+    return path
+
+
+@pytest.mark.parametrize(
+    "merged_ids,merges",
+    [
+        # merge-list order == merged-id order: the id-as-rank fast tables
+        ({"ab": 26, "cd": 27}, [["a", "b"], ["c", "d"]]),
+        # out of id order: the explicit-rank (RankedMerges) path
+        ({"cd": 26, "ab": 27}, [["a", "b"], ["c", "d"]]),
+    ],
+    ids=["id_ordered", "ranked"],
+)
+def test_byte_gap_drop_matches_hf(tmp_path, hy3_config, merged_ids, merges):
+    path = _write_config(tmp_path, hy3_config, LETTERS | merged_ids, merges)
+    ref = HFTokenizer.from_file(str(path))
+    giga = gigatoken.Tokenizer(path)
+    for probe in PROBES:
+        expected = ref.encode(probe, add_special_tokens=False).ids
+        assert giga.encode(probe).tolist() == expected, repr(probe)
+
+
+def test_hy3_full_vocab_matches_hf():
+    path = hf_file("tencent/Hy3", "tokenizer.json")
+    ref = HFTokenizer.from_file(str(path))
+    giga = gigatoken.Tokenizer(path)
+    texts = [
+        "Hello world",
+        "line one\r\nline two\rlone CR",
+        "\r",
+        "a\rb",
+        "tab\tand\x00nul\x01ctl",
+        "The quick brown fox jumps over the lazy dog.",
+        "人工智能正在改变世界。使用Python调用API接口。",
+        "café résumé naïve\r\n" * 20,
+        "def foo(x: int) -> int:\r\n    return x + 1\r\n",
+    ]
+    for text in texts:
+        expected = ref.encode(text, add_special_tokens=False).ids
+        assert giga.encode(text).tolist() == expected, repr(text)
+
+
+def test_byte_gap_with_unk_token_still_refused(tmp_path, hy3_config):
+    # unk substitution for missing bytes is not implemented; a gapped vocab
+    # WITH an unk token must keep the loud load error rather than drop bytes.
+    path = _write_config(
+        tmp_path, hy3_config, LETTERS | {"<unk>": 26}, [], unk_token="<unk>"
+    )
+    with pytest.raises(RuntimeError, match="Byte remapping failed"):
+        gigatoken.Tokenizer(path)


### PR DESCRIPTION
## What

HF `tokenizers`' BPE with `unk_token: null` silently drops a symbol that has no vocab entry when building a word — and the dropped symbol's neighbors then merge with each other. tencent/Hy3 (currently the most-used model on OpenRouter, surfaced by the OpenRouter top-100 parity sweep) ships a vocab with no single-byte entry for `0x0D`, so `"\r\n\r\n"` encodes exactly like `"\n\n"` under HF while gigatoken refused to load the tokenizer (`Byte remapping failed: no single-byte vocab entry for byte 0xd`).

`ByteRemapping::from_byte_vocab` now takes a `MissingBytePolicy`:

- the tokenizer.json loader passes `Drop` when `model.unk_token` is null — missing bytes map to a `DROPPED` sentinel and are compacted out of the symbol sequence *before* the merge loop (so neighbors merge, matching HF);
- tiktoken-style vocabs and the (never observed) gapped-vocab-with-unk combination keep the loud load error;
- vocabs whose only gaps are the never-in-UTF-8 bytes (`0xC0`, `0xC1`, `0xF5..=0xFF` — ModernBERT, GPT-NeoX) keep the existing placeholder fill and `has_drops = false`.

## Hot-path impact

None for previously-loading tokenizers, by construction: `has_drops` is tested once per remap call (miss/seed path only — never per byte, never on the cache-hit loop), and each arm carries its own complete loop, the non-drop arm being token-for-token the previously inlined code. The four hand-rolled remap loops in `tiktoken.rs` collapse into shared `remap_short_any` / `remap_extend_any` helpers, so the diff there is mostly deletion. A subagent perf review confirmed no new bounds checks and no inlining loss (fat LTO, same-crate `#[inline]`), and hardened `PairRankTable::build` against the sentinel reaching `max_initial` if the dense-grid clamp is ever widened.

## Validation

- `tencent/Hy3` and `tencent/Hy3-preview` now validate **exact** vs HF on the 25-text battery + 2 MB OpenWebText.
- DeepSeek-V4-Flash, GLM-5.2, gpt-oss-120b, Qwen3.6-35B-A3B re-validated exact as remapping-sensitive sanity checks.
- New `tests/test_byte_gap_vocab.py`: synthetic gapped vocabs on Hy3's real pre_tokenizer chain (drop-inside-pretoken merging, all-drop pretokens, >15-byte scratch path, id-ordered and ranked merge tables), full-Hy3-vs-HF parity, and the gapped-with-unk refusal. New Rust unit test pins the error naming the first *valid*-UTF-8 gap and the policy tri-state.
- `cargo test --release`: 94 passed. Python suite: 1438 passed, 8 skipped.

Note: `mistralai/Mistral-Small-3.2` (tekken.json) turned out to be a different root cause — transformers' tekken conversion emits `pre_tokenizer: null` and lets specials displace byte tokens — and is out of scope here; it now loads-and-mismatches instead of hard-erroring.