### PR TITLE
Parallelize SentencePiece encoding within oversized documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Additionally, Gigatoken uses concurrent data structures to use multiprocessing i
 \* All reference speeds in this section are measured on an M4 Pro CPU
 -->
 
+## Citation
+If you use Gigatoken in your research, please cite it as:
+
+```bibtex
+@software{roed2026gigatoken,
+  author = {Marcel R{\o}d},
+  title = {{G}igatoken: SIMD and Cache Hierarchies for 1000x Faster Byte-Pair Encoding Tokenization on Modern CPUs},
+  url = {https://github.com/marcelroed/gigatoken},
+  year = {2026},
+}
+```
+
 ---
 
 <details>

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -1,12 +1,9 @@
-//! Whole-file parallel encode benchmark. For ByteLevel BPE tokenizers the
-//! entire input is ONE document handed to the library's parallel encode path
-//! (`encode_docs_ragged`) — the same chunking policy, pretoken-safe
-//! splitting, and persistent worker pool as `BPETokenizer.encode_batch` /
-//! `encode_files` — so this measures gigatoken's own parallelism, not a
-//! bench-local split. SentencePiece-style tokenizers never split a document
-//! (merges can span it), so for those the input is split into ~1 MB
-//! newline-bounded documents first and handed to `sp_encode_docs_ragged`,
-//! which parallelizes across documents.
+//! Whole-file parallel encode benchmark. For both backends the entire input
+//! is ONE document handed to the library's parallel encode path
+//! (`encode_docs_ragged` / `sp_encode_docs_ragged`) — the same chunking
+//! policy, safe-boundary document splitting, and (for BPE) persistent worker
+//! pool as `encode_batch` / `encode_files` — so this measures gigatoken's
+//! own parallelism, not a bench-local split.
 //!
 //! Run with: cargo bench --bench encode                 (full OWT)
 //!           ENCODE_MB=500 cargo bench --bench encode
@@ -23,26 +20,6 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 mod common;
-
-/// Split at the first newline after each `target`-byte stride (documents for
-/// the SP path; a newline is always a char boundary).
-fn split_docs(text: &str, target: usize) -> Vec<&str> {
-    let bytes = text.as_bytes();
-    let mut docs = Vec::new();
-    let mut start = 0;
-    while start < bytes.len() {
-        let mut end = (start + target).min(bytes.len());
-        if end < bytes.len() {
-            end = match memchr::memchr(b'\n', &bytes[end..]) {
-                Some(i) => end + i + 1,
-                None => bytes.len(),
-            };
-        }
-        docs.push(&text[start..end]);
-        start = end;
-    }
-    docs
-}
 
 fn main() {
     common::allow_thp();
@@ -83,14 +60,12 @@ fn main() {
                 Ok(text) => text,
                 Err(e) => std::str::from_utf8(&input[..e.valid_up_to()]).unwrap(),
             };
-            let docs = split_docs(text, 1 << 20);
             eprintln!(
-                "Encoding (SentencePiece, {} documents, {} threads)...",
-                docs.len(),
+                "Encoding (SentencePiece, 1 document, {} threads)...",
                 rayon::current_num_threads()
             );
             let start = Instant::now();
-            let (ids, lens) = sp_encode_docs_ragged(tokenizer, &docs);
+            let (ids, lens) = sp_encode_docs_ragged(tokenizer, &[text]);
             black_box((&ids, lens));
             (ids.len(), start.elapsed().as_secs_f64())
         }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,8 +1,9 @@
 //! Parallel chunked batch encoding: the engine behind encode_batch and
-//! encode_files. Documents are grouped into coarse chunks (an oversized BPE
-//! document is split at pretoken-safe boundaries), encoded by pooled workers
-//! whose pretoken caches persist across calls, and reassembled into one flat
-//! id buffer plus per-document row lengths.
+//! encode_files. Documents are grouped into coarse chunks (an oversized
+//! document is split internally — at pretoken-safe boundaries for BPE,
+//! scanner-safe unit boundaries for SentencePiece), encoded by pooled
+//! workers whose pretoken caches persist across calls, and reassembled into
+//! one flat id buffer plus per-document row lengths.
 
 use crate::Tokenizer;
 use crate::bpe;
@@ -48,6 +49,23 @@ pub(crate) fn sp_encode_into(
 ) {
     let before = ids.len();
     encoder.encode_raw_cb(text, &mut |tokens| {
+        ids.extend(tokens.iter().map(|&t| u32::from(t)))
+    });
+    lens.push((ids.len() - before) as i64);
+}
+
+/// `sp_encode_into` for one fragment of a split document (see
+/// `SpChunk::Fragment`): a non-first fragment continues a section begun in
+/// an earlier fragment, so its leading section is never ▁-prefixed.
+fn sp_encode_fragment_into(
+    encoder: &mut bpe::sentencepiece::Encoder<'_>,
+    text: &str,
+    first: bool,
+    ids: &mut Vec<u32>,
+    lens: &mut Vec<i64>,
+) {
+    let before = ids.len();
+    encoder.encode_raw_fragment_cb(text, first, &mut |tokens| {
         ids.extend(tokens.iter().map(|&t| u32::from(t)))
     });
     lens.push((ids.len() - before) as i64);
@@ -789,44 +807,111 @@ pub fn encode_docs_ragged_serial(
     })
 }
 
+/// Work unit for parallel SentencePiece encoding, mirroring `EncodeChunk`.
+enum SpChunk<'a> {
+    /// A run of whole documents, one output row each.
+    Docs(Vec<&'a str>),
+    /// A scanner-safe fragment of one oversized document (see
+    /// `SentencePieceBPE::safe_fragment_ranges`). Fragments of a document
+    /// are consecutive chunks; `first` marks the document's first fragment.
+    Fragment { text: &'a str, first: bool },
+}
+
+/// Group documents into parallel chunks of roughly `target` bytes. A
+/// document larger than `2 * target` (the BPE path's oversize threshold) is
+/// split into consecutive Fragment chunks at unit boundaries the scanner
+/// proves safe, so even a single huge document is encoded across all cores
+/// with token-identical output — except on models without the raw fast path
+/// (`supports_fragment_split`), where no interior cut is provably safe and
+/// the document stays one chunk.
+fn sp_build_chunks<'a>(
+    tokenizer: &bpe::SentencePieceBPE,
+    texts: &[&'a str],
+    target: usize,
+) -> Vec<SpChunk<'a>> {
+    let can_split = tokenizer.supports_fragment_split();
+    let mut chunks = Vec::new();
+    let mut group: Vec<&str> = Vec::new();
+    let mut acc = 0usize;
+    for &text in texts {
+        if can_split && text.len() > 2 * target {
+            if !group.is_empty() {
+                chunks.push(SpChunk::Docs(std::mem::take(&mut group)));
+                acc = 0;
+            }
+            let mut first = true;
+            for r in tokenizer.safe_fragment_ranges(text, target) {
+                chunks.push(SpChunk::Fragment {
+                    text: &text[r],
+                    first: std::mem::take(&mut first),
+                });
+            }
+            continue;
+        }
+        group.push(text);
+        acc += text.len();
+        if acc >= target {
+            chunks.push(SpChunk::Docs(std::mem::take(&mut group)));
+            acc = 0;
+        }
+    }
+    if !group.is_empty() {
+        chunks.push(SpChunk::Docs(group));
+    }
+    chunks
+}
+
+/// Encode SentencePiece chunks with a per-chunk Encoder and gather them into
+/// one flat id buffer plus per-document row counts (`row_counts` merges a
+/// continuation fragment's first row into the previous document's row).
+fn sp_encode_chunks(
+    tokenizer: &bpe::SentencePieceBPE,
+    chunks: &[SpChunk],
+) -> (Vec<u32>, Vec<i64>) {
+    let outs = map_maybe_par(chunks, |chunk| {
+        // Reserve the output once from a bytes-per-token estimate on the
+        // low side of natural language, with huge pages before the encode's
+        // stores fault it in — as in `encode_chunk`.
+        let byte_len = match chunk {
+            SpChunk::Docs(group) => group.iter().map(|t| t.len()).sum::<usize>(),
+            SpChunk::Fragment { text, .. } => text.len(),
+        };
+        let mut ids: Vec<u32> = Vec::with_capacity(byte_len / 4 + 16);
+        madvise_hugepage(ids.as_mut_ptr() as *mut u8, ids.capacity() * 4);
+        let mut encoder = tokenizer.encoder();
+        let mut lens: Vec<i64> = Vec::new();
+        let mut continues = false;
+        match chunk {
+            SpChunk::Docs(group) => {
+                for text in group {
+                    sp_encode_into(&mut encoder, text, &mut ids, &mut lens);
+                }
+            }
+            SpChunk::Fragment { text, first } => {
+                sp_encode_fragment_into(&mut encoder, text, *first, &mut ids, &mut lens);
+                continues = !*first;
+            }
+        }
+        ChunkTokens {
+            ids,
+            lens,
+            continues,
+        }
+    });
+    assemble_ragged(outs)
+}
+
 /// SentencePiece analog of `encode_docs_ragged`: group whole documents into
-/// parallel chunks and encode each with its own Encoder. SentencePiece
-/// merges can span the whole document, so oversized documents are never
-/// split.
+/// parallel chunks — splitting an oversized document into scanner-safe
+/// fragments (see `sp_build_chunks`) — and encode each chunk with its own
+/// Encoder.
 pub fn sp_encode_docs_ragged(
     tokenizer: &bpe::SentencePieceBPE,
     texts: &[&str],
 ) -> (Vec<u32>, Vec<i64>) {
     let total: usize = texts.iter().map(|t| t.len()).sum();
-    let target = chunk_target_bytes(total);
-    let mut chunks: Vec<Vec<&str>> = Vec::new();
-    let mut group: Vec<&str> = Vec::new();
-    let mut acc = 0usize;
-    for &text in texts {
-        group.push(text);
-        acc += text.len();
-        if acc >= target {
-            chunks.push(std::mem::take(&mut group));
-            acc = 0;
-        }
-    }
-    if !group.is_empty() {
-        chunks.push(group);
-    }
-    let outs = map_maybe_par(&chunks, |group| {
-        let mut encoder = tokenizer.encoder();
-        let mut ids: Vec<u32> = Vec::new();
-        let mut lens: Vec<i64> = Vec::new();
-        for text in group {
-            sp_encode_into(&mut encoder, text, &mut ids, &mut lens);
-        }
-        ChunkTokens {
-            ids,
-            lens,
-            continues: false,
-        }
-    });
-    assemble_ragged(outs)
+    let chunks = sp_build_chunks(tokenizer, texts, chunk_target_bytes(total));
+    sp_encode_chunks(tokenizer, &chunks)
 }
 
 /// Sequential `sp_encode_docs_ragged`: one Encoder (so one pretoken cache)
@@ -899,14 +984,27 @@ pub(crate) fn encode_files_docs_serial(
     })
 }
 
-/// encode_files core for the SentencePiece backend: cut files into byte
-/// regions at document boundaries and encode each region's documents with a
+/// encode_files core for the SentencePiece backend. With no separator each
+/// file is one document (small files are grouped, huge ones split at
+/// scanner-safe boundaries); otherwise each file is cut into byte regions at
+/// document boundaries and each region's documents are encoded with a
 /// per-chunk Encoder. Documents are assumed to be valid UTF-8.
 pub(crate) fn sp_encode_files_docs(
     tokenizer: &bpe::SentencePieceBPE,
     files: &[&[u8]],
     format: &DocFormat,
 ) -> (Vec<u32>, Vec<i64>) {
+    if matches!(format, DocFormat::Text { separator: None }) {
+        // Whole-file documents: same grouping and oversized-document
+        // fragmenting as the batch path (mirrors `encode_files_docs`).
+        let texts: Vec<&str> = files
+            .iter()
+            // SAFETY: file contents are trusted valid UTF-8 (encode_files'
+            // documented contract, like the unchecked conversion below).
+            .map(|&bytes| unsafe { std::str::from_utf8_unchecked(bytes) })
+            .collect();
+        return sp_encode_docs_ragged(tokenizer, &texts);
+    }
     let total: usize = files.iter().map(|f| f.len()).sum();
     let target = chunk_target_bytes(total);
     let chunks: Vec<(usize, Range<usize>)> = files
@@ -1024,6 +1122,278 @@ mod tests {
         let (flat, lens) = encode_docs_ragged_serial(&workers, &proto, &docs);
         assert_eq!(lens, lens_ref, "lens mismatch (serial)");
         assert_eq!(flat, ids_ref, "ids mismatch (serial)");
+    }
+
+    /// Assert token identity with a readable failure: the position of the
+    /// first divergence and a short window of both streams (a plain
+    /// assert_eq would print millions of ids).
+    #[track_caller]
+    fn assert_ids_match(tag: &str, ids: &[u32], ids_ref: &[u32]) {
+        if ids == ids_ref {
+            return;
+        }
+        let i = ids_ref
+            .iter()
+            .zip(ids)
+            .position(|(a, b)| a != b)
+            .unwrap_or_else(|| ids_ref.len().min(ids.len()));
+        panic!(
+            "{tag}: ids mismatch at token {i}: serial[{i}..] = {:?}, fragmented[{i}..] = {:?}",
+            &ids_ref[i..(i + 8).min(ids_ref.len())],
+            &ids[i..(i + 8).min(ids.len())],
+        );
+    }
+
+    /// SentencePiece parallel chunked encode — grouped documents plus
+    /// oversized documents split into continuation fragments at
+    /// scanner-safe unit boundaries — must be token- and order-identical
+    /// to the serial one-encoder path. The cached HF models cover the raw
+    /// fast-path shapes: TinyLlama (unguarded ▁ prepend), gemma-2b
+    /// (SpaceRuns with `>▁</`-style crossing pieces), gemma-3 (guarded
+    /// prepend, 6.4k added tokens). The input is wall-to-wall
+    /// boundary-hostile content — whitespace runs, literal ▁, multi-byte
+    /// UTF-8 with combining marks, split punctuation, crossing-piece text,
+    /// added tokens mid-text and whitespace-adjacent — and a small explicit
+    /// target forces fragment boundaries all through it.
+    #[test]
+    fn sp_parallel_fragmented_matches_serial() {
+        let models = [
+            "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "unsloth/gemma-2b",
+            "google/gemma-3-4b-it",
+        ];
+        let block = concat!(
+            "The  quick   brown fox \u{2014} jumps; over, the: lazy. dog!  \n\n",
+            "\t\tindent()\twide  spacing      here \r\nCRLF\r\n",
+            "<s>raw<s> tokens </s> spaced <unk> out <bos> and <eos>\n",
+            "<start_of_turn>user hello<end_of_turn> <pad>\n",
+            "html-ish <b> </b> crossing > </ pieces >\u{2581}</ literal mark \u{2581}word\n",
+            "日本語のテキストと émojis 🎉🚀, combining a\u{301}e\u{308}o\u{302}, nbsp\u{a0}here ½ ﬁ ㎒\n",
+            "   leading and trailing   \n",
+        );
+        let mut big = String::new();
+        while big.len() < (6 << 20) {
+            big.push_str(block);
+        }
+        let texts: Vec<&str> = vec![
+            "short doc <s> one",
+            block,
+            &big,
+            "",
+            "tail doc </s>",
+            block,
+        ];
+        for repo in models {
+            let Some(path) = crate::test_hub::hf_tokenizer_json(repo) else {
+                eprintln!("Skipping {repo}: tokenizer.json not in the HF cache");
+                continue;
+            };
+            let tok = crate::load_tokenizer::hf::load_hf_sentencepiece(&path).unwrap();
+            assert!(
+                tok.supports_fragment_split(),
+                "{repo} should take the raw fast path (fragment splitting)"
+            );
+            let (ids_ref, lens_ref) = sp_encode_docs_ragged_serial(&tok, &texts);
+
+            // The public parallel path (default target sizing).
+            let (ids, lens) = sp_encode_docs_ragged(&tok, &texts);
+            assert_eq!(lens, lens_ref, "{repo}: lens mismatch (default target)");
+            assert_ids_match(&format!("{repo} (default target)"), &ids, &ids_ref);
+
+            // A small target forces ~a hundred fragment boundaries inside
+            // the hostile content.
+            let chunks = sp_build_chunks(&tok, &texts, 64 << 10);
+            let fragments = chunks
+                .iter()
+                .filter(|c| matches!(c, SpChunk::Fragment { .. }))
+                .count();
+            assert!(
+                fragments > 50,
+                "{repo}: expected many fragments, got {fragments}"
+            );
+            let (ids, lens) = sp_encode_chunks(&tok, &chunks);
+            assert_eq!(lens, lens_ref, "{repo}: lens mismatch (small target)");
+            assert_ids_match(&format!("{repo} (small target)"), &ids, &ids_ref);
+        }
+    }
+
+    /// Fragment cuts vs added-token edge cases on synthetic models covering
+    /// every raw-prepend shape (`Unguarded`, where a mis-placed cut would
+    /// inject a spurious ▁; `GuardedAlways` + `EveryMark`; `GuardedFirst`),
+    /// with lstrip- and rstrip-flagged tokens whose whitespace trimming must
+    /// never straddle a cut, a space-carrying token that can straddle one,
+    /// and a self-overlapping token. A tiny target tries a cut every few
+    /// bytes, so every blocked interval edge in the text gets exercised.
+    #[test]
+    fn sp_fragment_cuts_respect_added_tokens() {
+        use crate::load_tokenizer::hf::load_hf_slice;
+        // Char vocab + byte fallback, no merges (unit and section boundary
+        // divergence is fully visible in char-level ids), Llama-2-style
+        // normalizer, and added tokens with every strip shape.
+        let mut vocab_entries: Vec<String> = (0u16..=255)
+            .map(|b| format!("\"<0x{b:02X}>\": {b}"))
+            .collect();
+        let mut next_id = 256u32;
+        vocab_entries.push(format!("\"\u{2581}\": {next_id}"));
+        next_id += 1;
+        for c in "abcdefghijklmnopqrstuvwxyz.,!?".chars() {
+            vocab_entries.push(format!("\"{c}\": {next_id}"));
+            next_id += 1;
+        }
+        let added = [
+            ("<p>", false, false),
+            ("<l>", true, false),
+            ("<r>", false, true),
+            ("w w", false, false), // can straddle a space cut
+            ("aa", false, false),  // self-overlapping occurrences
+        ];
+        let added_json: Vec<String> = added
+            .iter()
+            .map(|(content, lstrip, rstrip)| {
+                let id = next_id;
+                next_id += 1;
+                format!(
+                    "{{\"id\": {id}, \"content\": \"{content}\", \"lstrip\": {lstrip}, \
+                     \"rstrip\": {rstrip}, \"normalized\": false, \"special\": true}}"
+                )
+            })
+            .collect();
+        // Every raw-prepend shape a cut interacts with: Llama-2's Prepend
+        // normalizer (`Unguarded`, where the added-token `e`-blocking is
+        // load-bearing), Metaspace always+split (`GuardedAlways` +
+        // `EveryMark`: cuts inside mark runs, `e` cuts allowed), and
+        // Metaspace first without split (`GuardedFirst` + `SpaceRuns`).
+        use crate::bpe::sentencepiece::{RawPrepend, WordSplit};
+        let pipelines = [
+            (
+                "{\"type\": \"Sequence\", \"normalizers\": [\
+                   {\"type\": \"Prepend\", \"prepend\": \"\u{2581}\"}, \
+                   {\"type\": \"Replace\", \"pattern\": {\"String\": \" \"}, \"content\": \"\u{2581}\"}]}",
+                "null",
+                RawPrepend::Unguarded,
+                WordSplit::SpaceRuns,
+            ),
+            (
+                "null",
+                "{\"type\": \"Metaspace\", \"replacement\": \"\u{2581}\", \
+                  \"prepend_scheme\": \"always\", \"split\": true}",
+                RawPrepend::GuardedAlways,
+                WordSplit::EveryMark,
+            ),
+            (
+                "null",
+                "{\"type\": \"Metaspace\", \"replacement\": \"\u{2581}\", \
+                  \"prepend_scheme\": \"first\", \"split\": false}",
+                RawPrepend::GuardedFirst,
+                WordSplit::SpaceRuns,
+            ),
+        ];
+
+        // Tokens adjacent to and inside whitespace runs, back to back, and
+        // overlapping ("aaa" holds two "aa" occurrences); words with the
+        // split punctuation; a "w w" occurrence wherever the text has one.
+        let block = concat!(
+            "plain words here <p> and <p><p> doubled\n",
+            "lstrip near ws   <l> and far<l>tight\n",
+            "rstrip eats ws <r>   after and<r>tight\n",
+            "aaa aaaa a aa overlapping aa\n",
+            "w w w w w straddling spaces\n",
+            "punct, split. here! ok? more,words.now\n",
+            "   runs\t\tof   whitespace \n\n",
+            "<l>   <r>   <l><r> adjacent tokens\n",
+        );
+        let mut text = String::new();
+        while text.len() < 100_000 {
+            text.push_str(block);
+        }
+        let texts = [text.as_str()];
+
+        for (normalizer, pre_tokenizer, prepend, word_split) in pipelines {
+            let json = format!(
+                "{{\"added_tokens\": [{}], \
+                  \"normalizer\": {normalizer}, \
+                  \"pre_tokenizer\": {pre_tokenizer}, \
+                  \"model\": {{\"type\": \"BPE\", \"byte_fallback\": true, \
+                    \"vocab\": {{{}}}, \"merges\": []}}}}",
+                added_json.join(", "),
+                vocab_entries.join(", "),
+            );
+            let tok = match load_hf_slice(json.as_bytes()).unwrap() {
+                crate::load_tokenizer::hf::HfTokenizer::SentencePiece(tok) => tok,
+                _ => panic!("synthetic model should load as SentencePiece"),
+            };
+            // Pin the shape under test — a loader change that silently lands
+            // on another fast path would hollow the test out.
+            assert_eq!(tok.raw_prepend, Some(prepend), "unexpected raw prepend");
+            assert_eq!(tok.word_split, word_split, "unexpected word split");
+
+            let (ids_ref, lens_ref) = sp_encode_docs_ragged_serial(&tok, &texts);
+            // A cut attempt every ~48 bytes: thousands of boundaries,
+            // hitting every edge of every blocked interval shape in the
+            // block.
+            let chunks = sp_build_chunks(&tok, &texts, 48);
+            assert!(
+                chunks.len() > 1000,
+                "expected a cut attempt every few bytes, got {} chunks",
+                chunks.len()
+            );
+            let (ids, lens) = sp_encode_chunks(&tok, &chunks);
+            assert_eq!(lens, lens_ref, "{prepend:?}: lens mismatch");
+            assert_ids_match(&format!("{prepend:?}"), &ids, &ids_ref);
+        }
+    }
+
+    /// SentencePiece parallel-vs-serial on REAL text: ~290 MB of OWT
+    /// (owt_valid) as one huge document plus a few multi-MB slices, for
+    /// each cached SP model. Token AND order identity against the serial
+    /// one-encoder encode.
+    /// `cargo test --release verify_sp_parallel_matches_serial_owt -- --ignored --nocapture`
+    #[test]
+    #[ignore = "reads ~290 MB of OWT; run explicitly in release mode"]
+    fn verify_sp_parallel_matches_serial_owt() {
+        let path = std::env::home_dir().unwrap().join("data/owt_valid.txt");
+        let input = std::fs::read(&path).expect("read ~/data/owt_valid.txt");
+        let text = match std::str::from_utf8(&input) {
+            Ok(t) => t,
+            Err(e) => std::str::from_utf8(&input[..e.valid_up_to()]).unwrap(),
+        };
+        // One huge doc (the whole file) plus a few multi-MB slices cut at
+        // char boundaries, so grouped-doc and fragment chunks both appear.
+        let mut texts: Vec<&str> = vec![text];
+        let mut off = 0usize;
+        for mb in [3, 7, 12] {
+            let mut end = (off + (mb << 20)).min(text.len());
+            while !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            texts.push(&text[off..end]);
+            off = end;
+        }
+        for repo in [
+            "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            "unsloth/gemma-2b",
+            "google/gemma-3-4b-it",
+        ] {
+            let Some(path) = crate::test_hub::hf_tokenizer_json(repo) else {
+                eprintln!("Skipping {repo}: tokenizer.json not in the HF cache");
+                continue;
+            };
+            let tok = crate::load_tokenizer::hf::load_hf_sentencepiece(&path).unwrap();
+            let t0 = std::time::Instant::now();
+            let (ids_ref, lens_ref) = sp_encode_docs_ragged_serial(&tok, &texts);
+            let t_serial = t0.elapsed();
+            let t0 = std::time::Instant::now();
+            let (ids, lens) = sp_encode_docs_ragged(&tok, &texts);
+            let t_par = t0.elapsed();
+            eprintln!(
+                "{repo}: {} tokens; serial {:.2?}, parallel {:.2?}",
+                ids_ref.len(),
+                t_serial,
+                t_par
+            );
+            assert_eq!(lens, lens_ref, "{repo}: lens mismatch");
+            assert_ids_match(repo, &ids, &ids_ref);
+        }
     }
 
     /// Parallel-vs-serial at scale on a REAL tokenizer: ~1 GB of OWT as a

--- a/src/bpe/sentencepiece.rs
+++ b/src/bpe/sentencepiece.rs
@@ -181,6 +181,21 @@ impl PrecompiledCharsmap {
     }
 }
 
+/// Position of a section (the text between added-token matches) within its
+/// document, which decides whether the raw fast path ▁-prefixes the
+/// section's first unit.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SectionPos {
+    /// The very start of the document (Metaspace `first` prepends only here).
+    First,
+    /// After an added-token match; per-section prepends still apply.
+    Middle,
+    /// Continues a section begun in an earlier fragment of a split document
+    /// (see [`SentencePieceBPE::safe_fragment_ranges`]): never prefixed —
+    /// the section's prefix, if any, was emitted with its first unit.
+    Continuation,
+}
+
 /// When the Metaspace pre-tokenizer prepends ▁ to a chunk.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PrependScheme {
@@ -539,6 +554,184 @@ impl SentencePieceBPE {
             .any(|(pre, post)| bytes[..mark_pos].ends_with(pre) && after.starts_with(post))
     }
 
+    /// Whether an oversized document can be split into fragments that encode
+    /// independently with token-identical output (see
+    /// [`Self::safe_fragment_ranges`]). Requires the raw fast path: its
+    /// per-unit encoding is what makes a provable unit boundary a safe cut.
+    /// The materialized-normalizer path applies whole-section ops (Strip
+    /// trims section edges, charsmaps span graphemes, Prepend re-fires per
+    /// section), so no interior cut has a local safety argument there — and
+    /// `WordSplit::None` merges whole chunks, so nothing can be split at all.
+    pub(crate) fn supports_fragment_split(&self) -> bool {
+        self.raw_prepend.is_some()
+    }
+
+    /// Split raw text into ranges of roughly `target` bytes at cuts the raw
+    /// scanner provably treats as unit boundaries, so encoding the first
+    /// range with `encode_raw_cb` and each later one with
+    /// `encode_raw_fragment_cb` and concatenating the token streams is
+    /// identical to encoding `text` in one call. Only valid when
+    /// [`Self::supports_fragment_split`] holds.
+    ///
+    /// A cut at `p` is safe when the serial scan is guaranteed to close a
+    /// unit exactly at `p` and every decision it makes is local to one side:
+    ///
+    /// - `p` starts a mark — a raw space, or a complete ▁ (0xE2 always
+    ///   leads a 3-byte char in valid UTF-8, so neither test can misread a
+    ///   continuation byte) — and, under `SpaceRuns`, does not extend a
+    ///   mark run (the char before it is not a mark) and no crossing vocab
+    ///   piece occurrence spans it (`piece_spans_boundary`). The scanner's
+    ///   remaining decisions cannot reach across `p`: a crossing piece's
+    ///   `pre`/`post` contain no space or ▁ (see `unit_crossing_pieces`),
+    ///   so no occurrence of one can span the mark at `p`; mark-run state
+    ///   resets at every non-mark char; and the punctuation split test
+    ///   reads one preceding byte.
+    /// - No added-token occurrence blocks `p` (see
+    ///   `added_token_cut_blocks`): leftmost-longest matching carries no
+    ///   state across an occurrence-free point, so restarting it at `p`
+    ///   reproduces the single-pass matches, and lstrip/rstrip whitespace
+    ///   trimming stays within one fragment.
+    ///
+    /// Where no safe cut exists the scan keeps probing forward, so a range
+    /// can exceed `target` (in the worst case it is the rest of the
+    /// document — output stays exact, only parallelism degrades).
+    pub(crate) fn safe_fragment_ranges(
+        &self,
+        text: &str,
+        target: usize,
+    ) -> Vec<std::ops::Range<usize>> {
+        debug_assert!(self.supports_fragment_split());
+        let bytes = text.as_bytes();
+        let len = bytes.len();
+        if len == 0 {
+            // Zero ranges would drop the document's output row.
+            return vec![0..0];
+        }
+        let blocks = self.added_token_cut_blocks(text);
+        let mut bi = 0usize; // cursor into `blocks`; probes are monotone
+        let every_mark = self.word_split == WordSplit::EveryMark;
+        let target = target.max(1);
+        let mut out = Vec::new();
+        let mut start = 0usize;
+        'chunks: while start < len {
+            let mut probe = start + target;
+            while probe < len {
+                let Some(width) = mark_width(bytes, probe, true) else {
+                    probe += 1;
+                    continue;
+                };
+                let extends_run = !every_mark
+                    && (bytes[probe - 1] == b' '
+                        || (probe >= 3 && bytes[probe - 3..probe] == SP_MARK));
+                if extends_run || self.piece_spans_boundary(bytes, probe, width) {
+                    probe += 1;
+                    continue;
+                }
+                while bi < blocks.len() && blocks[bi].end <= probe {
+                    bi += 1;
+                }
+                if bi < blocks.len() && blocks[bi].start <= probe {
+                    // Inside a blocked interval: hop past it (the merged
+                    // intervals are disjoint and sorted).
+                    probe = blocks[bi].end;
+                    continue;
+                }
+                out.push(start..probe);
+                start = probe;
+                continue 'chunks;
+            }
+            out.push(start..len);
+            break;
+        }
+        out
+    }
+
+    /// Sorted, disjoint byte intervals in which no fragment cut may land,
+    /// derived from added-token occurrences. Every occurrence is collected,
+    /// overlapping ones included — a superset of the matches an encode
+    /// selects, which is what makes the blocking conservative and exact:
+    ///
+    /// - inside an occurrence `[s, e)`: the cut halves would BPE-encode as
+    ///   plain text (and truncation could change leftmost-longest choices);
+    /// - at `e` itself, under `Unguarded` prepend only: the fragment's
+    ///   continuation section would go un-prefixed where the serial encode
+    ///   ▁-prefixes the post-match section it opens at `e`. (Guarded
+    ///   schemes skip the prefix on the cut's own mark either way, and both
+    ///   sides then scan the identical section from `e`.);
+    /// - `lstrip`: back through the whitespace run before `s`, whose
+    ///   trimming would otherwise reach into the previous fragment;
+    /// - `rstrip`: forward through the whitespace run after `e`, which the
+    ///   serial match consumes.
+    ///
+    /// A cut only ever lands on a mark start (a space or ▁'s 0xE2 lead), so
+    /// an occurrence's interior can hold one only when its content carries
+    /// such a byte. A token without one, without lstrip/rstrip, on a
+    /// non-`Unguarded` model therefore cannot block anything and is skipped
+    /// without a scan — gemma-3 carries 6.4k added tokens, and one pass per
+    /// token over a multi-hundred-MB document is seconds, not milliseconds.
+    ///
+    /// The surviving tokens' scans are independent and run on the rayon
+    /// pool: gemma keeps 30 ▁-run tokens, and their ~9 GB of memmem over a
+    /// 290 MB document was ~35% of the whole parallel encode when run
+    /// serially. Only the parallel encode entry points fragment documents,
+    /// so touching rayon here is safe (the fork-safe `_serial` paths never
+    /// reach this).
+    fn added_token_cut_blocks(&self, text: &str) -> Vec<std::ops::Range<usize>> {
+        use rayon::prelude::*;
+        let bytes = text.as_bytes();
+        let unguarded = self.raw_prepend == Some(RawPrepend::Unguarded);
+        let mut blocks: Vec<std::ops::Range<usize>> = self
+            .added_tokens
+            .par_iter()
+            .filter(|spec| {
+                let content = spec.content.as_bytes();
+                let interior = content.contains(&b' ') || content.contains(&0xE2);
+                !content.is_empty() && (interior || unguarded || spec.lstrip || spec.rstrip)
+            })
+            .flat_map_iter(|spec| {
+                let content = spec.content.as_bytes();
+                let finder = memchr::memmem::Finder::new(content);
+                let mut out = Vec::new();
+                let mut from = 0usize;
+                while let Some(off) = finder.find(&bytes[from..]) {
+                    let s = from + off;
+                    let e = s + content.len();
+                    // A valid-UTF-8 needle only matches at char boundaries
+                    // (its first byte is a lead byte, and a full match ends
+                    // a complete char), so slicing `text` at `s`/`e` cannot
+                    // panic.
+                    let lo = if spec.lstrip {
+                        text[..s].trim_end().len()
+                    } else {
+                        s + 1
+                    };
+                    let hi = if spec.rstrip {
+                        e + (text[e..].len() - text[e..].trim_start().len())
+                    } else if unguarded {
+                        e
+                    } else {
+                        e - 1 // only the interior (s, e) blocks; `e` is safe
+                    };
+                    if lo <= hi {
+                        out.push(lo..hi + 1);
+                    }
+                    from = s + 1; // step one byte: overlapping occurrences too
+                }
+                out
+            })
+            .collect();
+        blocks.sort_unstable_by_key(|r| r.start);
+        blocks.dedup_by(|next, prev| {
+            if next.start <= prev.end {
+                prev.end = prev.end.max(next.end);
+                true
+            } else {
+                false
+            }
+        });
+        blocks
+    }
+
     /// Raw-fast-path eligibility: the normalizer sequence must reduce to
     /// optional ▁ prepend + literal space→▁, with no normalized added tokens
     /// (those are matched against materialized normalizer output).
@@ -760,6 +953,25 @@ impl<'a> Encoder<'a> {
     pub fn encode_raw_cb<F: FnMut(&[TokenId])>(&mut self, input: &str, f: &mut F) {
         self.model.encode_raw_cb(&mut self.state, input, f);
     }
+
+    /// Like [`Self::encode_raw_cb`] for one fragment of a document split at
+    /// scanner-safe boundaries (see
+    /// [`SentencePieceBPE::safe_fragment_ranges`]). A non-first fragment's
+    /// leading section continues one begun in an earlier fragment, so it is
+    /// never ▁-prefixed.
+    pub fn encode_raw_fragment_cb<F: FnMut(&[TokenId])>(
+        &mut self,
+        input: &str,
+        first: bool,
+        f: &mut F,
+    ) {
+        let pos = if first {
+            SectionPos::First
+        } else {
+            SectionPos::Continuation
+        };
+        self.model.encode_raw_from(&mut self.state, input, pos, f);
+    }
 }
 
 /// Is the byte at `pos` the start of a unit mark? In raw mode both a space
@@ -796,8 +1008,23 @@ impl SentencePieceBPE {
         input: &str,
         f: &mut F,
     ) {
+        self.encode_raw_from(state, input, SectionPos::First, f);
+    }
+
+    /// [`Self::encode_raw_cb`] with the position of the input's leading
+    /// section given explicitly: `First` for a whole document,
+    /// `Continuation` for a non-first fragment of one (see
+    /// [`Self::safe_fragment_ranges`]). Sections after an added-token match
+    /// are always `Middle`.
+    fn encode_raw_from<F: FnMut(&[TokenId])>(
+        &self,
+        state: &mut EncodeState,
+        input: &str,
+        start: SectionPos,
+        f: &mut F,
+    ) {
         let Some(matcher) = &self.added_matcher else {
-            self.encode_section_cb(state, input, true, f);
+            self.encode_section_cb(state, input, start, f);
             return;
         };
 
@@ -805,7 +1032,7 @@ impl SentencePieceBPE {
         // consecutive matches forms the chunks. lstrip/rstrip consume the
         // whitespace adjacent to a match.
         let mut chunk_start = 0usize;
-        let mut first_chunk = true;
+        let mut pos = start;
         for m in matcher.find_iter(input.as_bytes()) {
             let spec = &self.added_tokens[m.pattern().as_usize()];
             if m.start() < chunk_start {
@@ -817,18 +1044,18 @@ impl SentencePieceBPE {
                 chunk = chunk.trim_end();
             }
             if !chunk.is_empty() {
-                self.encode_section_cb(state, chunk, first_chunk, f);
+                self.encode_section_cb(state, chunk, pos, f);
             }
             f(&[spec.id]);
             chunk_start = m.end();
             if spec.rstrip {
                 chunk_start += input[chunk_start..].len() - input[chunk_start..].trim_start().len();
             }
-            first_chunk = false;
+            pos = SectionPos::Middle;
         }
         let chunk = &input[chunk_start..];
         if !chunk.is_empty() {
-            self.encode_section_cb(state, chunk, first_chunk, f);
+            self.encode_section_cb(state, chunk, pos, f);
         }
     }
 
@@ -840,14 +1067,20 @@ impl SentencePieceBPE {
         &self,
         state: &mut EncodeState,
         text: &str,
-        first_chunk: bool,
+        pos: SectionPos,
         f: &mut F,
     ) {
         if let Some(prepend) = self.raw_prepend {
-            self.encode_chunk_raw(state, text, first_chunk, prepend, f);
+            self.encode_chunk_raw(state, text, pos, prepend, f);
             return;
         }
 
+        // Fragment splitting is gated on the raw fast path
+        // (`supports_fragment_split`), so a continuation never reaches the
+        // materialized-normalizer path below — its whole-section ops
+        // (Strip, per-section Prepend, ...) have no continuation form.
+        debug_assert!(pos != SectionPos::Continuation);
+        let first_chunk = pos == SectionPos::First;
         let normed = self.apply_norm_ops(text);
 
         if self.norm_added_tokens.is_empty() {
@@ -894,7 +1127,7 @@ impl SentencePieceBPE {
         &self,
         state: &mut EncodeState,
         chunk: &str,
-        first_chunk: bool,
+        pos: SectionPos,
         prepend: RawPrepend,
         f: &mut F,
     ) {
@@ -904,9 +1137,13 @@ impl SentencePieceBPE {
         let bytes = chunk.as_bytes();
         let starts_with_mark = mark_width(bytes, 0, true).is_some();
         let virtual_prefix = match prepend {
+            // A continuation resumes a section mid-way: its prefix, if any,
+            // was emitted with the section's first unit in an earlier
+            // fragment.
+            _ if pos == SectionPos::Continuation => false,
             RawPrepend::Unguarded => true,
             RawPrepend::GuardedAlways => !starts_with_mark,
-            RawPrepend::GuardedFirst => first_chunk && !starts_with_mark,
+            RawPrepend::GuardedFirst => pos == SectionPos::First && !starts_with_mark,
             RawPrepend::Never => false,
         };
         self.encode_units(state, bytes, virtual_prefix, true, f);


### PR DESCRIPTION
## Summary

A single huge document through an SP-backed tokenizer previously encoded serially (~154 MB/s on a 290 MB doc); only multi-document batches parallelized. This fragments oversized SP documents at provably safe boundaries and encodes them across the rayon pool, mirroring the BPE path's internal chunking, so the standard whole-file case parallelizes with no pre-splitting by the caller.

- **Safety**: cuts land only on space/`▁` unit marks on the raw fast path; rejected when a `▁`-crossing vocab piece or any added-token occurrence (overlaps included, lstrip/rstrip whitespace runs extended) could span them. Non-first fragments encode in a continuation mode that suppresses the section's already-emitted `▁` prefix. Models whose normalizers preclude a local safety argument keep one chunk per document.
- **Exactness**: fragmented output is byte-for-byte identical to serial encoding — verified on 290 MB of OWT for TinyLlama, gemma-2b, and gemma-3-4b-it, plus boundary-hostile synthetic tests parameterized over all three raw-prepend schemes (Unguarded, GuardedAlways/EveryMark, GuardedFirst) with loader-pinning asserts.
- **Perf**: the added-token blocker scan (30 pure-`▁` needles × whole doc for gemma ≈ 9 GB scanned serially) also moves onto rayon. gemma-2b: 548 → ~930 MB/s single-doc (parity with pre-split input), 1.28 GB/s on 11.9 GB owt_train; TinyLlama ~1.1 GB/s (was 154 MB/s serial).
- `benches/encode.rs` no longer pre-splits SP input; both backends receive the whole input as one document.

## Testing

- `cargo test --release`: 95 passed, 0 failed (includes the new fragmentation parity tests).
- `cargo test --release verify_sp_parallel_matches_serial_owt -- --ignored`: byte-identical ids and lens on 290 MB owt_valid for all three SP models.

https://claude.ai/code/session_013cwmfWS1kEXh3C9S2st3WU