### PR TITLE
Add cross-library throughput benchmarks and README results table

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ which remain more expensive to encode than byte-level BPE even with gigatoken's
 internal SP parallelism; ModernBERT is byte-level BPE with a heavier
 pretokenizer than the GPT-2 family.
 
+Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured
+on a representative repo. Rows whose tokenizer is shared beyond their own name
+(verified by matching tokenizer definitions across the local HF model cache) cover:
+
+- **Nemotron 3** — Nemotron 3 Nano, Super, and Ultra
+- **Llama 3 / 3.1 / 3.2** — Llama 3 / 3.1 / 3.2, DeepSeek-R1-Distill-Llama, Hermes 3, Saiga, and other Llama-3 finetunes
+- **Llama 3.3** — Llama 3.3, Llama-3.1-Nemotron-Nano-VL, SmolLM3, Kanana 1.5, jina-embeddings-v5, Ultravox
+- **Phi-4-mini** — Phi-4-mini and Phi-4-multimodal
+- **Kimi K2** — Kimi K2 / K2.5 / K2.6 / K2.7, Kimi-Linear, Kimi-VL, Moonlight
+- **Qwen 2 / 2.5** — Qwen 2 and 2.5 (incl. Coder and VL), Qwen3-Coder, Qwen3-VL, DeepSeek-R1 Qwen distills, MiMo V2.5, MiniCPM-o 2.6, InternVL3
+- **Qwen 3** — Qwen 3 (incl. Embedding and Reranker), Qwen2.5-Omni, Qwen3-VL-Embedding, MiMo V2.5 Pro, jina-reranker-m0, pplx-embed, MOSS-TTS, Zeta
+- **GLM 4** — GLM 4.1V, 4.5, and 4.7
+- **DeepSeek V3 / R1 / V4** — DeepSeek V3 / V3.1 / V3.2, R1, V4 Flash and Pro, DeepSeek-VL2
+- **GLM 5** — GLM 5 / 5.2 and GLM-4.7-Flash
+- **Gemma 4** — Gemma 4 (dense, MoE, and E-series) and DiffusionGemma
+- **TinyLlama / Phi-3 (Llama 2)** — TinyLlama, Phi-3-mini, Phi-3.5-mini and Phi-3.5-vision (the Llama 2 vocab)
+- **Gemma 3** — Gemma 3 (270M–27B) and EmbeddingGemma
+
 </details>
 <!-- benchmarks:end -->
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,52 @@ Additionally, Gigatoken uses concurrent data structures to use multiprocessing i
 \* All reference speeds in this section are measured on an M4 Pro CPU
 -->
 
+<!-- benchmarks:start -->
+## Benchmarks
+
+<details>
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — Apple M4 Max (16 cores)</b></summary>
+
+Best of 3 interleaved rounds, one fresh process per measurement, all libraries with
+parallelism enabled. gigatoken encodes the whole file un-split; HuggingFace
+`tokenizers` (`encode_batch_fast`) gets the first 100 MB and tiktoken
+(`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
+tiktoken rows exist only for tokenizers with official support.
+
+| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
+|---|---:|---:|---:|---:|---:|
+| GPT-2 | 8.79 GB/s | 6.9 MB/s | 62.8 MB/s | 1,268× | 140× |
+| Nemotron 3 | 7.82 GB/s | 10.9 MB/s | — | 715× | — |
+| Phi-4 | 7.76 GB/s | 7.7 MB/s | — | 1,012× | — |
+| Llama 3 / 3.1 / 3.2 | 7.60 GB/s | 11.2 MB/s | — | 676× | — |
+| OLMo 2 / 3 | 7.56 GB/s | 5.8 MB/s | — | 1,299× | — |
+| Llama 3.3 | 7.50 GB/s | 15.7 MB/s | — | 479× | — |
+| Phi-4-mini | 6.97 GB/s | 7.2 MB/s | — | 964× | — |
+| Kimi K2 | 6.88 GB/s | — | — | — | — |
+| Llama 4 | 6.81 GB/s | 11.6 MB/s | — | 590× | — |
+| Qwen 2 / 2.5 | 6.37 GB/s | 5.8 MB/s | — | 1,105× | — |
+| Qwen 3 | 6.36 GB/s | 6.9 MB/s | — | 918× | — |
+| Qwen 3.5 / 3.6 | 6.31 GB/s | 6.3 MB/s | — | 994× | — |
+| GPT-OSS | 6.20 GB/s | 20.2 MB/s | 87.2 MB/s | 306× | 71× |
+| GLM 4 | 6.17 GB/s | 15.8 MB/s | — | 392× | — |
+| DeepSeek V3 / R1 / V4 | 5.68 GB/s | 7.2 MB/s | — | 788× | — |
+| GLM 5 | 5.55 GB/s | 12.2 MB/s | — | 456× | — |
+| ModernBERT | 2.64 GB/s | 5.8 MB/s | — | 452× | — |
+| Mistral 7B v0.3 | 1.99 GB/s | 95.1 MB/s | — | 21× | — |
+| Gemma 4 | 1.82 GB/s | 85.2 MB/s | — | 21× | — |
+| CodeLlama | 1.73 GB/s | 80.2 MB/s | — | 22× | — |
+| TinyLlama / Phi-3 (Llama 2) | 1.69 GB/s | 80.1 MB/s | — | 21× | — |
+| Gemma 1 | 1.42 GB/s | 85.7 MB/s | — | 17× | — |
+| Gemma 3 | 1.38 GB/s | 82.2 MB/s | — | 17× | — |
+
+The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),
+which remain more expensive to encode than byte-level BPE even with gigatoken's
+internal SP parallelism; ModernBERT is byte-level BPE with a heavier
+pretokenizer than the GPT-2 family.
+
+</details>
+<!-- benchmarks:end -->
+
 ## Citation
 If you use Gigatoken in your research, please cite it as:
 

--- a/benchmarks/compare/measure.py
+++ b/benchmarks/compare/measure.py
@@ -1,0 +1,218 @@
+"""Single-library tokenizer throughput on one file.
+
+Each invocation measures exactly one library (--library {hf,tiktoken,gigatoken})
+so every measurement starts from a fresh process: no shared thread pools,
+allocator state, or warm caches between libraries. Interleave repeated
+invocations externally and take the min per library (sweep.py does both and
+records into benchmarks/results.json via results.py).
+
+Tokenizers are named by HF repo id for every library, so measurements of the
+same tokenizer line up across libraries. tiktoken only runs repos its own
+registry supports natively: the repo must belong to an OpenAI org and its
+basename must resolve through tiktoken.model's MODEL_TO_ENCODING /
+MODEL_PREFIX_TO_ENCODING tables to an installed encoding. Vocabs that could
+merely be converted into a tiktoken.Encoding (Qwen, Llama, ...) are refused;
+`--tiktoken-support [REPO ...]` prints the resolution (or the whole
+registry) and exits. --local-file makes hf/gigatoken load from an
+already-resolved local tokenizer file while still recording the repo id.
+
+The whole file is read into a Python bytes object before the timer starts;
+only the batch-encode call is timed. All three libraries run with parallelism
+enabled. hf and tiktoken only parallelize across documents, so their input is
+split on --separator (before timing); gigatoken is handed the raw un-split
+bytes object as a single document — both its BPE and SentencePiece backends
+chunk oversized documents internally at provably safe boundaries
+(src/batch.rs). Because of that, gigatoken also encodes the separator
+strings themselves (as special tokens), so its token count differs from the
+others by roughly one token per document.
+
+Usage:
+    uv run benchmarks/compare/measure.py --library gigatoken \
+        --tokenizer openai-community/gpt2 --file ~/data/owt_train.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import results
+
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "true")
+
+NATIVE_TIKTOKEN_OWNERS = {"openai", "openai-community"}
+
+
+def native_encoding(repo_id: str) -> str | None:
+    """The tiktoken encoding name for `repo_id`, or None if unsupported."""
+    import tiktoken
+    import tiktoken.model
+
+    owner, _, model = repo_id.rpartition("/")
+    if owner.lower() not in NATIVE_TIKTOKEN_OWNERS:
+        return None
+    model = model.lower()
+    encoding = tiktoken.model.MODEL_TO_ENCODING.get(model)
+    if encoding is None:
+        matches = [
+            enc
+            for prefix, enc in tiktoken.model.MODEL_PREFIX_TO_ENCODING.items()
+            if model.startswith(prefix)
+        ]
+        encoding = matches[0] if matches else None
+    if encoding is not None and encoding in tiktoken.list_encoding_names():
+        return encoding
+    return None
+
+
+def print_tiktoken_support(repos: list[str]) -> None:
+    import tiktoken
+    import tiktoken.model
+
+    if repos:
+        for repo in repos:
+            print(f"{repo} -> {native_encoding(repo) or '-'}")
+        return
+    print(f"tiktoken {getattr(tiktoken, '__version__', '?')} encodings: {', '.join(tiktoken.list_encoding_names())}")
+    for model, enc in sorted(tiktoken.model.MODEL_TO_ENCODING.items()):
+        print(f"{model} -> {enc}")
+    for prefix, enc in sorted(tiktoken.model.MODEL_PREFIX_TO_ENCODING.items()):
+        print(f"{prefix}* -> {enc}")
+
+
+def load_hf(name: str):
+    from tokenizers import Tokenizer
+
+    if os.path.exists(name):
+        return Tokenizer.from_file(name)
+    return Tokenizer.from_pretrained(name)
+
+
+def load_tiktoken(name: str):
+    import tiktoken
+
+    encoding = native_encoding(name)
+    if encoding is None:
+        raise SystemExit(f"{name} is not natively supported by tiktoken (see --tiktoken-support)")
+    return tiktoken.get_encoding(encoding)
+
+
+def load_gigatoken(name: str):
+    import gigatoken
+
+    return gigatoken.Tokenizer(name)
+
+
+def encode_hf(tokenizer, docs: list[str]):
+    encode_batch = getattr(tokenizer, "encode_batch_fast", tokenizer.encode_batch)
+    return encode_batch(docs)
+
+
+def encode_tiktoken(tokenizer, docs: list[str]):
+    # Sliced: the list-of-Python-int output costs ~36 bytes per token, so on
+    # multi-GB inputs one full-batch call would need tens of GB. Counting and
+    # freeing per slice keeps the timed region honest (the allocation cost is
+    # still paid) while bounding the footprint.
+    step = 25_000
+    total = 0
+    for i in range(0, len(docs), step):
+        rows = tokenizer.encode_ordinary_batch(docs[i : i + step], num_threads=os.cpu_count())
+        total += sum(map(len, rows))
+    return total
+
+
+def encode_gigatoken(tokenizer, docs: list[str]):
+    return tokenizer.encode_batch(docs, parallel=True)
+
+
+def count_gigatoken(result) -> int:
+    import awkward as ak
+
+    return int(ak.sum(ak.num(result)))
+
+
+LIBRARIES = {
+    "hf": (load_hf, encode_hf, lambda encodings: sum(len(e.ids) for e in encodings)),
+    "tiktoken": (load_tiktoken, encode_tiktoken, lambda total: total),
+    "gigatoken": (load_gigatoken, encode_gigatoken, count_gigatoken),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--library", choices=sorted(LIBRARIES))
+    parser.add_argument("--tokenizer", help="HF repo id, e.g. openai-community/gpt2")
+    parser.add_argument("--local-file", default=None, help="already-resolved local tokenizer file for hf/gigatoken to load; the recorded tokenizer name stays --tokenizer")
+    parser.add_argument("--file")
+    parser.add_argument("--separator", default="<|endoftext|>", help="document separator; empty string encodes the file as a single document")
+    parser.add_argument("--max-mb", type=float, default=None, help="truncate the file to roughly this many MB (at a UTF-8 character boundary)")
+    parser.add_argument("--tiktoken-support", nargs="*", default=None, metavar="REPO", help="print tiktoken's native resolution for REPOs (or the whole registry) and exit")
+    args = parser.parse_args()
+
+    if args.tiktoken_support is not None:
+        print_tiktoken_support(args.tiktoken_support)
+        return
+    for required in ("library", "tokenizer", "file"):
+        if getattr(args, required) is None:
+            parser.error(f"--{required} is required")
+
+    load, encode, count = LIBRARIES[args.library]
+    source = args.tokenizer if args.library == "tiktoken" else (args.local_file or args.tokenizer)
+    tokenizer = load(source)
+    if args.library == "gigatoken":
+        import awkward  # noqa: F401  (imported here so it isn't timed)
+
+    # Everything below happens before the timer: the file is fully in memory
+    # as bytes (and for hf/tiktoken decoded and split), so timing covers only
+    # tokenization.
+    data = open(os.path.expanduser(args.file), "rb").read()
+    if args.max_mb is not None:
+        budget = min(int(args.max_mb * 1e6), len(data))
+        while budget < len(data) and data[budget] & 0xC0 == 0x80:  # UTF-8 boundary
+            budget += 1
+        data = data[:budget]
+    if args.library == "gigatoken":
+        inputs = [data]
+    else:
+        text = data.decode("utf-8")
+        inputs = text.split(args.separator) if args.separator else [text]
+    n_docs = len(inputs)
+    n_bytes = len(data)
+    if args.library != "gigatoken":
+        del data, text  # keep peak memory down on multi-GB files
+
+    start = time.perf_counter()
+    encoded = encode(tokenizer, inputs)
+    elapsed = time.perf_counter() - start
+    n_tokens = count(encoded)
+
+    result = {
+        "library": args.library,
+        "tokenizer": args.tokenizer,
+        "file": args.file,
+        "cpu": results.cpu_label(),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "max_mb": args.max_mb,
+        "docs": n_docs,
+        "bytes": n_bytes,
+        "tokens": n_tokens,
+        "time_s": round(elapsed, 4),
+        "mb_per_s": round(n_bytes / 1e6 / elapsed, 2),
+        "mtokens_per_s": round(n_tokens / 1e6 / elapsed, 3),
+    }
+    if args.library == "tiktoken":
+        result["encoding"] = tokenizer.name
+    print(json.dumps(result))
+    print(
+        f"{args.library:>9}: {result['mb_per_s']:>8.2f} MB/s  "
+        f"{result['mtokens_per_s']:>7.3f} Mtok/s  "
+        f"({n_bytes / 1e6:.1f} MB, {n_docs} docs, {n_tokens} tokens, {elapsed:.3f}s)",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compare/plot_throughput.py
+++ b/benchmarks/compare/plot_throughput.py
@@ -1,0 +1,203 @@
+"""Bar charts (one PDF per corpus+tokenizer) from compare_throughput.py output.
+
+Reads one or more .jsonl result files, groups rows by (file, tokenizer), and
+draws one bar per library: bar height is the best (min-time) round, round dots
+show the spread. The y-axis is MB/s on a log scale — the libraries sit three
+orders of magnitude apart, so linear bars would leave two of them invisible;
+every bar carries an explicit value label instead.
+
+Usage:
+    uv run benchmarks/plot_throughput.py results/*.jsonl --out-dir plots
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+from collections import defaultdict
+
+import matplotlib
+
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+
+# Categorical slots 1-3 (blue, green, magenta) of the validated palette; the
+# same library keeps the same hue in every plot.
+LIBRARY_ORDER = ["hf", "tiktoken", "gigatoken"]  # slowest to fastest
+LIBRARY_LABELS = {"gigatoken": "gigatoken", "tiktoken": "tiktoken", "hf": "HF tokenizers"}
+LIBRARY_COLORS = {"gigatoken": "#2a78d6", "tiktoken": "#008300", "hf": "#e87ba4"}
+TEXT_PRIMARY, TEXT_SECONDARY, GRID = "#1a1a19", "#5f5e56", "#e4e3dc"
+
+
+NICE_NAMES = {
+    "gpt2": "GPT-2",
+    "qwen2_tokenizer.json": "Qwen2",
+    "qwen3_5_tokenizer.json": "Qwen 3.5",
+    "deepseek_v3_tokenizer.json": "DeepSeek-V3",
+    "glm5_2_tokenizer.json": "GLM-5.2",
+    "gptoss_tokenizer.json": "gpt-oss",
+    "o200k_harmony": "gpt-oss",  # tiktoken's native encoding for the same tokenizer
+    "nemotron_tokenizer.json": "Nemotron",
+    "olmo3_tokenizer.json": "OLMo-3",
+}
+
+
+def nice_name(tokenizer: str) -> str:
+    base = os.path.basename(tokenizer)
+    return NICE_NAMES.get(base, base.removesuffix("_tokenizer.json").removesuffix(".json"))
+
+
+def fmt_mbs(v: float) -> str:
+    return f"{v / 1000:.2f} GB/s" if v >= 1000 else f"{v:.1f} MB/s"
+
+
+def cpu_label() -> str:
+    if platform.system() == "Darwin":
+        chip = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"], capture_output=True, text=True).stdout.strip()
+    else:
+        chip = platform.processor() or platform.machine()
+    return f"{chip}, {os.cpu_count()} threads"
+
+
+def fmt_duration(seconds: float) -> str:
+    return f"{seconds / 60:.0f} min" if seconds >= 100 else f"{seconds:.1f} s"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", nargs="+", help=".jsonl files from compare_throughput.py")
+    parser.add_argument("--out-dir", default="plots")
+    parser.add_argument("--linear", action="store_true", help="linear y axis instead of log (small bars vanish; labels carry the values)")
+    parser.add_argument("--format", default="pdf", choices=["pdf", "svg", "png"])
+    parser.add_argument("--no-slice-note", action="store_true", help="omit the asterisk and footnote on libraries measured on a slice of the file")
+    parser.add_argument("--no-dots", action="store_true", help="omit the per-round dots")
+    parser.add_argument("--horizontal", action="store_true", help="sideways bars, fastest library on top")
+    parser.add_argument("--xmax", type=float, default=None, help="fixed upper limit for the value axis (horizontal+linear)")
+    parser.add_argument(
+        "--hf-arrow",
+        nargs="?",
+        const="Already implemented in Rust!",
+        default=None,
+        help="annotate the HF bar with an arrow and this text (horizontal charts only)",
+    )
+    args = parser.parse_args()
+
+    groups: dict[tuple[str, str], dict[str, list[dict]]] = defaultdict(lambda: defaultdict(list))
+    for path in args.results:
+        with open(path) as f:
+            for line in f:
+                row = json.loads(line)
+                key = (os.path.basename(row["file"]), nice_name(row["tokenizer"]))
+                groups[key][row["library"]].append(row)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    for (corpus, tok_name), by_lib in sorted(groups.items()):
+        libs = [lib for lib in LIBRARY_ORDER if lib in by_lib]
+        best = {lib: max(by_lib[lib], key=lambda r: r["mb_per_s"]) for lib in libs}
+        full_bytes = max(r["bytes"] for rows in by_lib.values() for r in rows)
+
+        fig, ax = plt.subplots(figsize=(7.2, 2.9) if args.horizontal else (5.4, 3.6))
+        xs = range(len(libs))
+        heights = [best[lib]["mb_per_s"] for lib in libs]
+        colors = [LIBRARY_COLORS[lib] for lib in libs]
+        if args.horizontal:
+            # barh puts y=0 at the bottom, so LIBRARY_ORDER (slowest first)
+            # lands the fastest library on top.
+            ax.barh(xs, heights, height=0.55, color=colors, zorder=3)
+        else:
+            ax.bar(xs, heights, width=0.55, color=colors, zorder=3)
+        value_max = args.xmax if (args.horizontal and args.linear and args.xmax) else max(heights) * 1.28
+        for x, lib in zip(xs, libs):
+            if not args.no_dots:
+                rounds = [r["mb_per_s"] for r in by_lib[lib]]
+                pos = ([x] * len(rounds), rounds) if not args.horizontal else (rounds, [x] * len(rounds))
+                ax.plot(*pos, "o", ms=4, mfc="white", mec=TEXT_PRIMARY, mew=0.8, zorder=4)
+            value = best[lib]["mb_per_s"]
+            # A bar ending near the axis limit gets its label inside the bar
+            # so it can't spill past the figure edge.
+            inside = args.horizontal and args.linear and value > 0.8 * value_max
+            ax.annotate(
+                fmt_mbs(value),
+                (value, x) if args.horizontal else (x, value),
+                xytext=((-8, 0) if inside else (8, 0)) if args.horizontal else (0, 10),
+                textcoords="offset points",
+                ha=("right" if inside else "left") if args.horizontal else "center",
+                va="center" if args.horizontal else "baseline",
+                color="white" if inside else TEXT_PRIMARY,
+                fontsize=10,
+                fontweight="bold",
+                zorder=5,
+            )
+
+        labels = []
+        footnotes = []
+        for lib in libs:
+            label = LIBRARY_LABELS[lib]
+            if best[lib]["bytes"] < full_bytes and not args.no_slice_note:
+                label += "*"
+                projected = full_bytes / 1e6 / best[lib]["mb_per_s"]
+                footnotes.append(
+                    f"*measured on the first {best[lib]['bytes'] / 1e6:.0f} MB; "
+                    f"full file projected {fmt_duration(projected)}"
+                )
+            labels.append(label)
+        if "tiktoken" not in by_lib:
+            footnotes.append("tiktoken omitted: not expressible as a tiktoken Encoding")
+
+        value_axis_label = "Throughput (MB/s)" if args.linear else "Throughput (MB/s, log scale)"
+        if args.horizontal:
+            ax.set_yticks(list(xs), labels, color=TEXT_PRIMARY, fontsize=10)
+            ax.set_xlabel(value_axis_label, color=TEXT_PRIMARY)
+            if args.linear:
+                ax.set_xlim(0, args.xmax if args.xmax else max(heights) * 1.28)
+            else:
+                ax.set_xscale("log")
+                ax.set_xlim(right=max(heights) * 8)
+        else:
+            ax.set_xticks(list(xs), labels, color=TEXT_PRIMARY, fontsize=10)
+            ax.set_ylabel(value_axis_label, color=TEXT_PRIMARY)
+            if args.linear:
+                ax.set_ylim(0, max(heights) * 1.18)
+            else:
+                ax.set_yscale("log")
+                ax.set_ylim(top=max(heights) * 4)
+        ax.set_title(
+            f"Tokenizer throughput — {tok_name} on {corpus} ({full_bytes / 1e9:.0f} GB)\n{cpu_label()}",
+            fontsize=11,
+            color=TEXT_PRIMARY,
+            loc="left",
+        )
+        if args.hf_arrow and args.horizontal and "hf" in libs:
+            hf_y = libs.index("hf")
+            ax.annotate(
+                args.hf_arrow,
+                xy=(0.04 * value_max, hf_y + 0.3),
+                xytext=(0.3 * value_max, hf_y + 0.62),
+                ha="left",
+                va="center",
+                color=TEXT_PRIMARY,
+                fontsize=10,
+                arrowprops={"arrowstyle": "->", "color": TEXT_PRIMARY, "lw": 1.2, "connectionstyle": "arc3,rad=0.25"},
+                zorder=5,
+            )
+        ax.tick_params(colors=TEXT_SECONDARY, labelsize=9)
+        ax.grid(axis="x" if args.horizontal else "y", which="major", color=GRID, lw=0.8, zorder=0)
+        keep_spine = "left" if args.horizontal else "bottom"
+        for spine in ax.spines:
+            ax.spines[spine].set_visible(spine == keep_spine)
+        ax.spines[keep_spine].set_color(GRID)
+        if footnotes:
+            fig.text(0.01, 0.01, "\n".join(footnotes), fontsize=7.5, color=TEXT_SECONDARY)
+
+        out = os.path.join(args.out_dir, f"throughput_{corpus.removesuffix('.txt')}_{tok_name.lower().replace(' ', '').replace('.', '_')}.{args.format}")
+        fig.tight_layout(rect=(0, 0.03 * len(footnotes), 1, 1))
+        fig.savefig(out)
+        plt.close(fig)
+        print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -1,0 +1,350 @@
+"""Best-results store and README table for the throughput benchmarks.
+
+Stdlib-only (run with `uv run --no-project`). Two subcommands:
+
+    uv run --no-project benchmarks/compare/results.py merge run.jsonl [...]
+    uv run --no-project benchmarks/compare/results.py render
+
+merge folds measurement JSONL (from measure.py, files or stdin) into
+benchmarks/results.json, nested cpu -> tokenizer (HF repo id) -> dataset
+(file basename) -> implementation {gigatoken, hf, tiktoken}. Within one
+input batch, consecutive records on the same cpu/tokenizer/file with each
+library appearing at most once form a *comparison set* — one interleaved
+round. A set replaces the stored group only if its gigatoken throughput
+beats the stored group's, so every stored group is one coherent round — the
+best one, as judged by gigatoken — never a mix of libraries from different
+rounds. Records without a "cpu" field are attributed to --cpu, which
+defaults to this machine.
+
+render rewrites the block between <!-- benchmarks:start --> and
+<!-- benchmarks:end --> in the repo README (appending a section when the
+markers are absent): one collapsible table per (cpu, dataset) with family
+display names, throughput per implementation, and gigatoken's speedup vs
+HF/tiktoken, plus coverage footnotes from benchmarks/families.json
+(regenerate with `sweep.py --scan-families`). Rows without a gigatoken
+measurement are skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BENCH_DIR = os.path.dirname(HERE)
+DEFAULT_RESULTS = os.path.join(BENCH_DIR, "results.json")
+DEFAULT_FAMILIES = os.path.join(BENCH_DIR, "families.json")
+DEFAULT_README = os.path.join(os.path.dirname(BENCH_DIR), "README.md")
+START, END = "<!-- benchmarks:start -->", "<!-- benchmarks:end -->"
+
+
+def cpu_label() -> str:
+    """Identify the CPU this benchmark ran on, e.g. "Apple M4 Max (16 cores)"."""
+    import platform
+
+    name = None
+    system = platform.system()
+    if system == "Darwin":
+        out = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"], capture_output=True, text=True)
+        name = out.stdout.strip() or None
+    elif system == "Linux":
+        try:
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        name = line.split(":", 1)[1].strip()
+                        break
+        except OSError:
+            pass
+    name = name or platform.processor() or platform.machine() or "unknown"
+    return f"{name} ({os.cpu_count()} cores)"
+
+
+# --- merge -----------------------------------------------------------------
+
+
+def read_records(origin: str, lines, cpu_fallback: str) -> list[dict]:
+    records = []
+    for lineno, line in enumerate(lines, 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise SystemExit(f"{origin}:{lineno}: invalid JSON: {e}")
+        if not isinstance(rec, dict) or not all(k in rec for k in ("library", "tokenizer", "file")):
+            raise SystemExit(f"{origin}:{lineno}: not a measure.py record (needs library/tokenizer/file)")
+        rec.setdefault("cpu", cpu_fallback)
+        records.append(rec)
+    return records
+
+
+def fits(cur: dict, rec: dict) -> bool:
+    return rec["library"] not in cur["libs"] and (rec["cpu"], rec["tokenizer"], rec["file"]) == (
+        cur["cpu"],
+        cur["tokenizer"],
+        cur["file"],
+    )
+
+
+def comparison_sets(records: list[dict]) -> list[dict]:
+    sets: list[dict] = []
+    for rec in records:
+        if not sets or not fits(sets[-1], rec):
+            sets.append({"cpu": rec["cpu"], "tokenizer": rec["tokenizer"], "file": rec["file"], "libs": {}})
+        sets[-1]["libs"][rec["library"]] = rec
+    return sets
+
+
+def stored_entry(rec: dict) -> dict:
+    return {k: v for k, v in rec.items() if k not in ("library", "cpu")}
+
+
+def merge_set(results: dict, cset: dict) -> tuple[str, bool]:
+    dataset = os.path.basename(cset["file"])
+    by_dataset = results.setdefault(cset["cpu"], {}).setdefault(cset["tokenizer"], {})
+    stored = by_dataset.get(dataset)
+    new_g = cset["libs"].get("gigatoken", {}).get("mb_per_s")
+    old_g = (stored or {}).get("gigatoken", {}).get("mb_per_s")
+    if stored is not None:
+        if new_g is None:
+            return "kept (set has no gigatoken measurement to judge by)", False
+        if old_g is not None and new_g <= old_g:
+            return f"kept (gigatoken {new_g} <= stored {old_g} MB/s)", False
+    by_dataset[dataset] = {lib: stored_entry(rec) for lib, rec in sorted(cset["libs"].items())}
+    if stored is None:
+        return f"stored ({', '.join(sorted(cset['libs']))})", True
+    if old_g is None:
+        return f"updated (stored group had no gigatoken; now {new_g} MB/s)", True
+    return f"updated (gigatoken {new_g} > {old_g} MB/s)", True
+
+
+def load_results(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            raise SystemExit(f"{path}: invalid JSON: {e}")
+
+
+def save_results(path: str, results: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(results, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def cmd_merge(args) -> None:
+    cpu = args.cpu or cpu_label()
+    batches = []
+    if args.jsonl:
+        for path in args.jsonl:
+            with open(path) as f:
+                batches.append(read_records(path, f, cpu))
+    else:
+        batches.append(read_records("<stdin>", sys.stdin, cpu))
+
+    results = load_results(args.results)
+    changed = 0
+    for records in batches:
+        for cset in comparison_sets(records):
+            outcome, wrote = merge_set(results, cset)
+            changed += wrote
+            print(f"{cset['cpu']} / {cset['tokenizer']} / {os.path.basename(cset['file'])}: {outcome}")
+    if changed:
+        save_results(args.results, results)
+    print(f"{changed} group(s) written to {args.results}" if changed else f"{args.results} unchanged")
+
+
+# --- render ----------------------------------------------------------------
+
+# Family display name per benchmarked repo; rows fall back to the repo id.
+DISPLAY = {
+    "openai-community/gpt2": "GPT-2",
+    "answerdotai/ModernBERT-base": "ModernBERT",
+    "meta-llama/Llama-3.1-8B": "Llama 3 / 3.1 / 3.2",
+    "meta-llama/Llama-3.3-70B-Instruct": "Llama 3.3",
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": "Llama 4",
+    "Qwen/Qwen2-1.5B-Instruct": "Qwen 2 / 2.5",
+    "Qwen/Qwen3-8B": "Qwen 3",
+    "Qwen/Qwen3.5-9B": "Qwen 3.5 / 3.6",
+    "deepseek-ai/DeepSeek-V3": "DeepSeek V3 / R1 / V4",
+    "zai-org/GLM-4.7": "GLM 4",
+    "zai-org/GLM-5.2": "GLM 5",
+    "openai/gpt-oss-20b": "GPT-OSS",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "Nemotron 3",
+    "allenai/Olmo-3-1025-7B": "OLMo 2 / 3",
+    "moonshotai/Kimi-K2-Instruct": "Kimi K2",
+    "tencent/Hy3": "Hunyuan 3",
+    "microsoft/phi-4": "Phi-4",
+    "microsoft/Phi-4-mini-instruct": "Phi-4-mini",
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0": "TinyLlama / Phi-3 (Llama 2)",
+    "codellama/CodeLlama-7b-hf": "CodeLlama",
+    "mistralai/Mistral-7B-Instruct-v0.3": "Mistral 7B v0.3",
+    "unsloth/gemma-2b": "Gemma 1",
+    "google/gemma-3-4b-it": "Gemma 3",
+    "google/gemma-4-E4B-it": "Gemma 4",
+}
+
+# Trailing repo-name tokens that mark a quant/format re-release, not a model.
+QUANT_TOKEN = re.compile(
+    r"(?i)^(awq|gptq|gguf|bf16|fp8|nvfp4|mxfp8|int\d+|\d+bit|w\d+a\d+(-g\d+)?"
+    r"|quantized(\.w\d+a\d+)?|dynamic|qat|ct|block|bnb)$"
+)
+
+
+def covered_names(repos: list[str]) -> list[str]:
+    """Org-stripped, quant-deduped model names for a coverage footnote."""
+    names, seen = [], set()
+    for repo in repos:
+        if "internal-testing" in repo or repo.split("/")[-1].lower().startswith("tiny-"):
+            continue
+        parts = repo.split("/")[-1].split("-")
+        while len(parts) > 1 and QUANT_TOKEN.match(parts[-1]):
+            parts.pop()
+        name = "-".join(parts)
+        if name.lower() not in seen:
+            seen.add(name.lower())
+            names.append(name)
+    return names
+
+
+def fmt_speed(mb_per_s: float | None) -> str:
+    if mb_per_s is None:
+        return "—"
+    if mb_per_s >= 1000:
+        return f"{mb_per_s / 1000:.2f} GB/s"
+    return f"{mb_per_s:.1f} MB/s"
+
+
+def fmt_ratio(giga: float | None, other: float | None) -> str:
+    if giga is None or not other:
+        return "—"
+    ratio = giga / other
+    return f"{ratio:,.0f}×" if ratio >= 10 else f"{ratio:.1f}×"
+
+
+def render_table(cpu: str, dataset: str, tokenizers: dict, families: dict, coverage: bool) -> str | None:
+    rows = []
+    corpus_bytes = 0
+    for repo, by_dataset in tokenizers.items():
+        group = by_dataset.get(dataset)
+        if group is None or "gigatoken" not in group:
+            continue
+        corpus_bytes = max(corpus_bytes, group["gigatoken"].get("bytes", 0))
+        speeds = {lib: rec.get("mb_per_s") for lib, rec in group.items()}
+        # Coverage: the cache scan (families.json) when available, else the
+        # sweep's own shared_with candidates.
+        covers = families.get(repo) or next(
+            (rec["shared_with"] for rec in group.values() if rec.get("shared_with")), []
+        )
+        rows.append((repo, speeds, covers))
+    if not rows:
+        return None
+    rows.sort(key=lambda row: row[1].get("gigatoken") or 0, reverse=True)
+
+    coverage_notes = []
+    for repo, _, covers in rows:
+        names = covered_names(covers)
+        if len(names) > 1:
+            coverage_notes.append(f"- **{DISPLAY.get(repo, repo)}** — {', '.join(names)}")
+
+    size = f" ({corpus_bytes / 1e9:.1f} GB)" if corpus_bytes else ""
+    lines = [
+        "<details>",
+        f"<summary><b>Encoding throughput on {dataset}{size} — {cpu}</b></summary>",
+        "",
+        "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with",
+        "parallelism enabled. gigatoken encodes the whole file un-split; HuggingFace",
+        "`tokenizers` (`encode_batch_fast`) gets the first 100 MB and tiktoken",
+        "(`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
+        "tiktoken rows exist only for tokenizers with official support.",
+        "",
+        "| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for repo, speeds, _ in rows:
+        giga, hf, tik = speeds.get("gigatoken"), speeds.get("hf"), speeds.get("tiktoken")
+        lines.append(
+            f"| {DISPLAY.get(repo, repo)} | {fmt_speed(giga)} | {fmt_speed(hf)} | {fmt_speed(tik)} "
+            f"| {fmt_ratio(giga, hf)} | {fmt_ratio(giga, tik)} |"
+        )
+    lines += [
+        "",
+        "The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),",
+        "which remain more expensive to encode than byte-level BPE even with gigatoken's",
+        "internal SP parallelism; ModernBERT is byte-level BPE with a heavier",
+        "pretokenizer than the GPT-2 family.",
+    ]
+    if coverage and coverage_notes:
+        lines += [
+            "",
+            "Each row benchmarks one distinct tokenizer (identical vocab/merges/pretokenizer),",
+            "measured on the family's representative repo. Models verified to share it:",
+            "",
+        ] + coverage_notes
+    lines += ["", "</details>"]
+    return "\n".join(lines)
+
+
+def cmd_render(args) -> None:
+    results = load_results(args.results)
+    if not results:
+        raise SystemExit(f"{args.results}: no results to render")
+    families = {}
+    if os.path.exists(args.families):
+        with open(args.families) as f:
+            families = json.load(f)
+
+    tables = []
+    for cpu, tokenizers in results.items():
+        datasets = sorted({ds for by_dataset in tokenizers.values() for ds in by_dataset})
+        for dataset in datasets:
+            table = render_table(cpu, dataset, tokenizers, families, args.coverage)
+            if table is not None:
+                tables.append(table)
+    block = "\n".join([START, "## Benchmarks", ""] + tables + [END])
+
+    with open(args.readme) as f:
+        readme = f.read()
+    start, end = readme.find(START), readme.find(END)
+    if start == -1 and end == -1:
+        readme = readme.rstrip("\n") + "\n\n" + block + "\n"
+    elif start != -1 and end > start:
+        readme = readme[:start] + block + readme[end + len(END):]
+    else:
+        raise SystemExit(f"{args.readme}: malformed benchmark markers ({START} / {END})")
+    with open(args.readme, "w") as f:
+        f.write(readme)
+    print(f"wrote {len(tables)} table(s) to {args.readme}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    merge = sub.add_parser("merge", help="fold measurement JSONL into the results file")
+    merge.add_argument("jsonl", nargs="*", help="JSONL measurement files; stdin if omitted")
+    merge.add_argument("--results", default=DEFAULT_RESULTS, help="results JSON file to update (default: %(default)s)")
+    merge.add_argument("--cpu", default=None, help="CPU label for records that lack one (default: this machine)")
+    merge.set_defaults(func=cmd_merge)
+
+    render = sub.add_parser("render", help="rewrite the README benchmark table from the results file")
+    render.add_argument("--results", default=DEFAULT_RESULTS)
+    render.add_argument("--families", default=DEFAULT_FAMILIES, help="coverage map from sweep.py --scan-families; optional")
+    render.add_argument("--readme", default=DEFAULT_README)
+    render.add_argument("--coverage", action="store_true", help="append the per-family model coverage footnotes")
+    render.set_defaults(func=cmd_render)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -20,9 +20,9 @@ render rewrites the block between <!-- benchmarks:start --> and
 <!-- benchmarks:end --> in the repo README (appending a section when the
 markers are absent): one collapsible table per (cpu, dataset) with family
 display names, throughput per implementation, and gigatoken's speedup vs
-HF/tiktoken, plus coverage footnotes from benchmarks/families.json
-(regenerate with `sweep.py --scan-families`). Rows without a gigatoken
-measurement are skipped.
+HF/tiktoken, plus hand-curated coverage footnotes (COVERS below, written
+from the `sweep.py --scan-families` data in benchmarks/families.json).
+Rows without a gigatoken measurement are skipped.
 """
 
 from __future__ import annotations
@@ -30,7 +30,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -192,27 +191,25 @@ DISPLAY = {
     "google/gemma-4-E4B-it": "Gemma 4",
 }
 
-# Trailing repo-name tokens that mark a quant/format re-release, not a model.
-QUANT_TOKEN = re.compile(
-    r"(?i)^(awq|gptq|gguf|bf16|fp8|nvfp4|mxfp8|int\d+|\d+bit|w\d+a\d+(-g\d+)?"
-    r"|quantized(\.w\d+a\d+)?|dynamic|qat|ct|block|bnb)$"
-)
-
-
-def covered_names(repos: list[str]) -> list[str]:
-    """Org-stripped, quant-deduped model names for a coverage footnote."""
-    names, seen = [], set()
-    for repo in repos:
-        if "internal-testing" in repo or repo.split("/")[-1].lower().startswith("tiny-"):
-            continue
-        parts = repo.split("/")[-1].split("-")
-        while len(parts) > 1 and QUANT_TOKEN.match(parts[-1]):
-            parts.pop()
-        name = "-".join(parts)
-        if name.lower() not in seen:
-            seen.add(name.lower())
-            names.append(name)
-    return names
+# Hand-curated coverage per row, written from the verified scan data in
+# benchmarks/families.json (regenerate the raw data with
+# `sweep.py --scan-families` and update these lines when it changes). Only
+# rows whose coverage goes beyond their display name are listed.
+COVERS = {
+    "meta-llama/Llama-3.1-8B": "Llama 3 / 3.1 / 3.2, DeepSeek-R1-Distill-Llama, Hermes 3, Saiga, and other Llama-3 finetunes",
+    "meta-llama/Llama-3.3-70B-Instruct": "Llama 3.3, Llama-3.1-Nemotron-Nano-VL, SmolLM3, Kanana 1.5, jina-embeddings-v5, Ultravox",
+    "Qwen/Qwen2-1.5B-Instruct": "Qwen 2 and 2.5 (incl. Coder and VL), Qwen3-Coder, Qwen3-VL, DeepSeek-R1 Qwen distills, MiMo V2.5, MiniCPM-o 2.6, InternVL3",
+    "Qwen/Qwen3-8B": "Qwen 3 (incl. Embedding and Reranker), Qwen2.5-Omni, Qwen3-VL-Embedding, MiMo V2.5 Pro, jina-reranker-m0, pplx-embed, MOSS-TTS, Zeta",
+    "deepseek-ai/DeepSeek-V3": "DeepSeek V3 / V3.1 / V3.2, R1, V4 Flash and Pro, DeepSeek-VL2",
+    "zai-org/GLM-4.7": "GLM 4.1V, 4.5, and 4.7",
+    "zai-org/GLM-5.2": "GLM 5 / 5.2 and GLM-4.7-Flash",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "Nemotron 3 Nano, Super, and Ultra",
+    "moonshotai/Kimi-K2-Instruct": "Kimi K2 / K2.5 / K2.6 / K2.7, Kimi-Linear, Kimi-VL, Moonlight",
+    "microsoft/Phi-4-mini-instruct": "Phi-4-mini and Phi-4-multimodal",
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0": "TinyLlama, Phi-3-mini, Phi-3.5-mini and Phi-3.5-vision (the Llama 2 vocab)",
+    "google/gemma-3-4b-it": "Gemma 3 (270M–27B) and EmbeddingGemma",
+    "google/gemma-4-E4B-it": "Gemma 4 (dense, MoE, and E-series) and DiffusionGemma",
+}
 
 
 def fmt_speed(mb_per_s: float | None) -> str:
@@ -230,7 +227,7 @@ def fmt_ratio(giga: float | None, other: float | None) -> str:
     return f"{ratio:,.0f}×" if ratio >= 10 else f"{ratio:.1f}×"
 
 
-def render_table(cpu: str, dataset: str, tokenizers: dict, families: dict, coverage: bool) -> str | None:
+def render_table(cpu: str, dataset: str, tokenizers: dict) -> str | None:
     rows = []
     corpus_bytes = 0
     for repo, by_dataset in tokenizers.items():
@@ -239,21 +236,14 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, families: dict, cover
             continue
         corpus_bytes = max(corpus_bytes, group["gigatoken"].get("bytes", 0))
         speeds = {lib: rec.get("mb_per_s") for lib, rec in group.items()}
-        # Coverage: the cache scan (families.json) when available, else the
-        # sweep's own shared_with candidates.
-        covers = families.get(repo) or next(
-            (rec["shared_with"] for rec in group.values() if rec.get("shared_with")), []
-        )
-        rows.append((repo, speeds, covers))
+        rows.append((repo, speeds))
     if not rows:
         return None
     rows.sort(key=lambda row: row[1].get("gigatoken") or 0, reverse=True)
 
-    coverage_notes = []
-    for repo, _, covers in rows:
-        names = covered_names(covers)
-        if len(names) > 1:
-            coverage_notes.append(f"- **{DISPLAY.get(repo, repo)}** — {', '.join(names)}")
+    coverage_notes = [
+        f"- **{DISPLAY.get(repo, repo)}** — {COVERS[repo]}" for repo, _ in rows if repo in COVERS
+    ]
 
     size = f" ({corpus_bytes / 1e9:.1f} GB)" if corpus_bytes else ""
     lines = [
@@ -269,7 +259,7 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, families: dict, cover
         "| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |",
         "|---|---:|---:|---:|---:|---:|",
     ]
-    for repo, speeds, _ in rows:
+    for repo, speeds in rows:
         giga, hf, tik = speeds.get("gigatoken"), speeds.get("hf"), speeds.get("tiktoken")
         lines.append(
             f"| {DISPLAY.get(repo, repo)} | {fmt_speed(giga)} | {fmt_speed(hf)} | {fmt_speed(tik)} "
@@ -282,11 +272,12 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, families: dict, cover
         "internal SP parallelism; ModernBERT is byte-level BPE with a heavier",
         "pretokenizer than the GPT-2 family.",
     ]
-    if coverage and coverage_notes:
+    if coverage_notes:
         lines += [
             "",
-            "Each row benchmarks one distinct tokenizer (identical vocab/merges/pretokenizer),",
-            "measured on the family's representative repo. Models verified to share it:",
+            "Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured",
+            "on a representative repo. Rows whose tokenizer is shared beyond their own name",
+            "(verified by matching tokenizer definitions across the local HF model cache) cover:",
             "",
         ] + coverage_notes
     lines += ["", "</details>"]
@@ -297,16 +288,12 @@ def cmd_render(args) -> None:
     results = load_results(args.results)
     if not results:
         raise SystemExit(f"{args.results}: no results to render")
-    families = {}
-    if os.path.exists(args.families):
-        with open(args.families) as f:
-            families = json.load(f)
 
     tables = []
     for cpu, tokenizers in results.items():
         datasets = sorted({ds for by_dataset in tokenizers.values() for ds in by_dataset})
         for dataset in datasets:
-            table = render_table(cpu, dataset, tokenizers, families, args.coverage)
+            table = render_table(cpu, dataset, tokenizers)
             if table is not None:
                 tables.append(table)
     block = "\n".join([START, "## Benchmarks", ""] + tables + [END])
@@ -337,9 +324,7 @@ def main() -> None:
 
     render = sub.add_parser("render", help="rewrite the README benchmark table from the results file")
     render.add_argument("--results", default=DEFAULT_RESULTS)
-    render.add_argument("--families", default=DEFAULT_FAMILIES, help="coverage map from sweep.py --scan-families; optional")
     render.add_argument("--readme", default=DEFAULT_README)
-    render.add_argument("--coverage", action="store_true", help="append the per-family model coverage footnotes")
     render.set_defaults(func=cmd_render)
 
     args = parser.parse_args()

--- a/benchmarks/compare/sweep.py
+++ b/benchmarks/compare/sweep.py
@@ -1,0 +1,238 @@
+"""Sequential cross-library sweep over the project's benchmark tokenizers.
+
+Candidate repos are deduplicated by their tokenizer definition in the HF
+cache: for tokenizer.json the hash covers the model, normalizer, and
+pre_tokenizer sections (so repos differing only in added special tokens or
+chat metadata — Llama-3.1 vs 3.2, DeepSeek-V3 vs R1 — count as shared);
+tokenizer.model / tiktoken.model files are hashed whole. Each shared group
+is benchmarked once under the first-listed repo, with the rest recorded as
+"shared_with". For each unique tokenizer the sweep runs --rounds interleaved
+rounds of measure.py — gigatoken on the whole file, hf on the first --hf-mb
+MB (only when the repo ships a tokenizer.json), tiktoken on the first
+--tiktoken-mb MB (only for natively supported repos, see
+`measure.py --tiktoken-support`) — one fresh process per measurement,
+strictly sequentially, never in parallel. Each round is merged into the
+single results file (cpu > tokenizer > dataset > implementation) as it
+completes, via results.py's best-round-by-gigatoken rule.
+
+`--scan-families` instead scans every model in the local HF cache for repos
+sharing a benchmarked row's tokenizer (same digest) and writes the coverage
+map benchmarks/families.json used by `results.py render`, then exits.
+
+Usage:
+    uv run benchmarks/compare/sweep.py --file ~/data/owt_train.txt
+    uv run benchmarks/compare/sweep.py --only openai-community/gpt2 --rounds 1
+    uv run benchmarks/compare/sweep.py --scan-families
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+import measure
+import results
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MEASURE = os.path.join(HERE, "measure.py")
+DEFAULT_FAMILIES = results.DEFAULT_FAMILIES
+TOKENIZER_FILES = ("tokenizer.json", "tokenizer.model", "tiktoken.model")
+HUB_CACHE = os.path.expanduser(os.environ.get("HF_HUB_CACHE", "~/.cache/huggingface/hub"))
+
+# Candidate repos, deduplicated at runtime. Order matters: the first repo of
+# a shared-tokenizer group becomes the group's representative.
+REPOS = [
+    # BPE / tokenizer.json families
+    "openai-community/gpt2",
+    "answerdotai/ModernBERT-base",
+    "meta-llama/Llama-3.1-8B",
+    "meta-llama/Llama-3.2-1B",
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+    "Qwen/Qwen2-1.5B-Instruct",
+    "Qwen/Qwen2.5-7B-Instruct",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.6-27B",
+    "deepseek-ai/DeepSeek-V3",
+    "deepseek-ai/DeepSeek-R1",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "zai-org/GLM-4.7",
+    "zai-org/GLM-5.2",
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-120b",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "allenai/Olmo-3-1025-7B",
+    "moonshotai/Kimi-K2-Instruct",
+    "moonshotai/Kimi-K2.5",
+    "tencent/Hy3",
+    "microsoft/phi-4",
+    "microsoft/Phi-4-mini-instruct",
+    # SentencePiece families
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "codellama/CodeLlama-7b-hf",
+    "mistralai/Mistral-7B-Instruct-v0.3",
+    "microsoft/Phi-3-mini-4k-instruct",
+    "unsloth/gemma-2b",
+    "google/gemma-3-4b-it",
+    "google/gemma-4-E4B-it",
+]
+
+
+def cached_file(repo: str, filename: str) -> str | None:
+    from huggingface_hub import try_to_load_from_cache
+
+    path = try_to_load_from_cache(repo, filename)
+    return path if isinstance(path, str) else None
+
+
+def tokenizer_digest(path: str) -> str:
+    """Identity of the tokenizer proper: for tokenizer.json only the parts
+    that determine how ordinary text is encoded (vocab/merges, normalizer,
+    pre_tokenizer), so repos differing in added special tokens still count
+    as the same tokenizer; other formats are hashed whole."""
+    with open(path, "rb") as f:
+        raw = f.read()
+    if os.path.basename(path) == "tokenizer.json":
+        cfg = json.loads(raw)
+        core = {key: cfg.get(key) for key in ("model", "normalizer", "pre_tokenizer")}
+        raw = json.dumps(core, sort_keys=True).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def repo_digest(repo: str) -> str | None:
+    for fname in TOKENIZER_FILES:
+        path = cached_file(repo, fname)
+        if path is not None:
+            try:
+                return tokenizer_digest(path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                return None
+    return None
+
+
+def tokenizer_groups(repos: list[str]) -> list[dict]:
+    groups: list[dict] = []
+    by_digest: dict[str, dict] = {}
+    for repo in repos:
+        for fname in TOKENIZER_FILES:
+            path = cached_file(repo, fname)
+            if path is not None:
+                break
+        else:
+            print(f"skip {repo}: no tokenizer file in the HF cache", file=sys.stderr)
+            continue
+        digest = tokenizer_digest(path)
+        if digest in by_digest:
+            by_digest[digest]["shared_with"].append(repo)
+        else:
+            group = {"repo": repo, "hf_json": fname == "tokenizer.json", "local": path, "shared_with": []}
+            by_digest[digest] = group
+            groups.append(group)
+    return groups
+
+
+def scan_families(results_path: str, out_path: str) -> None:
+    """Map each benchmarked tokenizer to every cached repo sharing its digest."""
+    stored = results.load_results(results_path)
+    benchmarked = sorted({repo for tokenizers in stored.values() for repo in tokenizers})
+    digests = {repo: repo_digest(repo) for repo in benchmarked}
+    for repo in (r for r, d in digests.items() if d is None):
+        print(f"warning: no digestible tokenizer file for {repo}", file=sys.stderr)
+
+    by_digest: dict[str, list[str]] = {d: [] for d in digests.values() if d is not None}
+    cached = [
+        entry[len("models--") :].replace("--", "/")
+        for entry in sorted(os.listdir(HUB_CACHE))
+        if entry.startswith("models--")
+    ]
+    for repo in cached:
+        digest = repo_digest(repo)
+        if digest in by_digest:
+            by_digest[digest].append(repo)
+
+    families = {
+        repo: sorted(by_digest[digest], key=str.lower)
+        for repo, digest in digests.items()
+        if digest is not None
+    }
+    with open(out_path, "w") as f:
+        json.dump(families, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(f"scanned {len(cached)} cached repos; wrote coverage for {len(families)} tokenizers to {out_path}")
+
+
+def run_one(lib: str, repo: str, file: str, max_mb: float | None, local_file: str | None) -> dict | None:
+    cmd = [sys.executable, MEASURE, "--library", lib, "--tokenizer", repo, "--file", file]
+    if max_mb is not None:
+        cmd += ["--max-mb", str(max_mb)]
+    if local_file is not None:
+        cmd += ["--local-file", local_file]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
+    lines = proc.stdout.strip().splitlines()
+    if proc.returncode != 0 or not lines:
+        print(f"    FAILED: {lib} on {repo} (exit {proc.returncode}); skipping this library", file=sys.stderr)
+        return None
+    return json.loads(lines[-1])
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--file", default="~/data/owt_train.txt")
+    parser.add_argument("--rounds", type=int, default=3)
+    parser.add_argument("--hf-mb", type=float, default=100)
+    parser.add_argument("--tiktoken-mb", type=float, default=1000)
+    parser.add_argument("--results", default=results.DEFAULT_RESULTS)
+    parser.add_argument("--only", nargs="*", default=None, help="benchmark only these repos instead of the built-in list")
+    parser.add_argument("--scan-families", action="store_true", help="regenerate the families.json coverage map from the HF cache and exit")
+    args = parser.parse_args()
+
+    if args.scan_families:
+        scan_families(args.results, DEFAULT_FAMILIES)
+        return
+
+    file = os.path.expanduser(args.file)
+    repos = args.only if args.only else REPOS
+    groups = tokenizer_groups(repos)
+    print(f"{len(groups)} unique tokenizers from {len(repos)} candidate repos", file=sys.stderr)
+
+    stored = results.load_results(args.results)
+    for i, group in enumerate(groups):
+        repo = group["repo"]
+        plan = [("gigatoken", None, None)]
+        if group["hf_json"]:
+            plan.append(("hf", args.hf_mb, group["local"]))
+        if measure.native_encoding(repo) is not None:
+            plan.append(("tiktoken", args.tiktoken_mb, None))
+        shared = f"  (= {', '.join(group['shared_with'])})" if group["shared_with"] else ""
+        print(f"[{i + 1}/{len(groups)}] {repo}{shared}: {', '.join(lib for lib, _, _ in plan)}", file=sys.stderr)
+
+        failed: set[str] = set()
+        for rnd in range(args.rounds):
+            records = []
+            for lib, max_mb, local in plan:
+                if lib in failed:
+                    continue
+                rec = run_one(lib, repo, file, max_mb, local)
+                if rec is None:
+                    failed.add(lib)
+                    continue
+                if group["shared_with"]:
+                    rec["shared_with"] = group["shared_with"]
+                records.append(rec)
+            round_wrote = False
+            for cset in results.comparison_sets(records):
+                outcome, wrote = results.merge_set(stored, cset)
+                round_wrote |= wrote
+                print(f"    round {rnd + 1}: {outcome}", file=sys.stderr)
+            if round_wrote:
+                results.save_results(args.results, stored)
+    print(f"sweep done -> {args.results}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/families.json
+++ b/benchmarks/families.json
@@ -1,0 +1,216 @@
+{
+  "Qwen/Qwen2-1.5B-Instruct": [
+    "deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+    "openbmb/MiniCPM-o-2_6",
+    "OpenGVLab/InternVL3-1B",
+    "Qwen/Qwen2-1.5B-Instruct",
+    "Qwen/Qwen2-VL-2B-Instruct",
+    "Qwen/Qwen2-VL-7B-Instruct",
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen2.5-14B-Instruct",
+    "Qwen/Qwen2.5-14B-Instruct-AWQ",
+    "Qwen/Qwen2.5-32B-Instruct",
+    "Qwen/Qwen2.5-3B-Instruct",
+    "Qwen/Qwen2.5-72B-Instruct-AWQ",
+    "Qwen/Qwen2.5-7B-Instruct",
+    "Qwen/Qwen2.5-7B-Instruct-AWQ",
+    "Qwen/Qwen2.5-Coder-14B-Instruct",
+    "Qwen/Qwen2.5-Coder-32B-Instruct-AWQ",
+    "Qwen/Qwen2.5-Coder-7B-Instruct",
+    "Qwen/Qwen2.5-VL-3B-Instruct",
+    "Qwen/Qwen2.5-VL-7B-Instruct",
+    "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+    "Qwen/Qwen3-Coder-Next",
+    "Qwen/Qwen3-Coder-Next-FP8",
+    "Qwen/Qwen3-VL-235B-A22B-Instruct",
+    "Qwen/Qwen3-VL-32B-Instruct",
+    "Qwen/Qwen3-VL-4B-Instruct",
+    "Qwen/Qwen3-VL-8B-Instruct",
+    "Qwen/Qwen3-VL-8B-Instruct-FP8",
+    "XiaomiMiMo/MiMo-V2.5"
+  ],
+  "Qwen/Qwen3-8B": [
+    "boboliu/Qwen3-Embedding-4B-W4A16-G128",
+    "boboliu/Qwen3-Reranker-4B-W4A16-G128",
+    "jinaai/jina-reranker-m0",
+    "openbmb/MiniCPM-o-4_5",
+    "OpenMOSS-Team/MOSS-TTS",
+    "perplexity-ai/pplx-embed-v1-0.6b",
+    "Qwen/Qwen2.5-Omni-3B",
+    "Qwen/Qwen2.5-VL-7B-Instruct-AWQ",
+    "Qwen/Qwen3-0.6B",
+    "Qwen/Qwen3-14B",
+    "Qwen/Qwen3-14B-AWQ",
+    "Qwen/Qwen3-235B-A22B-Instruct-2507",
+    "Qwen/Qwen3-30B-A3B",
+    "Qwen/Qwen3-30B-A3B-Instruct-2507",
+    "Qwen/Qwen3-32B",
+    "Qwen/Qwen3-32B-AWQ",
+    "Qwen/Qwen3-4B",
+    "Qwen/Qwen3-4B-Instruct-2507",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8",
+    "Qwen/Qwen3-Embedding-0.6B",
+    "Qwen/Qwen3-Embedding-4B",
+    "Qwen/Qwen3-Embedding-8B",
+    "Qwen/Qwen3-Reranker-4B",
+    "Qwen/Qwen3-VL-Embedding-8B",
+    "RedHatAI/Qwen2.5-1.5B-quantized.w8a8",
+    "trl-internal-testing/tiny-Qwen2_5_VLForConditionalGeneration",
+    "trl-internal-testing/tiny-Qwen2ForCausalLM-2.5",
+    "XiaomiMiMo/MiMo-V2.5-Pro",
+    "zed-industries/zeta"
+  ],
+  "Qwen/Qwen3.5-9B": [
+    "cyankiwi/Qwen3.6-27B-AWQ-INT4",
+    "cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit",
+    "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "QuantTrio/Qwen3.6-27B-AWQ",
+    "Qwen/Qwen3.5-27B",
+    "Qwen/Qwen3.5-35B-A3B",
+    "Qwen/Qwen3.5-4B",
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.6-27B",
+    "Qwen/Qwen3.6-27B-FP8",
+    "Qwen/Qwen3.6-35B-A3B",
+    "Qwen/Qwen3.6-35B-A3B-FP8"
+  ],
+  "TinyLlama/TinyLlama-1.1B-Chat-v1.0": [
+    "microsoft/Phi-3-mini-4k-instruct",
+    "microsoft/Phi-3.5-mini-instruct",
+    "microsoft/Phi-3.5-vision-instruct",
+    "TheBloke/TinyLlama-1.1B-Chat-v0.3-GPTQ",
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "TinyLlama/TinyLlama_v1.1"
+  ],
+  "allenai/Olmo-3-1025-7B": [
+    "allenai/OLMo-2-0425-1B",
+    "allenai/Olmo-3-1025-7B"
+  ],
+  "answerdotai/ModernBERT-base": [
+    "answerdotai/ModernBERT-base"
+  ],
+  "codellama/CodeLlama-7b-hf": [
+    "codellama/CodeLlama-7b-hf"
+  ],
+  "deepseek-ai/DeepSeek-V3": [
+    "deepseek-ai/DeepSeek-R1",
+    "deepseek-ai/DeepSeek-V3",
+    "deepseek-ai/DeepSeek-V3-0324",
+    "deepseek-ai/DeepSeek-V3.1",
+    "deepseek-ai/DeepSeek-V3.2",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "deepseek-ai/deepseek-vl2-tiny"
+  ],
+  "google/gemma-3-4b-it": [
+    "google/embeddinggemma-300m",
+    "google/gemma-3-1b-it",
+    "google/gemma-3-270m",
+    "google/gemma-3-27b-it",
+    "google/gemma-3-4b-it"
+  ],
+  "google/gemma-4-E4B-it": [
+    "cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit",
+    "farbodtavakkoli/OTel-LLM-E4B-IT",
+    "google/diffusiongemma-26B-A4B-it",
+    "google/gemma-4-12B-it-qat-w4a16-ct",
+    "google/gemma-4-26B-A4B",
+    "google/gemma-4-26B-A4B-it",
+    "google/gemma-4-31B-it",
+    "google/gemma-4-31B-it-assistant",
+    "google/gemma-4-31B-it-qat-w4a16-ct",
+    "google/gemma-4-E2B-it",
+    "google/gemma-4-E4B-it",
+    "mlx-community/gemma-4-31b-8bit",
+    "nvidia/diffusiongemma-26B-A4B-it-NVFP4",
+    "nvidia/Gemma-4-26B-A4B-NVFP4",
+    "nvidia/Gemma-4-31B-IT-NVFP4",
+    "RedHatAI/diffusiongemma-26B-A4B-it-NVFP4",
+    "RedHatAI/gemma-4-26B-A4B-it-FP8-dynamic",
+    "RedHatAI/gemma-4-26B-A4B-it-NVFP4",
+    "RedHatAI/gemma-4-31B-it-FP8-block",
+    "RedHatAI/gemma-4-31B-it-NVFP4"
+  ],
+  "meta-llama/Llama-3.1-8B": [
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+    "IlyaGusev/saiga_llama3_8b",
+    "meta-llama/Llama-3.1-8B",
+    "meta-llama/Llama-3.1-8B-Instruct",
+    "meta-llama/Llama-3.2-1B",
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct",
+    "meta-llama/Meta-Llama-3-8B-Instruct",
+    "meta-llama/Meta-Llama-3.1-8B-Instruct",
+    "NousResearch/Hermes-3-Llama-3.1-8B",
+    "RedHatAI/Llama-3.2-1B-Instruct-FP8"
+  ],
+  "meta-llama/Llama-3.3-70B-Instruct": [
+    "fixie-ai/ultravox-v0_5-llama-3_2-1b",
+    "HuggingFaceTB/SmolLM3-3B",
+    "jinaai/jina-embeddings-v5-text-nano",
+    "kakaocorp/kanana-1.5-v-3b-instruct",
+    "meta-llama/Llama-3.3-70B-Instruct",
+    "nvidia/Llama-3.1-Nemotron-Nano-VL-8B-V1",
+    "RedHatAI/Llama-3.2-1B-Instruct-FP8-dynamic"
+  ],
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct": [
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct"
+  ],
+  "microsoft/Phi-4-mini-instruct": [
+    "microsoft/Phi-4-mini-instruct",
+    "microsoft/Phi-4-multimodal-instruct"
+  ],
+  "microsoft/phi-4": [
+    "microsoft/phi-4"
+  ],
+  "mistralai/Mistral-7B-Instruct-v0.3": [
+    "mistralai/Mistral-7B-Instruct-v0.3"
+  ],
+  "moonshotai/Kimi-K2-Instruct": [
+    "moonshotai/Kimi-K2-Base",
+    "moonshotai/Kimi-K2-Instruct",
+    "moonshotai/Kimi-K2-Instruct-0905",
+    "moonshotai/Kimi-K2-Thinking",
+    "moonshotai/Kimi-K2.5",
+    "moonshotai/Kimi-K2.6",
+    "moonshotai/Kimi-K2.7-Code",
+    "moonshotai/Kimi-Linear-48B-A3B-Instruct",
+    "moonshotai/Kimi-VL-A3B-Instruct",
+    "moonshotai/Moonlight-16B-A3B-Instruct"
+  ],
+  "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": [
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+  ],
+  "openai-community/gpt2": [
+    "openai-community/gpt2"
+  ],
+  "openai/gpt-oss-20b": [
+    "openai/gpt-oss-120b",
+    "openai/gpt-oss-20b"
+  ],
+  "tencent/Hy3": [
+    "tencent/HunyuanOCR",
+    "tencent/Hy3"
+  ],
+  "unsloth/gemma-2b": [
+    "unsloth/gemma-2b"
+  ],
+  "zai-org/GLM-4.7": [
+    "trl-internal-testing/tiny-Glm4MoeForCausalLM",
+    "zai-org/GLM-4.1V-9B-Thinking",
+    "zai-org/GLM-4.5-Air",
+    "zai-org/GLM-4.7"
+  ],
+  "zai-org/GLM-5.2": [
+    "zai-org/GLM-4.7-Flash",
+    "zai-org/GLM-5-FP8",
+    "zai-org/GLM-5.2",
+    "zai-org/GLM-5.2-FP8"
+  ]
+}

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,0 +1,722 @@
+{
+  "Apple M4 Max (16 cores)": {
+    "Qwen/Qwen2-1.5B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6366.36,
+          "mtokens_per_s": 1394.861,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 1.8724,
+          "timestamp": "2026-07-20T13:04:51",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 5.76,
+          "mtokens_per_s": 1.259,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 17.3699,
+          "timestamp": "2026-07-20T13:05:10",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6361.59,
+          "mtokens_per_s": 1393.814,
+          "time_s": 1.8738,
+          "timestamp": "2026-07-20T13:05:33",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 6.93,
+          "mtokens_per_s": 1.515,
+          "time_s": 14.4303,
+          "timestamp": "2026-07-20T13:05:49",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3.5-9B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6312.73,
+          "mtokens_per_s": 1398.552,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 1.8883,
+          "timestamp": "2026-07-20T13:06:37",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 2640927277
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 6.35,
+          "mtokens_per_s": 1.402,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 15.7544,
+          "timestamp": "2026-07-20T13:06:55",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 22092233
+        }
+      }
+    },
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1692.76,
+          "mtokens_per_s": 437.653,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 7.0421,
+          "timestamp": "2026-07-20T14:26:43",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 3081985364
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 80.13,
+          "mtokens_per_s": 20.615,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 1.248,
+          "timestamp": "2026-07-20T14:26:46",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 25725923
+        }
+      }
+    },
+    "allenai/Olmo-3-1025-7B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 7559.38,
+          "mtokens_per_s": 1621.283,
+          "time_s": 1.5769,
+          "timestamp": "2026-07-20T13:11:47",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 5.82,
+          "mtokens_per_s": 1.247,
+          "time_s": 17.1775,
+          "timestamp": "2026-07-20T13:12:06",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 21417051
+        }
+      }
+    },
+    "answerdotai/ModernBERT-base": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 2643.18,
+          "mtokens_per_s": 598.601,
+          "time_s": 4.5099,
+          "timestamp": "2026-07-20T13:01:37",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 2699642019
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 5.85,
+          "mtokens_per_s": 1.327,
+          "time_s": 17.0913,
+          "timestamp": "2026-07-20T13:01:55",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 22677527
+        }
+      }
+    },
+    "codellama/CodeLlama-7b-hf": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1731.32,
+          "mtokens_per_s": 447.624,
+          "time_s": 6.8852,
+          "timestamp": "2026-07-20T14:27:17",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 3081984489
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 80.18,
+          "mtokens_per_s": 20.627,
+          "time_s": 1.2472,
+          "timestamp": "2026-07-20T14:27:20",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 25725750
+        }
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5675.75,
+          "mtokens_per_s": 1236.799,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 2.1003,
+          "timestamp": "2026-07-20T13:07:38",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 2597590340
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 7.2,
+          "mtokens_per_s": 1.56,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 13.8803,
+          "timestamp": "2026-07-20T13:07:54",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 21650989
+        }
+      }
+    },
+    "google/gemma-3-4b-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1383.11,
+          "mtokens_per_s": 308.44,
+          "time_s": 8.6187,
+          "timestamp": "2026-07-20T14:28:41",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 2658340885
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 82.23,
+          "mtokens_per_s": 18.238,
+          "time_s": 1.2161,
+          "timestamp": "2026-07-20T14:28:44",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 22178584
+        }
+      }
+    },
+    "google/gemma-4-E4B-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1822.56,
+          "mtokens_per_s": 406.456,
+          "time_s": 6.5405,
+          "timestamp": "2026-07-20T14:29:45",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 2658430536
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 85.21,
+          "mtokens_per_s": 18.881,
+          "time_s": 1.1736,
+          "timestamp": "2026-07-20T14:29:48",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 22158714
+        }
+      }
+    },
+    "meta-llama/Llama-3.1-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 7600.7,
+          "mtokens_per_s": 1636.863,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 1.5683,
+          "timestamp": "2026-07-20T13:02:45",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 11.24,
+          "mtokens_per_s": 2.406,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 8.8961,
+          "timestamp": "2026-07-20T13:02:56",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 7497.7,
+          "mtokens_per_s": 1614.681,
+          "time_s": 1.5899,
+          "timestamp": "2026-07-20T13:02:59",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 15.65,
+          "mtokens_per_s": 3.351,
+          "time_s": 6.3884,
+          "timestamp": "2026-07-20T13:03:07",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6814.87,
+          "mtokens_per_s": 1468.485,
+          "time_s": 1.7492,
+          "timestamp": "2026-07-20T13:03:59",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 2568660194
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 11.56,
+          "mtokens_per_s": 2.477,
+          "time_s": 8.6524,
+          "timestamp": "2026-07-20T13:04:09",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 21434680
+        }
+      }
+    },
+    "microsoft/Phi-4-mini-instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6967.27,
+          "mtokens_per_s": 1482.626,
+          "time_s": 1.7109,
+          "timestamp": "2026-07-20T13:14:28",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 7.23,
+          "mtokens_per_s": 1.535,
+          "time_s": 13.8342,
+          "timestamp": "2026-07-20T13:14:43",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 21234009
+        }
+      }
+    },
+    "microsoft/phi-4": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 7759.98,
+          "mtokens_per_s": 1664.306,
+          "time_s": 1.5362,
+          "timestamp": "2026-07-20T13:14:10",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 7.67,
+          "mtokens_per_s": 1.643,
+          "time_s": 13.0352,
+          "timestamp": "2026-07-20T13:14:24",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 21417051
+        }
+      }
+    },
+    "mistralai/Mistral-7B-Instruct-v0.3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1990.84,
+          "mtokens_per_s": 497.518,
+          "time_s": 5.9877,
+          "timestamp": "2026-07-20T14:27:49",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 2978987937
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 95.11,
+          "mtokens_per_s": 23.65,
+          "time_s": 1.0514,
+          "timestamp": "2026-07-20T14:27:51",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 24864785
+        }
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6884.07,
+          "mtokens_per_s": 1491.585,
+          "shared_with": [
+            "moonshotai/Kimi-K2.5"
+          ],
+          "time_s": 1.7316,
+          "timestamp": "2026-07-20T13:12:37",
+          "tokenizer": "moonshotai/Kimi-K2-Instruct",
+          "tokens": 2582841844
+        }
+      }
+    },
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 7819.26,
+          "mtokens_per_s": 1751.333,
+          "time_s": 1.5245,
+          "timestamp": "2026-07-20T13:11:01",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 2669917451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 10.94,
+          "mtokens_per_s": 2.432,
+          "time_s": 9.1385,
+          "timestamp": "2026-07-20T13:11:12",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 22229104
+        }
+      }
+    },
+    "openai-community/gpt2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 8790.45,
+          "mtokens_per_s": 1994.023,
+          "time_s": 1.3561,
+          "timestamp": "2026-07-20T12:59:17",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 2704046552
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 6.93,
+          "mtokens_per_s": 1.573,
+          "time_s": 14.4305,
+          "timestamp": "2026-07-20T12:59:33",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 22703001
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "gpt2",
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 62.76,
+          "mtokens_per_s": 14.236,
+          "time_s": 15.9329,
+          "timestamp": "2026-07-20T12:59:51",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 226815823
+        }
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6202.07,
+          "mtokens_per_s": 1319.792,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 1.922,
+          "timestamp": "2026-07-20T13:09:58",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 20.24,
+          "mtokens_per_s": 4.298,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 4.94,
+          "timestamp": "2026-07-20T13:10:05",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 21234009
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "o200k_harmony",
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 87.17,
+          "mtokens_per_s": 18.543,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 11.4717,
+          "timestamp": "2026-07-20T13:10:19",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 212718509
+        }
+      }
+    },
+    "tencent/Hy3": {
+      "owt_train.txt": {
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 7.35,
+          "mtokens_per_s": 1.609,
+          "time_s": 13.6044,
+          "timestamp": "2026-07-20T13:12:52",
+          "tokenizer": "tencent/Hy3",
+          "tokens": 21882884
+        }
+      }
+    },
+    "unsloth/gemma-2b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1417.46,
+          "mtokens_per_s": 315.059,
+          "time_s": 8.4098,
+          "timestamp": "2026-07-20T14:28:01",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 2649565869
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 85.72,
+          "mtokens_per_s": 18.947,
+          "time_s": 1.1666,
+          "timestamp": "2026-07-20T14:28:04",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 22103965
+        }
+      }
+    },
+    "zai-org/GLM-4.7": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6173.78,
+          "mtokens_per_s": 1324.691,
+          "time_s": 1.9308,
+          "timestamp": "2026-07-20T13:08:29",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 2557750876
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 15.76,
+          "mtokens_per_s": 3.374,
+          "time_s": 6.3451,
+          "timestamp": "2026-07-20T13:08:37",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 21407946
+        }
+      }
+    },
+    "zai-org/GLM-5.2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5547.88,
+          "mtokens_per_s": 1190.325,
+          "time_s": 2.1487,
+          "timestamp": "2026-07-20T13:09:18",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 2557602611
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/Users/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 12.16,
+          "mtokens_per_s": 2.603,
+          "time_s": 8.2227,
+          "timestamp": "2026-07-20T13:09:28",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 21407262
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the benchmark pipeline under `benchmarks/compare/` (three modules) plus the data files and the spoilered results table in the README.

- **`measure.py`** — times one library (gigatoken / HF `tokenizers` / tiktoken) per fresh process on one file; tokenizers are named by HF repo id for every library so measurements line up. tiktoken runs only repos its own model registry resolves to an installed encoding (`--tiktoken-support` prints the registry); convertible-but-unsupported vocabs are refused.
- **`sweep.py`** — dedupes candidate repos by tokenizer identity (hashing `tokenizer.json`'s model/normalizer/pre_tokenizer sections, so Llama-3.1/3.2, DeepSeek-V3/R1/V4, TinyLlama/Phi-3 each count as one tokenizer), then runs interleaved rounds strictly sequentially. `--scan-families` rescans the local HF cache for every model sharing a benchmarked tokenizer → `families.json`.
- **`results.py`** — the single `benchmarks/results.json` store, nested `cpu > tokenizer > dataset > implementation`. A round replaces a stored group only when its gigatoken throughput beats the stored round, so every group is one coherent interleaved round. `render` rewrites the README table between the `<!-- benchmarks:start/end -->` markers with family display names.

## Numbers

M4 Max (16 cores), 11.9 GB OpenWebText, best of 3 interleaved rounds: gigatoken 5.5–8.8 GB/s on byte-level-BPE tokenizers (300–1300× HF, 71–140× tiktoken) and 1.4–2.0 GB/s on SentencePiece (17–22× HF). SP rows were measured whole-file against #21's internal SP parallelism (its build; everything else on main `34c1e25`) — merge #21 first. `tencent/Hy3` currently fails to load (byte-gap vocab, fix lives on `byte-gap-vocab`) and is stored HF-only, excluded from the table.

## Testing

- Merge semantics round-trip (store / update-on-better / kept-on-worse / tie / idempotent re-merge) and an end-to-end one-round sweep smoke were exercised against scratch files.
- `results.py render` is byte-stable across runs and reproduces the committed README block exactly.