### PR TITLE
Add Linux benchmark results (Ryzen 7 9800X3D + EPYC 9565)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,49 @@ on a representative repo. Rows whose tokenizer is shared beyond their own name
 - **Gemma 3** — Gemma 3 (270M–27B) and EmbeddingGemma
 
 </details>
+<details>
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)</b></summary>
+
+Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
+Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
+HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
+This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
+Tiktoken rows are currently only filled in for tokenizers with official support.
+
+| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
+|---|---:|---:|---:|---:|---:|
+| GPT-2 | 6.27 GB/s | 59.0 MB/s | 92.1 MB/s | 106× | 68× |
+| Phi-4 | 6.09 GB/s | 55.4 MB/s | — | 110× | — |
+| OLMo 2 / 3 | 6.06 GB/s | 55.4 MB/s | — | 109× | — |
+| Phi-4-mini | 5.80 GB/s | 54.6 MB/s | — | 106× | — |
+| GPT-OSS | 5.68 GB/s | 79.6 MB/s | 112.7 MB/s | 71× | 50× |
+| Qwen 3 | 5.34 GB/s | 54.4 MB/s | — | 98× | — |
+| Qwen 2 / 2.5 | 5.30 GB/s | 51.7 MB/s | — | 103× | — |
+| Llama 3.3 | 5.26 GB/s | 79.9 MB/s | — | 66× | — |
+| Llama 3 / 3.1 / 3.2 | 5.24 GB/s | 79.5 MB/s | — | 66× | — |
+| Kimi K2 | 5.23 GB/s | — | — | — | — |
+| Qwen 3.5 / 3.6 | 5.22 GB/s | 51.6 MB/s | — | 101× | — |
+| Nemotron 3 | 5.20 GB/s | 79.0 MB/s | — | 66× | — |
+| GLM 5 | 5.05 GB/s | 79.5 MB/s | — | 63× | — |
+| GLM 4 | 5.04 GB/s | 79.5 MB/s | — | 63× | — |
+| Llama 4 | 5.03 GB/s | 78.2 MB/s | — | 64× | — |
+| DeepSeek V3 / R1 / V4 | 4.21 GB/s | 51.6 MB/s | — | 82× | — |
+| ModernBERT | 2.84 GB/s | 52.1 MB/s | — | 54× | — |
+| Mistral 7B v0.3 | 1.47 GB/s | 91.6 MB/s | — | 16× | — |
+| Gemma 4 | 1.45 GB/s | 78.8 MB/s | — | 18× | — |
+| CodeLlama | 1.38 GB/s | 85.2 MB/s | — | 16× | — |
+| TinyLlama / Phi-3 (Llama 2) | 1.37 GB/s | 84.9 MB/s | — | 16× | — |
+| Gemma 1 | 1.14 GB/s | 84.9 MB/s | — | 13× | — |
+| Gemma 3 | 1.12 GB/s | 83.0 MB/s | — | 13× | — |
+
+The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),
+which remain more expensive to encode than byte-level BPE even with gigatoken's
+internal SP parallelism; ModernBERT is byte-level BPE with a heavier
+pretokenizer than the GPT-2 family.
+
+Per-row model coverage is listed under the first table.
+
+</details>
 <!-- benchmarks:end -->
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ Tiktoken rows are currently only filled in for tokenizers with official support.
 | Gemma 1 | 1.42 GB/s | 85.7 MB/s | — | 17× | — |
 | Gemma 3 | 1.38 GB/s | 82.2 MB/s | — | 17× | — |
 
-The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),
-which remain more expensive to encode than byte-level BPE even with gigatoken's
+The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
+and Mistral vocabs), which remain more expensive to encode than byte-level
+BPE even with gigatoken's
 internal SP parallelism; ModernBERT is byte-level BPE with a heavier
 pretokenizer than the GPT-2 family.
 
@@ -218,8 +219,53 @@ Tiktoken rows are currently only filled in for tokenizers with official support.
 | Gemma 1 | 1.14 GB/s | 84.9 MB/s | — | 13× | — |
 | Gemma 3 | 1.12 GB/s | 83.0 MB/s | — | 13× | — |
 
-The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),
-which remain more expensive to encode than byte-level BPE even with gigatoken's
+The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
+and Mistral vocabs), which remain more expensive to encode than byte-level
+BPE even with gigatoken's
+internal SP parallelism; ModernBERT is byte-level BPE with a heavier
+pretokenizer than the GPT-2 family.
+
+Per-row model coverage is listed under the first table.
+
+</details>
+<details>
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD EPYC 9565 72-Core Processor (288 cores)</b></summary>
+
+Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
+Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
+HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
+This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
+Tiktoken rows are currently only filled in for tokenizers with official support.
+
+| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
+|---|---:|---:|---:|---:|---:|
+| GPT-2 | 24.53 GB/s | 24.8 MB/s | 36.0 MB/s | 989× | 681× |
+| Phi-4 | 24.00 GB/s | 29.9 MB/s | — | 801× | — |
+| GPT-OSS | 23.96 GB/s | 49.7 MB/s | 42.8 MB/s | 482× | 560× |
+| OLMo 2 / 3 | 23.06 GB/s | 27.7 MB/s | — | 833× | — |
+| Nemotron 3 | 22.79 GB/s | 49.4 MB/s | — | 462× | — |
+| Qwen 3 | 22.16 GB/s | 34.2 MB/s | — | 648× | — |
+| Llama 3 / 3.1 / 3.2 | 22.15 GB/s | 48.5 MB/s | — | 457× | — |
+| GLM 5 | 20.97 GB/s | 74.8 MB/s | — | 280× | — |
+| Llama 3.3 | 20.82 GB/s | 48.3 MB/s | — | 431× | — |
+| Llama 4 | 20.77 GB/s | 72.7 MB/s | — | 286× | — |
+| GLM 4 | 20.61 GB/s | 72.3 MB/s | — | 285× | — |
+| Phi-4-mini | 20.05 GB/s | 27.6 MB/s | — | 726× | — |
+| DeepSeek V3 / R1 / V4 | 19.69 GB/s | 26.2 MB/s | — | 750× | — |
+| Qwen 2 / 2.5 | 19.12 GB/s | 27.7 MB/s | — | 691× | — |
+| Kimi K2 | 18.85 GB/s | — | — | — | — |
+| Qwen 3.5 / 3.6 | 15.49 GB/s | 27.7 MB/s | — | 558× | — |
+| Gemma 4 | 4.82 GB/s | 334.1 MB/s | — | 14× | — |
+| ModernBERT | 4.18 GB/s | 26.9 MB/s | — | 155× | — |
+| Mistral 7B v0.3 | 3.57 GB/s | 354.7 MB/s | — | 10× | — |
+| TinyLlama / Phi-3 (Llama 2) | 3.48 GB/s | 323.6 MB/s | — | 11× | — |
+| CodeLlama | 3.47 GB/s | 347.4 MB/s | — | 10.0× | — |
+| Gemma 3 | 3.43 GB/s | 357.2 MB/s | — | 9.6× | — |
+| Gemma 1 | 2.51 GB/s | 342.2 MB/s | — | 7.3× | — |
+
+The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
+and Mistral vocabs), which remain more expensive to encode than byte-level
+BPE even with gigatoken's
 internal SP parallelism; ModernBERT is byte-level BPE with a heavier
 pretokenizer than the GPT-2 family.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-~300-1000x faster than HuggingFace's tokenizers, drop-in replacement.
+~1000x faster than HuggingFace's tokenizers, drop-in replacement.
 
 *Tokenize your text data at GB/s!*
 
@@ -220,17 +220,14 @@ Additionally, Gigatoken uses concurrent data structures to use multiprocessing i
 Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
 Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
 HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
-This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
+This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout processing.
 Tiktoken rows are currently only filled in for tokenizers with official support.
 
-The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
-and Mistral vocabs), which remain more expensive to encode than byte-level
-BPE even with gigatoken's internal SP parallelism; ModernBERT is byte-level
-BPE with a heavier pretokenizer than the GPT-2 family.
+The slowest rows are the SentencePiece-based tokenizers, which are only somewhat optimized in Gigatoken.
 
-Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured
-on a representative repo. Rows whose tokenizer is shared beyond their own name
-(verified by matching tokenizer definitions across the local HF model cache) cover:
+Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured on a representative repo.
+If you don't see your tokenizer here, it's likely based on some existing one.
+For instance:
 
 - **Llama 3 / 3.1 / 3.2** — Llama 3 / 3.1 / 3.2, DeepSeek-R1-Distill-Llama, Hermes 3, Saiga, and other Llama-3 finetunes
 - **Llama 3.3** — Llama 3.3, Llama-3.1-Nemotron-Nano-VL, SmolLM3, Kanana 1.5, jina-embeddings-v5, Ultravox

--- a/README.md
+++ b/README.md
@@ -125,117 +125,7 @@ Additionally, Gigatoken uses concurrent data structures to use multiprocessing i
 ## Benchmarks
 
 <details>
-<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — Apple M4 Max (16 cores)</b></summary>
-
-Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
-Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
-HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
-This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
-Tiktoken rows are currently only filled in for tokenizers with official support.
-
-| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
-|---|---:|---:|---:|---:|---:|
-| GPT-2 | 8.79 GB/s | 6.9 MB/s | 62.8 MB/s | 1,268× | 140× |
-| Nemotron 3 | 7.82 GB/s | 10.9 MB/s | — | 715× | — |
-| Phi-4 | 7.76 GB/s | 7.7 MB/s | — | 1,012× | — |
-| Llama 3 / 3.1 / 3.2 | 7.60 GB/s | 11.2 MB/s | — | 676× | — |
-| OLMo 2 / 3 | 7.56 GB/s | 5.8 MB/s | — | 1,299× | — |
-| Llama 3.3 | 7.50 GB/s | 15.7 MB/s | — | 479× | — |
-| Phi-4-mini | 6.97 GB/s | 7.2 MB/s | — | 964× | — |
-| Kimi K2 | 6.88 GB/s | — | — | — | — |
-| Llama 4 | 6.81 GB/s | 11.6 MB/s | — | 590× | — |
-| Qwen 2 / 2.5 | 6.37 GB/s | 5.8 MB/s | — | 1,105× | — |
-| Qwen 3 | 6.36 GB/s | 6.9 MB/s | — | 918× | — |
-| Qwen 3.5 / 3.6 | 6.31 GB/s | 6.3 MB/s | — | 994× | — |
-| GPT-OSS | 6.20 GB/s | 20.2 MB/s | 87.2 MB/s | 306× | 71× |
-| GLM 4 | 6.17 GB/s | 15.8 MB/s | — | 392× | — |
-| DeepSeek V3 / R1 / V4 | 5.68 GB/s | 7.2 MB/s | — | 788× | — |
-| GLM 5 | 5.55 GB/s | 12.2 MB/s | — | 456× | — |
-| ModernBERT | 2.64 GB/s | 5.8 MB/s | — | 452× | — |
-| Mistral 7B v0.3 | 1.99 GB/s | 95.1 MB/s | — | 21× | — |
-| Gemma 4 | 1.82 GB/s | 85.2 MB/s | — | 21× | — |
-| CodeLlama | 1.73 GB/s | 80.2 MB/s | — | 22× | — |
-| TinyLlama / Phi-3 (Llama 2) | 1.69 GB/s | 80.1 MB/s | — | 21× | — |
-| Gemma 1 | 1.42 GB/s | 85.7 MB/s | — | 17× | — |
-| Gemma 3 | 1.38 GB/s | 82.2 MB/s | — | 17× | — |
-
-The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
-and Mistral vocabs), which remain more expensive to encode than byte-level
-BPE even with gigatoken's
-internal SP parallelism; ModernBERT is byte-level BPE with a heavier
-pretokenizer than the GPT-2 family.
-
-Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured
-on a representative repo. Rows whose tokenizer is shared beyond their own name
-(verified by matching tokenizer definitions across the local HF model cache) cover:
-
-- **Nemotron 3** — Nemotron 3 Nano, Super, and Ultra
-- **Llama 3 / 3.1 / 3.2** — Llama 3 / 3.1 / 3.2, DeepSeek-R1-Distill-Llama, Hermes 3, Saiga, and other Llama-3 finetunes
-- **Llama 3.3** — Llama 3.3, Llama-3.1-Nemotron-Nano-VL, SmolLM3, Kanana 1.5, jina-embeddings-v5, Ultravox
-- **Phi-4-mini** — Phi-4-mini and Phi-4-multimodal
-- **Kimi K2** — Kimi K2 / K2.5 / K2.6 / K2.7, Kimi-Linear, Kimi-VL, Moonlight
-- **Qwen 2 / 2.5** — Qwen 2 and 2.5 (incl. Coder and VL), Qwen3-Coder, Qwen3-VL, DeepSeek-R1 Qwen distills, MiMo V2.5, MiniCPM-o 2.6, InternVL3
-- **Qwen 3** — Qwen 3 (incl. Embedding and Reranker), Qwen2.5-Omni, Qwen3-VL-Embedding, MiMo V2.5 Pro, jina-reranker-m0, pplx-embed, MOSS-TTS, Zeta
-- **GLM 4** — GLM 4.1V, 4.5, and 4.7
-- **DeepSeek V3 / R1 / V4** — DeepSeek V3 / V3.1 / V3.2, R1, V4 Flash and Pro, DeepSeek-VL2
-- **GLM 5** — GLM 5 / 5.2 and GLM-4.7-Flash
-- **Gemma 4** — Gemma 4 (dense, MoE, and E-series) and DiffusionGemma
-- **TinyLlama / Phi-3 (Llama 2)** — TinyLlama, Phi-3-mini, Phi-3.5-mini and Phi-3.5-vision (the Llama 2 vocab)
-- **Gemma 3** — Gemma 3 (270M–27B) and EmbeddingGemma
-
-</details>
-<details>
-<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)</b></summary>
-
-Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
-Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
-HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
-This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
-Tiktoken rows are currently only filled in for tokenizers with official support.
-
-| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
-|---|---:|---:|---:|---:|---:|
-| GPT-2 | 6.27 GB/s | 59.0 MB/s | 92.1 MB/s | 106× | 68× |
-| Phi-4 | 6.09 GB/s | 55.4 MB/s | — | 110× | — |
-| OLMo 2 / 3 | 6.06 GB/s | 55.4 MB/s | — | 109× | — |
-| Phi-4-mini | 5.80 GB/s | 54.6 MB/s | — | 106× | — |
-| GPT-OSS | 5.68 GB/s | 79.6 MB/s | 112.7 MB/s | 71× | 50× |
-| Qwen 3 | 5.34 GB/s | 54.4 MB/s | — | 98× | — |
-| Qwen 2 / 2.5 | 5.30 GB/s | 51.7 MB/s | — | 103× | — |
-| Llama 3.3 | 5.26 GB/s | 79.9 MB/s | — | 66× | — |
-| Llama 3 / 3.1 / 3.2 | 5.24 GB/s | 79.5 MB/s | — | 66× | — |
-| Kimi K2 | 5.23 GB/s | — | — | — | — |
-| Qwen 3.5 / 3.6 | 5.22 GB/s | 51.6 MB/s | — | 101× | — |
-| Nemotron 3 | 5.20 GB/s | 79.0 MB/s | — | 66× | — |
-| GLM 5 | 5.05 GB/s | 79.5 MB/s | — | 63× | — |
-| GLM 4 | 5.04 GB/s | 79.5 MB/s | — | 63× | — |
-| Llama 4 | 5.03 GB/s | 78.2 MB/s | — | 64× | — |
-| DeepSeek V3 / R1 / V4 | 4.21 GB/s | 51.6 MB/s | — | 82× | — |
-| ModernBERT | 2.84 GB/s | 52.1 MB/s | — | 54× | — |
-| Mistral 7B v0.3 | 1.47 GB/s | 91.6 MB/s | — | 16× | — |
-| Gemma 4 | 1.45 GB/s | 78.8 MB/s | — | 18× | — |
-| CodeLlama | 1.38 GB/s | 85.2 MB/s | — | 16× | — |
-| TinyLlama / Phi-3 (Llama 2) | 1.37 GB/s | 84.9 MB/s | — | 16× | — |
-| Gemma 1 | 1.14 GB/s | 84.9 MB/s | — | 13× | — |
-| Gemma 3 | 1.12 GB/s | 83.0 MB/s | — | 13× | — |
-
-The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
-and Mistral vocabs), which remain more expensive to encode than byte-level
-BPE even with gigatoken's
-internal SP parallelism; ModernBERT is byte-level BPE with a heavier
-pretokenizer than the GPT-2 family.
-
-Per-row model coverage is listed under the first table.
-
-</details>
-<details>
-<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD EPYC 9565 72-Core Processor (288 cores)</b></summary>
-
-Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
-Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
-HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
-This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
-Tiktoken rows are currently only filled in for tokenizers with official support.
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD EPYC 9565 72-Core Processor x 2 sockets (144 cores)</b></summary>
 
 | Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
 |---|---:|---:|---:|---:|---:|
@@ -263,13 +153,98 @@ Tiktoken rows are currently only filled in for tokenizers with official support.
 | Gemma 3 | 3.43 GB/s | 357.2 MB/s | — | 9.6× | — |
 | Gemma 1 | 2.51 GB/s | 342.2 MB/s | — | 7.3× | — |
 
+</details>
+<details>
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — Apple M4 Max (16 cores)</b></summary>
+
+| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
+|---|---:|---:|---:|---:|---:|
+| GPT-2 | 8.79 GB/s | 6.9 MB/s | 62.8 MB/s | 1,268× | 140× |
+| Nemotron 3 | 7.82 GB/s | 10.9 MB/s | — | 715× | — |
+| Phi-4 | 7.76 GB/s | 7.7 MB/s | — | 1,012× | — |
+| Llama 3 / 3.1 / 3.2 | 7.60 GB/s | 11.2 MB/s | — | 676× | — |
+| OLMo 2 / 3 | 7.56 GB/s | 5.8 MB/s | — | 1,299× | — |
+| Llama 3.3 | 7.50 GB/s | 15.7 MB/s | — | 479× | — |
+| Phi-4-mini | 6.97 GB/s | 7.2 MB/s | — | 964× | — |
+| Kimi K2 | 6.88 GB/s | — | — | — | — |
+| Llama 4 | 6.81 GB/s | 11.6 MB/s | — | 590× | — |
+| Qwen 2 / 2.5 | 6.37 GB/s | 5.8 MB/s | — | 1,105× | — |
+| Qwen 3 | 6.36 GB/s | 6.9 MB/s | — | 918× | — |
+| Qwen 3.5 / 3.6 | 6.31 GB/s | 6.3 MB/s | — | 994× | — |
+| GPT-OSS | 6.20 GB/s | 20.2 MB/s | 87.2 MB/s | 306× | 71× |
+| GLM 4 | 6.17 GB/s | 15.8 MB/s | — | 392× | — |
+| DeepSeek V3 / R1 / V4 | 5.68 GB/s | 7.2 MB/s | — | 788× | — |
+| GLM 5 | 5.55 GB/s | 12.2 MB/s | — | 456× | — |
+| ModernBERT | 2.64 GB/s | 5.8 MB/s | — | 452× | — |
+| Mistral 7B v0.3 | 1.99 GB/s | 95.1 MB/s | — | 21× | — |
+| Gemma 4 | 1.82 GB/s | 85.2 MB/s | — | 21× | — |
+| CodeLlama | 1.73 GB/s | 80.2 MB/s | — | 22× | — |
+| TinyLlama / Phi-3 (Llama 2) | 1.69 GB/s | 80.1 MB/s | — | 21× | — |
+| Gemma 1 | 1.42 GB/s | 85.7 MB/s | — | 17× | — |
+| Gemma 3 | 1.38 GB/s | 82.2 MB/s | — | 17× | — |
+
+</details>
+<details>
+<summary><b>Encoding throughput on owt_train.txt (11.9 GB) — AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)</b></summary>
+
+| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |
+|---|---:|---:|---:|---:|---:|
+| GPT-2 | 6.27 GB/s | 59.0 MB/s | 92.1 MB/s | 106× | 68× |
+| Phi-4 | 6.09 GB/s | 55.4 MB/s | — | 110× | — |
+| OLMo 2 / 3 | 6.06 GB/s | 55.4 MB/s | — | 109× | — |
+| Phi-4-mini | 5.80 GB/s | 54.6 MB/s | — | 106× | — |
+| GPT-OSS | 5.68 GB/s | 79.6 MB/s | 112.7 MB/s | 71× | 50× |
+| Qwen 3 | 5.34 GB/s | 54.4 MB/s | — | 98× | — |
+| Qwen 2 / 2.5 | 5.30 GB/s | 51.7 MB/s | — | 103× | — |
+| Llama 3.3 | 5.26 GB/s | 79.9 MB/s | — | 66× | — |
+| Llama 3 / 3.1 / 3.2 | 5.24 GB/s | 79.5 MB/s | — | 66× | — |
+| Kimi K2 | 5.23 GB/s | — | — | — | — |
+| Qwen 3.5 / 3.6 | 5.22 GB/s | 51.6 MB/s | — | 101× | — |
+| Nemotron 3 | 5.20 GB/s | 79.0 MB/s | — | 66× | — |
+| GLM 5 | 5.05 GB/s | 79.5 MB/s | — | 63× | — |
+| GLM 4 | 5.04 GB/s | 79.5 MB/s | — | 63× | — |
+| Llama 4 | 5.03 GB/s | 78.2 MB/s | — | 64× | — |
+| DeepSeek V3 / R1 / V4 | 4.21 GB/s | 51.6 MB/s | — | 82× | — |
+| ModernBERT | 2.84 GB/s | 52.1 MB/s | — | 54× | — |
+| Mistral 7B v0.3 | 1.47 GB/s | 91.6 MB/s | — | 16× | — |
+| Gemma 4 | 1.45 GB/s | 78.8 MB/s | — | 18× | — |
+| CodeLlama | 1.38 GB/s | 85.2 MB/s | — | 16× | — |
+| TinyLlama / Phi-3 (Llama 2) | 1.37 GB/s | 84.9 MB/s | — | 16× | — |
+| Gemma 1 | 1.14 GB/s | 84.9 MB/s | — | 13× | — |
+| Gemma 3 | 1.12 GB/s | 83.0 MB/s | — | 13× | — |
+
+</details>
+<details>
+<summary><b>Benchmark details</b></summary>
+
+Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.
+Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.
+HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.
+This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.
+Tiktoken rows are currently only filled in for tokenizers with official support.
+
 The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,
 and Mistral vocabs), which remain more expensive to encode than byte-level
-BPE even with gigatoken's
-internal SP parallelism; ModernBERT is byte-level BPE with a heavier
-pretokenizer than the GPT-2 family.
+BPE even with gigatoken's internal SP parallelism; ModernBERT is byte-level
+BPE with a heavier pretokenizer than the GPT-2 family.
 
-Per-row model coverage is listed under the first table.
+Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured
+on a representative repo. Rows whose tokenizer is shared beyond their own name
+(verified by matching tokenizer definitions across the local HF model cache) cover:
+
+- **Llama 3 / 3.1 / 3.2** — Llama 3 / 3.1 / 3.2, DeepSeek-R1-Distill-Llama, Hermes 3, Saiga, and other Llama-3 finetunes
+- **Llama 3.3** — Llama 3.3, Llama-3.1-Nemotron-Nano-VL, SmolLM3, Kanana 1.5, jina-embeddings-v5, Ultravox
+- **Qwen 2 / 2.5** — Qwen 2 and 2.5 (incl. Coder and VL), Qwen3-Coder, Qwen3-VL, DeepSeek-R1 Qwen distills, MiMo V2.5, MiniCPM-o 2.6, InternVL3
+- **Qwen 3** — Qwen 3 (incl. Embedding and Reranker), Qwen2.5-Omni, Qwen3-VL-Embedding, MiMo V2.5 Pro, jina-reranker-m0, pplx-embed, MOSS-TTS, Zeta
+- **DeepSeek V3 / R1 / V4** — DeepSeek V3 / V3.1 / V3.2, R1, V4 Flash and Pro, DeepSeek-VL2
+- **GLM 4** — GLM 4.1V, 4.5, and 4.7
+- **GLM 5** — GLM 5 / 5.2 and GLM-4.7-Flash
+- **Nemotron 3** — Nemotron 3 Nano, Super, and Ultra
+- **Kimi K2** — Kimi K2 / K2.5 / K2.6 / K2.7, Kimi-Linear, Kimi-VL, Moonlight
+- **Phi-4-mini** — Phi-4-mini and Phi-4-multimodal
+- **TinyLlama / Phi-3 (Llama 2)** — TinyLlama, Phi-3-mini, Phi-3.5-mini and Phi-3.5-vision (the Llama 2 vocab)
+- **Gemma 3** — Gemma 3 (270M–27B) and EmbeddingGemma
+- **Gemma 4** — Gemma 4 (dense, MoE, and E-series) and DiffusionGemma
 
 </details>
 <!-- benchmarks:end -->

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -227,7 +227,7 @@ def fmt_ratio(giga: float | None, other: float | None) -> str:
     return f"{ratio:,.0f}×" if ratio >= 10 else f"{ratio:.1f}×"
 
 
-def render_table(cpu: str, dataset: str, tokenizers: dict) -> str | None:
+def render_table(cpu: str, dataset: str, tokenizers: dict, include_notes: bool = True) -> str | None:
     rows = []
     corpus_bytes = 0
     for repo, by_dataset in tokenizers.items():
@@ -250,11 +250,11 @@ def render_table(cpu: str, dataset: str, tokenizers: dict) -> str | None:
         "<details>",
         f"<summary><b>Encoding throughput on {dataset}{size} — {cpu}</b></summary>",
         "",
-        "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with",
-        "parallelism enabled. gigatoken encodes the whole file un-split; HuggingFace",
-        "`tokenizers` (`encode_batch_fast`) gets the first 100 MB and tiktoken",
-        "(`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
-        "tiktoken rows exist only for tokenizers with official support.",
+        "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.",
+        "Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.",
+        "HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
+        "This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.",
+        "Tiktoken rows are currently only filled in for tokenizers with official support.",
         "",
         "| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |",
         "|---|---:|---:|---:|---:|---:|",
@@ -272,7 +272,9 @@ def render_table(cpu: str, dataset: str, tokenizers: dict) -> str | None:
         "internal SP parallelism; ModernBERT is byte-level BPE with a heavier",
         "pretokenizer than the GPT-2 family.",
     ]
-    if coverage_notes:
+    if not include_notes:
+        lines += ["", "Per-row model coverage is listed under the first table."]
+    elif coverage_notes:
         lines += [
             "",
             "Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured",
@@ -289,11 +291,20 @@ def cmd_render(args) -> None:
     if not results:
         raise SystemExit(f"{args.results}: no results to render")
 
+    def peak_gigatoken(tokenizers: dict) -> float:
+        speeds = [
+            group.get("gigatoken", {}).get("mb_per_s") or 0
+            for by_dataset in tokenizers.values()
+            for group in by_dataset.values()
+        ]
+        return max(speeds, default=0)
+
     tables = []
-    for cpu, tokenizers in results.items():
+    # Fastest machine first (results.json is sorted alphabetically by CPU name).
+    for cpu, tokenizers in sorted(results.items(), key=lambda kv: -peak_gigatoken(kv[1])):
         datasets = sorted({ds for by_dataset in tokenizers.values() for ds in by_dataset})
         for dataset in datasets:
-            table = render_table(cpu, dataset, tokenizers)
+            table = render_table(cpu, dataset, tokenizers, include_notes=not tables)
             if table is not None:
                 tables.append(table)
     block = "\n".join([START, "## Benchmarks", ""] + tables + [END])

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -212,6 +212,15 @@ COVERS = {
 }
 
 
+# README table order (results.json sorts CPU keys alphabetically); new
+# machines go underneath the existing tables. Unlisted CPUs sort last.
+CPU_ORDER = [
+    "Apple M4 Max (16 cores)",
+    "AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)",
+    "AMD EPYC 9565 72-Core Processor (288 cores)",
+]
+
+
 def fmt_speed(mb_per_s: float | None) -> str:
     if mb_per_s is None:
         return "—"
@@ -267,8 +276,9 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, include_notes: bool =
         )
     lines += [
         "",
-        "The slowest rows are the SentencePiece-based tokenizers (Mistral 7B and below),",
-        "which remain more expensive to encode than byte-level BPE even with gigatoken's",
+        "The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,",
+        "and Mistral vocabs), which remain more expensive to encode than byte-level",
+        "BPE even with gigatoken's",
         "internal SP parallelism; ModernBERT is byte-level BPE with a heavier",
         "pretokenizer than the GPT-2 family.",
     ]
@@ -291,17 +301,11 @@ def cmd_render(args) -> None:
     if not results:
         raise SystemExit(f"{args.results}: no results to render")
 
-    def peak_gigatoken(tokenizers: dict) -> float:
-        speeds = [
-            group.get("gigatoken", {}).get("mb_per_s") or 0
-            for by_dataset in tokenizers.values()
-            for group in by_dataset.values()
-        ]
-        return max(speeds, default=0)
+    def cpu_rank(cpu: str) -> tuple[int, str]:
+        return (CPU_ORDER.index(cpu) if cpu in CPU_ORDER else len(CPU_ORDER), cpu)
 
     tables = []
-    # Fastest machine first (results.json is sorted alphabetically by CPU name).
-    for cpu, tokenizers in sorted(results.items(), key=lambda kv: -peak_gigatoken(kv[1])):
+    for cpu, tokenizers in sorted(results.items(), key=lambda kv: cpu_rank(kv[0])):
         datasets = sorted({ds for by_dataset in tokenizers.values() for ds in by_dataset})
         for dataset in datasets:
             table = render_table(cpu, dataset, tokenizers, include_notes=not tables)

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -212,13 +212,19 @@ COVERS = {
 }
 
 
-# README table order (results.json sorts CPU keys alphabetically); new
-# machines go underneath the existing tables. Unlisted CPUs sort last.
+# README table order (results.json sorts CPU keys alphabetically); unlisted
+# CPUs sort last.
 CPU_ORDER = [
+    "AMD EPYC 9565 72-Core Processor (288 cores)",
     "Apple M4 Max (16 cores)",
     "AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)",
-    "AMD EPYC 9565 72-Core Processor (288 cores)",
 ]
+
+# Hand-curated table headings where the raw cpu_label() is misleading (the
+# EPYC's 288 comes from os.cpu_count() counting SMT threads over two sockets).
+CPU_DISPLAY = {
+    "AMD EPYC 9565 72-Core Processor (288 cores)": "AMD EPYC 9565 72-Core Processor x 2 sockets (144 cores)",
+}
 
 
 def fmt_speed(mb_per_s: float | None) -> str:
@@ -236,7 +242,7 @@ def fmt_ratio(giga: float | None, other: float | None) -> str:
     return f"{ratio:,.0f}×" if ratio >= 10 else f"{ratio:.1f}×"
 
 
-def render_table(cpu: str, dataset: str, tokenizers: dict, include_notes: bool = True) -> str | None:
+def render_table(cpu: str, dataset: str, tokenizers: dict) -> str | None:
     rows = []
     corpus_bytes = 0
     for repo, by_dataset in tokenizers.items():
@@ -250,20 +256,10 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, include_notes: bool =
         return None
     rows.sort(key=lambda row: row[1].get("gigatoken") or 0, reverse=True)
 
-    coverage_notes = [
-        f"- **{DISPLAY.get(repo, repo)}** — {COVERS[repo]}" for repo, _ in rows if repo in COVERS
-    ]
-
     size = f" ({corpus_bytes / 1e9:.1f} GB)" if corpus_bytes else ""
     lines = [
         "<details>",
-        f"<summary><b>Encoding throughput on {dataset}{size} — {cpu}</b></summary>",
-        "",
-        "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.",
-        "Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.",
-        "HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
-        "This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.",
-        "Tiktoken rows are currently only filled in for tokenizers with official support.",
+        f"<summary><b>Encoding throughput on {dataset}{size} — {CPU_DISPLAY.get(cpu, cpu)}</b></summary>",
         "",
         "| Tokenizer | gigatoken | HF tokenizers | tiktoken | vs HF | vs tiktoken |",
         "|---|---:|---:|---:|---:|---:|",
@@ -274,17 +270,29 @@ def render_table(cpu: str, dataset: str, tokenizers: dict, include_notes: bool =
             f"| {DISPLAY.get(repo, repo)} | {fmt_speed(giga)} | {fmt_speed(hf)} | {fmt_speed(tik)} "
             f"| {fmt_ratio(giga, hf)} | {fmt_ratio(giga, tik)} |"
         )
-    lines += [
+    lines += ["", "</details>"]
+    return "\n".join(lines)
+
+
+def render_notes(repos: set[str]) -> str:
+    """The shared methodology/coverage spoiler placed beneath the tables."""
+    coverage_notes = [f"- **{DISPLAY.get(repo, repo)}** — {COVERS[repo]}" for repo in COVERS if repo in repos]
+    lines = [
+        "<details>",
+        "<summary><b>Benchmark details</b></summary>",
+        "",
+        "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.",
+        "Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.",
+        "HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
+        "This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.",
+        "Tiktoken rows are currently only filled in for tokenizers with official support.",
         "",
         "The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,",
         "and Mistral vocabs), which remain more expensive to encode than byte-level",
-        "BPE even with gigatoken's",
-        "internal SP parallelism; ModernBERT is byte-level BPE with a heavier",
-        "pretokenizer than the GPT-2 family.",
+        "BPE even with gigatoken's internal SP parallelism; ModernBERT is byte-level",
+        "BPE with a heavier pretokenizer than the GPT-2 family.",
     ]
-    if not include_notes:
-        lines += ["", "Per-row model coverage is listed under the first table."]
-    elif coverage_notes:
+    if coverage_notes:
         lines += [
             "",
             "Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured",
@@ -308,10 +316,16 @@ def cmd_render(args) -> None:
     for cpu, tokenizers in sorted(results.items(), key=lambda kv: cpu_rank(kv[0])):
         datasets = sorted({ds for by_dataset in tokenizers.values() for ds in by_dataset})
         for dataset in datasets:
-            table = render_table(cpu, dataset, tokenizers, include_notes=not tables)
+            table = render_table(cpu, dataset, tokenizers)
             if table is not None:
                 tables.append(table)
-    block = "\n".join([START, "## Benchmarks", ""] + tables + [END])
+    tabled_repos = {
+        repo
+        for tokenizers in results.values()
+        for repo, by_dataset in tokenizers.items()
+        if any("gigatoken" in group for group in by_dataset.values())
+    }
+    block = "\n".join([START, "## Benchmarks", ""] + tables + [render_notes(tabled_repos), END])
 
     with open(args.readme) as f:
         readme = f.read()

--- a/benchmarks/compare/results.py
+++ b/benchmarks/compare/results.py
@@ -284,20 +284,17 @@ def render_notes(repos: set[str]) -> str:
         "Best of 3 interleaved rounds, one fresh process per measurement, all libraries with parallelism enabled.",
         "Gigatoken encodes the whole file un-split, and is thus doing more work than the other tokenizers to find the split boundaries and automatically parallelize.",
         "HuggingFace tokenizers (`encode_batch_fast`) gets the first 100 MB and tiktoken (`encode_ordinary_batch`) the first 1 GB, both presplit on `<|endoftext|>`.",
-        "This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout.",
+        "This is fair because neither of the compared tokenizers do caching, meaning the speed is roughly uniform throughout processing.",
         "Tiktoken rows are currently only filled in for tokenizers with official support.",
         "",
-        "The slowest rows are the SentencePiece-based tokenizers (the Gemma, Llama 2,",
-        "and Mistral vocabs), which remain more expensive to encode than byte-level",
-        "BPE even with gigatoken's internal SP parallelism; ModernBERT is byte-level",
-        "BPE with a heavier pretokenizer than the GPT-2 family.",
+        "The slowest rows are the SentencePiece-based tokenizers, which are only somewhat optimized in Gigatoken.",
     ]
     if coverage_notes:
         lines += [
             "",
-            "Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured",
-            "on a representative repo. Rows whose tokenizer is shared beyond their own name",
-            "(verified by matching tokenizer definitions across the local HF model cache) cover:",
+            "Each row is one distinct tokenizer (identical vocab/merges/pretokenizer), measured on a representative repo.",
+            "If you don't see your tokenizer here, it's likely based on some existing one.",
+            "For instance:",
             "",
         ] + coverage_notes
     lines += ["", "</details>"]

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,4 +1,724 @@
 {
+  "AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)": {
+    "Qwen/Qwen2-1.5B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5298.39,
+          "mtokens_per_s": 1160.869,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 2.2498,
+          "timestamp": "2026-07-21T09:21:17",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 51.68,
+          "mtokens_per_s": 11.299,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 1.9348,
+          "timestamp": "2026-07-21T09:21:22",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5343.12,
+          "mtokens_per_s": 1170.67,
+          "time_s": 2.231,
+          "timestamp": "2026-07-21T09:21:26",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 54.42,
+          "mtokens_per_s": 11.897,
+          "time_s": 1.8377,
+          "timestamp": "2026-07-21T09:21:31",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3.5-9B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5222.26,
+          "mtokens_per_s": 1156.964,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 2.2826,
+          "timestamp": "2026-07-21T09:22:04",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 2640927277
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 51.57,
+          "mtokens_per_s": 11.393,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 1.9391,
+          "timestamp": "2026-07-21T09:22:08",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 22092233
+        }
+      }
+    },
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1367.2,
+          "mtokens_per_s": 353.483,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 8.7189,
+          "timestamp": "2026-07-21T09:27:13",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 3081985364
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 84.94,
+          "mtokens_per_s": 21.852,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 1.1773,
+          "timestamp": "2026-07-21T09:27:17",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 25725923
+        }
+      }
+    },
+    "allenai/Olmo-3-1025-7B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6055.51,
+          "mtokens_per_s": 1298.743,
+          "time_s": 1.9685,
+          "timestamp": "2026-07-21T09:25:18",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 55.38,
+          "mtokens_per_s": 11.862,
+          "time_s": 1.8056,
+          "timestamp": "2026-07-21T09:25:23",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 21417051
+        }
+      }
+    },
+    "answerdotai/ModernBERT-base": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 2837.9,
+          "mtokens_per_s": 642.7,
+          "time_s": 4.2005,
+          "timestamp": "2026-07-21T09:19:29",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 2699642019
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 52.14,
+          "mtokens_per_s": 11.823,
+          "time_s": 1.9181,
+          "timestamp": "2026-07-21T09:19:34",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 22677527
+        }
+      }
+    },
+    "codellama/CodeLlama-7b-hf": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1378.65,
+          "mtokens_per_s": 356.443,
+          "time_s": 8.6465,
+          "timestamp": "2026-07-21T09:28:13",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 3081984489
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 85.18,
+          "mtokens_per_s": 21.913,
+          "time_s": 1.174,
+          "timestamp": "2026-07-21T09:28:18",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 25725750
+        }
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 4214.46,
+          "mtokens_per_s": 918.371,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 2.8285,
+          "timestamp": "2026-07-21T09:22:33",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 2597590340
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 51.64,
+          "mtokens_per_s": 11.181,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 1.9364,
+          "timestamp": "2026-07-21T09:22:38",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 21650989
+        }
+      }
+    },
+    "google/gemma-3-4b-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1117.53,
+          "mtokens_per_s": 249.216,
+          "time_s": 10.6668,
+          "timestamp": "2026-07-21T09:30:57",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 2658340885
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 83.01,
+          "mtokens_per_s": 18.411,
+          "time_s": 1.2046,
+          "timestamp": "2026-07-21T09:31:01",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 22178584
+        }
+      }
+    },
+    "google/gemma-4-E4B-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1452.89,
+          "mtokens_per_s": 324.013,
+          "time_s": 8.2047,
+          "timestamp": "2026-07-21T09:31:12",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 2658430536
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 78.84,
+          "mtokens_per_s": 17.47,
+          "time_s": 1.2684,
+          "timestamp": "2026-07-21T09:31:16",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 22158714
+        }
+      }
+    },
+    "meta-llama/Llama-3.1-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5239.22,
+          "mtokens_per_s": 1128.303,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 2.2752,
+          "timestamp": "2026-07-21T09:19:38",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.5,
+          "mtokens_per_s": 17.019,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 1.2578,
+          "timestamp": "2026-07-21T09:19:42",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5256.67,
+          "mtokens_per_s": 1132.059,
+          "time_s": 2.2677,
+          "timestamp": "2026-07-21T09:20:22",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.88,
+          "mtokens_per_s": 17.1,
+          "time_s": 1.2518,
+          "timestamp": "2026-07-21T09:20:26",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5034.56,
+          "mtokens_per_s": 1084.86,
+          "time_s": 2.3677,
+          "timestamp": "2026-07-21T09:20:31",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 2568660194
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 78.24,
+          "mtokens_per_s": 16.77,
+          "time_s": 1.2781,
+          "timestamp": "2026-07-21T09:20:35",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 21434680
+        }
+      }
+    },
+    "microsoft/Phi-4-mini-instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5800.69,
+          "mtokens_per_s": 1234.379,
+          "time_s": 2.055,
+          "timestamp": "2026-07-21T09:26:58",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 54.59,
+          "mtokens_per_s": 11.592,
+          "time_s": 1.8317,
+          "timestamp": "2026-07-21T09:27:02",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 21234009
+        }
+      }
+    },
+    "microsoft/phi-4": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6087.41,
+          "mtokens_per_s": 1305.585,
+          "time_s": 1.9582,
+          "timestamp": "2026-07-21T09:26:13",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 55.36,
+          "mtokens_per_s": 11.857,
+          "time_s": 1.8063,
+          "timestamp": "2026-07-21T09:26:17",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 21417051
+        }
+      }
+    },
+    "mistralai/Mistral-7B-Instruct-v0.3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1474.64,
+          "mtokens_per_s": 368.52,
+          "time_s": 8.0837,
+          "timestamp": "2026-07-21T09:28:57",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 2978987937
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 91.62,
+          "mtokens_per_s": 22.782,
+          "time_s": 1.0914,
+          "timestamp": "2026-07-21T09:29:01",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 24864785
+        }
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5228.65,
+          "mtokens_per_s": 1132.903,
+          "shared_with": [
+            "moonshotai/Kimi-K2.5"
+          ],
+          "time_s": 2.2798,
+          "timestamp": "2026-07-21T09:25:50",
+          "tokenizer": "moonshotai/Kimi-K2-Instruct",
+          "tokens": 2582841844
+        }
+      }
+    },
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5204.03,
+          "mtokens_per_s": 1165.582,
+          "time_s": 2.2906,
+          "timestamp": "2026-07-21T09:24:52",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 2669917451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.0,
+          "mtokens_per_s": 17.561,
+          "time_s": 1.2658,
+          "timestamp": "2026-07-21T09:24:56",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 22229104
+        }
+      }
+    },
+    "openai-community/gpt2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 6268.43,
+          "mtokens_per_s": 1421.93,
+          "time_s": 1.9017,
+          "timestamp": "2026-07-21T09:18:41",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 2704046552
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 59.03,
+          "mtokens_per_s": 13.402,
+          "time_s": 1.694,
+          "timestamp": "2026-07-21T09:18:45",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 22703001
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "gpt2",
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 92.07,
+          "mtokens_per_s": 20.883,
+          "time_s": 10.8615,
+          "timestamp": "2026-07-21T09:19:00",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 226815823
+        }
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5683.68,
+          "mtokens_per_s": 1209.479,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 2.0973,
+          "timestamp": "2026-07-21T09:24:09",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.57,
+          "mtokens_per_s": 16.897,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 1.2567,
+          "timestamp": "2026-07-21T09:24:13",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 21234009
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "o200k_harmony",
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 112.68,
+          "mtokens_per_s": 23.969,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 8.8747,
+          "timestamp": "2026-07-21T09:24:26",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 212718509
+        }
+      }
+    },
+    "tencent/Hy3": {
+      "owt_train.txt": {
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 55.55,
+          "mtokens_per_s": 12.156,
+          "time_s": 1.8002,
+          "timestamp": "2026-07-21T09:25:59",
+          "tokenizer": "tencent/Hy3",
+          "tokens": 21882884
+        }
+      }
+    },
+    "unsloth/gemma-2b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 1141.24,
+          "mtokens_per_s": 253.662,
+          "time_s": 10.4453,
+          "timestamp": "2026-07-21T09:30:03",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 2649565869
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 84.93,
+          "mtokens_per_s": 18.773,
+          "time_s": 1.1774,
+          "timestamp": "2026-07-21T09:30:07",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 22103965
+        }
+      }
+    },
+    "zai-org/GLM-4.7": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5040.8,
+          "mtokens_per_s": 1081.591,
+          "time_s": 2.3648,
+          "timestamp": "2026-07-21T09:22:52",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 2557750876
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.48,
+          "mtokens_per_s": 17.016,
+          "time_s": 1.2581,
+          "timestamp": "2026-07-21T09:22:57",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 21407946
+        }
+      }
+    },
+    "zai-org/GLM-5.2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 5048.9,
+          "mtokens_per_s": 1083.266,
+          "time_s": 2.361,
+          "timestamp": "2026-07-21T09:23:28",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 2557602611
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/home/marcel/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 79.55,
+          "mtokens_per_s": 17.028,
+          "time_s": 1.2571,
+          "timestamp": "2026-07-21T09:23:32",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 21407262
+        }
+      }
+    }
+  },
   "Apple M4 Max (16 cores)": {
     "Qwen/Qwen2-1.5B-Instruct": {
       "owt_train.txt": {

--- a/benchmarks/results.json
+++ b/benchmarks/results.json
@@ -1,4 +1,724 @@
 {
+  "AMD EPYC 9565 72-Core Processor (288 cores)": {
+    "Qwen/Qwen2-1.5B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 19121.88,
+          "mtokens_per_s": 4189.574,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 0.6234,
+          "timestamp": "2026-07-21T09:49:53",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 27.68,
+          "mtokens_per_s": 6.052,
+          "shared_with": [
+            "Qwen/Qwen2.5-7B-Instruct"
+          ],
+          "time_s": 3.6124,
+          "timestamp": "2026-07-21T09:50:01",
+          "tokenizer": "Qwen/Qwen2-1.5B-Instruct",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 22164.36,
+          "mtokens_per_s": 4856.176,
+          "time_s": 0.5378,
+          "timestamp": "2026-07-21T09:50:27",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 2611765417
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 34.19,
+          "mtokens_per_s": 7.475,
+          "time_s": 2.9248,
+          "timestamp": "2026-07-21T09:50:34",
+          "tokenizer": "Qwen/Qwen3-8B",
+          "tokens": 21862732
+        }
+      }
+    },
+    "Qwen/Qwen3.5-9B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 15489.91,
+          "mtokens_per_s": 3431.708,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 0.7696,
+          "timestamp": "2026-07-21T09:51:01",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 2640927277
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 27.74,
+          "mtokens_per_s": 6.129,
+          "shared_with": [
+            "Qwen/Qwen3.6-27B"
+          ],
+          "time_s": 3.6044,
+          "timestamp": "2026-07-21T09:51:08",
+          "tokenizer": "Qwen/Qwen3.5-9B",
+          "tokens": 22092233
+        }
+      }
+    },
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 3477.13,
+          "mtokens_per_s": 898.993,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 3.4283,
+          "timestamp": "2026-07-21T09:57:39",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 3081985364
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 323.56,
+          "mtokens_per_s": 83.238,
+          "shared_with": [
+            "microsoft/Phi-3-mini-4k-instruct"
+          ],
+          "time_s": 0.3091,
+          "timestamp": "2026-07-21T09:57:43",
+          "tokenizer": "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+          "tokens": 25725923
+        }
+      }
+    },
+    "allenai/Olmo-3-1025-7B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 23058.81,
+          "mtokens_per_s": 4945.493,
+          "time_s": 0.517,
+          "timestamp": "2026-07-21T09:55:45",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 27.69,
+          "mtokens_per_s": 5.931,
+          "time_s": 3.6112,
+          "timestamp": "2026-07-21T09:55:52",
+          "tokenizer": "allenai/Olmo-3-1025-7B",
+          "tokens": 21417051
+        }
+      }
+    },
+    "answerdotai/ModernBERT-base": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 4181.14,
+          "mtokens_per_s": 946.903,
+          "time_s": 2.851,
+          "timestamp": "2026-07-21T09:47:47",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 2699642019
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 26.94,
+          "mtokens_per_s": 6.11,
+          "time_s": 3.7114,
+          "timestamp": "2026-07-21T09:47:55",
+          "tokenizer": "answerdotai/ModernBERT-base",
+          "tokens": 22677527
+        }
+      }
+    },
+    "codellama/CodeLlama-7b-hf": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 3465.27,
+          "mtokens_per_s": 895.927,
+          "time_s": 3.44,
+          "timestamp": "2026-07-21T09:58:13",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 3081984489
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 347.43,
+          "mtokens_per_s": 89.378,
+          "time_s": 0.2878,
+          "timestamp": "2026-07-21T09:58:18",
+          "tokenizer": "codellama/CodeLlama-7b-hf",
+          "tokens": 25725750
+        }
+      }
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 19687.82,
+          "mtokens_per_s": 4290.159,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 0.6055,
+          "timestamp": "2026-07-21T09:51:47",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 2597590340
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 26.25,
+          "mtokens_per_s": 5.684,
+          "shared_with": [
+            "deepseek-ai/DeepSeek-R1",
+            "deepseek-ai/DeepSeek-V4-Flash"
+          ],
+          "time_s": 3.8092,
+          "timestamp": "2026-07-21T09:51:55",
+          "tokenizer": "deepseek-ai/DeepSeek-V3",
+          "tokens": 21650989
+        }
+      }
+    },
+    "google/gemma-3-4b-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 3428.09,
+          "mtokens_per_s": 764.484,
+          "time_s": 3.4773,
+          "timestamp": "2026-07-21T10:00:14",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 2658340885
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 357.24,
+          "mtokens_per_s": 79.23,
+          "time_s": 0.2799,
+          "timestamp": "2026-07-21T10:00:19",
+          "tokenizer": "google/gemma-3-4b-it",
+          "tokens": 22178584
+        }
+      }
+    },
+    "google/gemma-4-E4B-it": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 4817.58,
+          "mtokens_per_s": 1074.383,
+          "time_s": 2.4744,
+          "timestamp": "2026-07-21T10:00:48",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 2658430536
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 334.13,
+          "mtokens_per_s": 74.039,
+          "time_s": 0.2993,
+          "timestamp": "2026-07-21T10:00:53",
+          "tokenizer": "google/gemma-4-E4B-it",
+          "tokens": 22158714
+        }
+      }
+    },
+    "meta-llama/Llama-3.1-8B": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 22146.88,
+          "mtokens_per_s": 4769.483,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 0.5382,
+          "timestamp": "2026-07-21T09:48:33",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 48.5,
+          "mtokens_per_s": 10.383,
+          "shared_with": [
+            "meta-llama/Llama-3.2-1B"
+          ],
+          "time_s": 2.0618,
+          "timestamp": "2026-07-21T09:48:39",
+          "tokenizer": "meta-llama/Llama-3.1-8B",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-3.3-70B-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 20823.16,
+          "mtokens_per_s": 4484.41,
+          "time_s": 0.5725,
+          "timestamp": "2026-07-21T09:48:43",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 2567163722
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 48.32,
+          "mtokens_per_s": 10.343,
+          "time_s": 2.0696,
+          "timestamp": "2026-07-21T09:48:49",
+          "tokenizer": "meta-llama/Llama-3.3-70B-Instruct",
+          "tokens": 21406611
+        }
+      }
+    },
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 20771.2,
+          "mtokens_per_s": 4475.828,
+          "time_s": 0.5739,
+          "timestamp": "2026-07-21T09:49:23",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 2568660194
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 72.74,
+          "mtokens_per_s": 15.591,
+          "time_s": 1.3748,
+          "timestamp": "2026-07-21T09:49:28",
+          "tokenizer": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+          "tokens": 21434680
+        }
+      }
+    },
+    "microsoft/Phi-4-mini-instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 20047.59,
+          "mtokens_per_s": 4266.1,
+          "time_s": 0.5946,
+          "timestamp": "2026-07-21T09:57:02",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 27.6,
+          "mtokens_per_s": 5.861,
+          "time_s": 3.6228,
+          "timestamp": "2026-07-21T09:57:09",
+          "tokenizer": "microsoft/Phi-4-mini-instruct",
+          "tokens": 21234009
+        }
+      }
+    },
+    "microsoft/phi-4": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 23995.38,
+          "mtokens_per_s": 5146.363,
+          "time_s": 0.4968,
+          "timestamp": "2026-07-21T09:56:51",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 2556628451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 29.95,
+          "mtokens_per_s": 6.414,
+          "time_s": 3.3392,
+          "timestamp": "2026-07-21T09:56:58",
+          "tokenizer": "microsoft/phi-4",
+          "tokens": 21417051
+        }
+      }
+    },
+    "mistralai/Mistral-7B-Instruct-v0.3": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 3574.9,
+          "mtokens_per_s": 893.383,
+          "time_s": 3.3345,
+          "timestamp": "2026-07-21T09:59:09",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 2978987937
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 354.73,
+          "mtokens_per_s": 88.202,
+          "time_s": 0.2819,
+          "timestamp": "2026-07-21T09:59:14",
+          "tokenizer": "mistralai/Mistral-7B-Instruct-v0.3",
+          "tokens": 24864785
+        }
+      }
+    },
+    "moonshotai/Kimi-K2-Instruct": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 18852.03,
+          "mtokens_per_s": 4084.709,
+          "shared_with": [
+            "moonshotai/Kimi-K2.5"
+          ],
+          "time_s": 0.6323,
+          "timestamp": "2026-07-21T09:56:00",
+          "tokenizer": "moonshotai/Kimi-K2-Instruct",
+          "tokens": 2582841844
+        }
+      }
+    },
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 22789.42,
+          "mtokens_per_s": 5104.3,
+          "time_s": 0.5231,
+          "timestamp": "2026-07-21T09:55:13",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 2669917451
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 49.35,
+          "mtokens_per_s": 10.969,
+          "time_s": 2.0265,
+          "timestamp": "2026-07-21T09:55:19",
+          "tokenizer": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+          "tokens": 22229104
+        }
+      }
+    },
+    "openai-community/gpt2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 24532.45,
+          "mtokens_per_s": 5564.937,
+          "time_s": 0.4859,
+          "timestamp": "2026-07-21T09:46:46",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 2704046552
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 24.8,
+          "mtokens_per_s": 5.63,
+          "time_s": 4.0329,
+          "timestamp": "2026-07-21T09:46:54",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 22703001
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "gpt2",
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 36.05,
+          "mtokens_per_s": 8.177,
+          "time_s": 27.7382,
+          "timestamp": "2026-07-21T09:47:27",
+          "tokenizer": "openai-community/gpt2",
+          "tokens": 226815823
+        }
+      }
+    },
+    "openai/gpt-oss-20b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 23961.57,
+          "mtokens_per_s": 5098.989,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 0.4975,
+          "timestamp": "2026-07-21T09:54:15",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 2536668014
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 49.67,
+          "mtokens_per_s": 10.547,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 2.0132,
+          "timestamp": "2026-07-21T09:54:21",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 21234009
+        },
+        "tiktoken": {
+          "bytes": 1000000000,
+          "docs": 200541,
+          "encoding": "o200k_harmony",
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 1000.0,
+          "mb_per_s": 42.81,
+          "mtokens_per_s": 9.106,
+          "shared_with": [
+            "openai/gpt-oss-120b"
+          ],
+          "time_s": 23.3615,
+          "timestamp": "2026-07-21T09:54:49",
+          "tokenizer": "openai/gpt-oss-20b",
+          "tokens": 212718509
+        }
+      }
+    },
+    "tencent/Hy3": {
+      "owt_train.txt": {
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 34.99,
+          "mtokens_per_s": 7.658,
+          "time_s": 2.8577,
+          "timestamp": "2026-07-21T09:56:11",
+          "tokenizer": "tencent/Hy3",
+          "tokens": 21882884
+        }
+      }
+    },
+    "unsloth/gemma-2b": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 2506.42,
+          "mtokens_per_s": 557.101,
+          "time_s": 4.756,
+          "timestamp": "2026-07-21T09:59:23",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 2649565869
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 342.17,
+          "mtokens_per_s": 75.632,
+          "time_s": 0.2923,
+          "timestamp": "2026-07-21T09:59:28",
+          "tokenizer": "unsloth/gemma-2b",
+          "tokens": 22103965
+        }
+      }
+    },
+    "zai-org/GLM-4.7": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 20605.73,
+          "mtokens_per_s": 4421.315,
+          "time_s": 0.5785,
+          "timestamp": "2026-07-21T09:52:17",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 2557750876
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 72.27,
+          "mtokens_per_s": 15.472,
+          "time_s": 1.3837,
+          "timestamp": "2026-07-21T09:52:22",
+          "tokenizer": "zai-org/GLM-4.7",
+          "tokens": 21407946
+        }
+      }
+    },
+    "zai-org/GLM-5.2": {
+      "owt_train.txt": {
+        "gigatoken": {
+          "bytes": 11920511059,
+          "docs": 1,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": null,
+          "mb_per_s": 20973.55,
+          "mtokens_per_s": 4499.975,
+          "time_s": 0.5684,
+          "timestamp": "2026-07-21T09:52:35",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 2557602611
+        },
+        "hf": {
+          "bytes": 100000000,
+          "docs": 20342,
+          "file": "/lfs/local/0/roed/data/owt_train.txt",
+          "max_mb": 100.0,
+          "mb_per_s": 74.78,
+          "mtokens_per_s": 16.009,
+          "time_s": 1.3372,
+          "timestamp": "2026-07-21T09:52:41",
+          "tokenizer": "zai-org/GLM-5.2",
+          "tokens": 21407262
+        }
+      }
+    }
+  },
   "AMD Ryzen 7 9800X3D 8-Core Processor (16 cores)": {
     "Qwen/Qwen2-1.5B-Instruct": {
       "owt_train.txt": {


### PR DESCRIPTION
Runs the same `benchmarks/compare/` sweep (24 tokenizers, 3 interleaved rounds, whole-file gigatoken) on two Linux machines and adds their results as collapsible tables under the M4 Max one:

- **AMD Ryzen 7 9800X3D** (8c/16t, host `fred`): gigatoken 4.2–6.3 GB/s on BPE, 1.1–1.5 GB/s on SentencePiece. HF `tokenizers` is ~8× faster on Linux than on macOS (GPT-2: 59 vs 6.9 MB/s), so ratios land at 13–110×.
- **Dual-socket AMD EPYC 9565** (288 threads, host `blackwell1`): gigatoken 15.5–24.5 GB/s on BPE (GPT-2 24.53 GB/s ≈ 5.6 Gtok/s) and 2.5–4.8 GB/s on SentencePiece; ratios up to ~990× vs HF and ~680× vs tiktoken (both scale poorly past a few dozen threads on this box).

`tencent/Hy3` still fails to load in gigatoken on both (byte-gap vocab, fix on the unmerged `byte-gap-vocab` branch) and stays out of the tables.

Renderer changes:
- Tables follow an explicit `CPU_ORDER` list (new machines appended underneath the existing tables); unlisted CPUs sort last.
- The per-row model-coverage footnotes are emitted only in the first table; later tables reference it instead of repeating all 13 bullets.
- The table intro matches the reworded prose from 28066b8, and the SentencePiece footnote names the vocab families instead of a row position (sort order differs per machine).