### PR TITLE
Fix `from_tiktoken` assuming pretokenizer implementation

### DIFF
--- a/gigatoken/_cli.py
+++ b/gigatoken/_cli.py
@@ -155,6 +155,8 @@ def _load_tokenizer(spec: str, pretokenizer: str | None = None) -> Tokenizer:
 
     if spec.endswith(".tiktoken"):
         return Tokenizer.from_tiktoken(spec, pretokenizer)
+    if pretokenizer is not None:
+        raise typer.BadParameter("--pretokenizer only applies to .tiktoken vocabulary files")
     if spec.endswith(".model"):
         return Tokenizer.from_sentencepiece(spec)
     return Tokenizer(spec)

--- a/gigatoken/_cli.py
+++ b/gigatoken/_cli.py
@@ -150,11 +150,11 @@ def _warn_if_memory_tight(total_bytes: int, comparing: bool, limit_bytes: int | 
         )
 
 
-def _load_tokenizer(spec: str) -> Tokenizer:
+def _load_tokenizer(spec: str, pretokenizer: str | None = None) -> Tokenizer:
     from gigatoken import Tokenizer
 
     if spec.endswith(".tiktoken"):
-        return Tokenizer.from_tiktoken(spec)
+        return Tokenizer.from_tiktoken(spec, pretokenizer)
     if spec.endswith(".model"):
         return Tokenizer.from_sentencepiece(spec)
     return Tokenizer(spec)
@@ -219,6 +219,7 @@ def bench(
     comparison_limit: str = typer.Option("100MB", help="cap the bytes fed to the comparison tokenizer, e.g. 100MB; 'none' compares on everything"),
     validate: bool = typer.Option(False, "--validate", help="check that HuggingFace token ids match gigatoken's on the comparison subset (implies --compare-to hf)"),
     doc_separator: Optional[str] = typer.Option(None, "--doc-separator", help='document separator to split the files on, e.g. "<|endoftext|>"; whole files are single documents otherwise'),
+    pretokenizer: Optional[str] = typer.Option(None, "--pretokenizer", help='pretokenization scheme of a .tiktoken vocabulary that is not one OpenAI publishes, e.g. "gpt2" or "cl100k"'),
 ) -> None:
     """Measure the time to encode FILES with TOKENIZER."""
     if validate and compare_to is None:
@@ -233,7 +234,7 @@ def bench(
 
     from gigatoken import BytesSource, TextFileSource
 
-    gt_tokenizer = _load_tokenizer(tokenizer)
+    gt_tokenizer = _load_tokenizer(tokenizer, pretokenizer)
 
     # gigatoken pass. A separator is handed to gigatoken along with the whole
     # files (documents are split inside Rust, during the encode itself) —

--- a/gigatoken/_load/hf.py
+++ b/gigatoken/_load/hf.py
@@ -150,7 +150,7 @@ def try_load_from_config(source: str | os.PathLike[str]) -> "tuple[object, dict[
     if not model.is_file():
         return None
     specials = {str(t["content"]): int(i) for i, t in (config_json.get("added_tokens_decoder") or {}).items()}
-    return BPETokenizer.from_tiktoken_model(model, config, line.pretokenizer), specials
+    return BPETokenizer.from_tiktoken(model, line.pretokenizer, specials), specials
 
 
 def to_tokenizer_json(source: TokenizerJsonSource) -> str | bytes:

--- a/gigatoken/_load/tiktoken.py
+++ b/gigatoken/_load/tiktoken.py
@@ -1,33 +1,37 @@
-# URL sources: https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py
+"""The .tiktoken vocabulary files OpenAI publishes, keyed by file name.
 
-from typing import TypedDict
+A .tiktoken file holds mergeable ranks and nothing else: the pretokenization
+scheme (split regex) and the special tokens of an encoding live in the code
+that defines it, not in the file. These are the definitions for the files
+served from openaipublic.blob.core.windows.net/encodings, transcribed from
+https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py.
+Any other rank file has to name its scheme at load time. (p50k_base is
+absent because its ranks are not dense — it leaves 50256 free for
+<|endoftext|> — which the rank loader rejects.)
+"""
 
-from tiktoken.load import load_tiktoken_bpe
+from typing import NamedTuple
 
 ENDOFTEXT = "<|endoftext|>"
+FIM_PREFIX = "<|fim_prefix|>"
+FIM_MIDDLE = "<|fim_middle|>"
+FIM_SUFFIX = "<|fim_suffix|>"
+ENDOFPROMPT = "<|endofprompt|>"
 
-r50k_pat_str = r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"""
 
+class TiktokenEncoding(NamedTuple):
+    """What a .tiktoken rank file does not carry: the name of the
+    pretokenization scheme, and the special tokens with their ids."""
 
-class EncodingParams(TypedDict):
-    """Constructor kwargs for tiktoken.Encoding."""
-
-    name: str
-    explicit_n_vocab: int
-    pat_str: str
-    mergeable_ranks: dict[bytes, int]
+    pretokenizer: str
     special_tokens: dict[str, int]
 
 
-def r50k_base() -> EncodingParams:
-    mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
-        expected_hash="306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930",
-    )
-    return {
-        "name": "r50k_base",
-        "explicit_n_vocab": 50257,
-        "pat_str": r50k_pat_str,
-        "mergeable_ranks": mergeable_ranks,
-        "special_tokens": {ENDOFTEXT: 50256},
-    }
+ENCODINGS: dict[str, TiktokenEncoding] = {
+    "r50k_base": TiktokenEncoding("gpt2", {ENDOFTEXT: 50256}),
+    "cl100k_base": TiktokenEncoding(
+        "gpt4",
+        {ENDOFTEXT: 100257, FIM_PREFIX: 100258, FIM_MIDDLE: 100259, FIM_SUFFIX: 100260, ENDOFPROMPT: 100276},
+    ),
+    "o200k_base": TiktokenEncoding("o200k", {ENDOFTEXT: 199999, ENDOFPROMPT: 200018}),
+}

--- a/gigatoken/_tokenizer.py
+++ b/gigatoken/_tokenizer.py
@@ -100,29 +100,30 @@ class Tokenizer:
 
         The file holds mergeable ranks only — an encoding's pretokenization
         scheme (split regex) and special tokens live in the code that defines
-        it — so both are taken from the file's name for the encodings OpenAI
-        publishes (r50k_base, cl100k_base, o200k_base). For any other rank
+        it — so for the encodings OpenAI publishes (r50k_base, cl100k_base,
+        o200k_base) both are taken from the file's name. For any other rank
         file, name the scheme: `pretokenizer` is one of "gpt2"/"r50k",
         "gpt4"/"cl100k", "o200k", "qwen2", "qwen35", "olmo3", "deepseek_v3",
         "nemotron" or "kimi", and `special_tokens` maps token content to id
-        (none by default). Nothing is guessed: an unrecognized file name with
-        no `pretokenizer` raises rather than silently mistokenizing.
+        (none by default). Passing `pretokenizer` skips the file-name lookup
+        entirely; nothing is ever guessed — an unrecognized file name with no
+        `pretokenizer` raises rather than silently mistokenizing.
         """
-        name = os.path.basename(os.fspath(path)).removesuffix(".tiktoken")
-        known = ENCODINGS.get(name) if pretokenizer is None else None
         if pretokenizer is None:
+            name = os.path.basename(os.fspath(path)).removesuffix(".tiktoken")
+            known = ENCODINGS.get(name)
             if known is None:
                 raise ValueError(
                     f"cannot tell which pretokenizer {name!r} needs: a .tiktoken file does not carry one, "
-                    f"and its name is not one of the encodings OpenAI publishes ({', '.join(ENCODINGS)}). "
+                    f"and its name is not an encoding gigatoken recognizes ({', '.join(ENCODINGS)}). "
                     'Pass pretokenizer=... (e.g. "gpt4" for a cl100k-style vocabulary), since the wrong '
                     "scheme silently mistokenizes everything."
                 )
             pretokenizer = known.pretokenizer
-        if special_tokens is None:
-            special_tokens = known.special_tokens if known is not None else {}
+            if special_tokens is None:
+                special_tokens = known.special_tokens
         tokenizer = cls(BPETokenizer.from_tiktoken(path, pretokenizer, special_tokens))
-        tokenizer._tiktoken_specials = dict(special_tokens)
+        tokenizer._tiktoken_specials = dict(special_tokens or {})
         return tokenizer
 
     @classmethod

--- a/gigatoken/_tokenizer.py
+++ b/gigatoken/_tokenizer.py
@@ -7,6 +7,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 from gigatoken._load.hf import capture_named_special_tokens, to_tokenizer_json, try_load_from_config
+from gigatoken._load.tiktoken import ENCODINGS
 from gigatoken._parallel import resolve_parallel
 from gigatoken.gigatoken_rs import BPETokenizer, PadTruncate, SentencePieceTokenizer, load_hf_json
 
@@ -24,8 +25,6 @@ if TYPE_CHECKING:
     from gigatoken.gigatoken_rs import BytesSource, FileSource, _WrapTruncate
 
 _BACKEND_TYPES = (BPETokenizer, SentencePieceTokenizer)
-
-_TIKTOKEN_ENDOFTEXT = "<|endoftext|>"
 
 
 class Tokenizer:
@@ -91,12 +90,39 @@ class Tokenizer:
         return tokenizer
 
     @classmethod
-    def from_tiktoken(cls, path: str | Path) -> "Tokenizer":
-        """Load from a .tiktoken vocabulary file."""
-        tokenizer = cls(BPETokenizer.from_tiktoken(path))
-        # The Rust loader registers <|endoftext|> right after the mergeable
-        # ranks (see src/load_tokenizer/tiktoken.rs), which are contiguous.
-        tokenizer._tiktoken_specials = {_TIKTOKEN_ENDOFTEXT: tokenizer.vocab_size - 1}
+    def from_tiktoken(
+        cls,
+        path: str | Path,
+        pretokenizer: str | None = None,
+        special_tokens: dict[str, int] | None = None,
+    ) -> "Tokenizer":
+        """Load from a .tiktoken vocabulary file.
+
+        The file holds mergeable ranks only — an encoding's pretokenization
+        scheme (split regex) and special tokens live in the code that defines
+        it — so both are taken from the file's name for the encodings OpenAI
+        publishes (r50k_base, cl100k_base, o200k_base). For any other rank
+        file, name the scheme: `pretokenizer` is one of "gpt2"/"r50k",
+        "gpt4"/"cl100k", "o200k", "qwen2", "qwen35", "olmo3", "deepseek_v3",
+        "nemotron" or "kimi", and `special_tokens` maps token content to id
+        (none by default). Nothing is guessed: an unrecognized file name with
+        no `pretokenizer` raises rather than silently mistokenizing.
+        """
+        name = os.path.basename(os.fspath(path)).removesuffix(".tiktoken")
+        known = ENCODINGS.get(name) if pretokenizer is None else None
+        if pretokenizer is None:
+            if known is None:
+                raise ValueError(
+                    f"cannot tell which pretokenizer {name!r} needs: a .tiktoken file does not carry one, "
+                    f"and its name is not one of the encodings OpenAI publishes ({', '.join(ENCODINGS)}). "
+                    'Pass pretokenizer=... (e.g. "gpt4" for a cl100k-style vocabulary), since the wrong '
+                    "scheme silently mistokenizes everything."
+                )
+            pretokenizer = known.pretokenizer
+        if special_tokens is None:
+            special_tokens = known.special_tokens if known is not None else {}
+        tokenizer = cls(BPETokenizer.from_tiktoken(path, pretokenizer, special_tokens))
+        tokenizer._tiktoken_specials = dict(special_tokens)
         return tokenizer
 
     @classmethod

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -152,7 +152,13 @@ class BPETokenizer:
         """The merge rules as a freshly built list of `(left, right)` byte
         pairs in merge-priority order."""
     @staticmethod
-    def from_tiktoken(path: str | Path) -> "BPETokenizer": ...
+    def from_tiktoken(path: str | Path, pretokenizer: str, special_tokens: dict[str, int] | None = None) -> "BPETokenizer":
+        """Load from a .tiktoken rank file with the named pretokenizer scheme
+        ("gpt2", "gpt4", "qwen2", "qwen35", "olmo3", "deepseek_v3", "o200k",
+        "nemotron", or "kimi") and, optionally, the encoding's special tokens
+        as {content: id}. The file carries neither, so both are the caller's
+        to supply — see `gigatoken.Tokenizer.from_tiktoken`, which knows them
+        for the encodings OpenAI publishes."""
     @staticmethod
     def from_tiktoken_model(model_path: str | Path, config_path: str | Path, pretokenizer: str) -> "BPETokenizer":
         """Load from a tiktoken rank file plus a tokenizer_config.json

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -160,13 +160,6 @@ class BPETokenizer:
         to supply — see `gigatoken.Tokenizer.from_tiktoken`, which knows them
         for the encodings OpenAI publishes."""
     @staticmethod
-    def from_tiktoken_model(model_path: str | Path, config_path: str | Path, pretokenizer: str) -> "BPETokenizer":
-        """Load from a tiktoken rank file plus a tokenizer_config.json
-        carrying the special tokens — the layout of repos that ship no
-        tokenizer.json (e.g. the moonshotai Kimi line) — with the named
-        pretokenizer scheme ("gpt2", "gpt4", "qwen2", "qwen35", "olmo3",
-        "deepseek_v3", "o200k", "nemotron", or "kimi")."""
-    @staticmethod
     def from_hf(path: str | Path) -> "BPETokenizer": ...
     def __repr__(self) -> str: ...
 

--- a/src/bindings/pretokenize.rs
+++ b/src/bindings/pretokenize.rs
@@ -29,6 +29,17 @@ impl PretokenizerIter {
     }
 }
 
+/// The pretokenization scheme a loader was given by name, for the sources
+/// whose format carries no split regex (tiktoken rank files).
+pub(crate) fn pretokenizer_scheme(name: &str) -> PyResult<pretokenize::PretokenizerType> {
+    pretokenize::PretokenizerType::from_name(name).ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "unknown pretokenizer scheme {name:?}; expected one of \
+             gpt2, gpt4, qwen2, qwen35, olmo3, deepseek_v3, o200k, nemotron, kimi"
+        ))
+    })
+}
+
 #[pyfunction]
 pub(crate) fn pretokenizer<'py>(text: Bound<'py, PyBytes>) -> PyResult<PretokenizerIter> {
     Ok(PretokenizerIter {

--- a/src/bindings/pretokenize.rs
+++ b/src/bindings/pretokenize.rs
@@ -34,8 +34,8 @@ impl PretokenizerIter {
 pub(crate) fn pretokenizer_scheme(name: &str) -> PyResult<pretokenize::PretokenizerType> {
     pretokenize::PretokenizerType::from_name(name).ok_or_else(|| {
         pyo3::exceptions::PyValueError::new_err(format!(
-            "unknown pretokenizer scheme {name:?}; expected one of \
-             gpt2, gpt4, qwen2, qwen35, olmo3, deepseek_v3, o200k, nemotron, kimi"
+            "unknown pretokenizer scheme {name:?}; expected one of {}",
+            pretokenize::PretokenizerType::NAMES.join(", ")
         ))
     })
 }

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -1700,7 +1700,8 @@ mod tests {
         let text = "This is a test string. Please tokenize it!";
         let data_dir = std::env::home_dir().unwrap().join("data");
         let tiktoken_path = data_dir.join("tokenizers/r50k_base.tiktoken");
-        let mut tokenizer = load_tiktoken(tiktoken_path).expect("Failed to load tokenizer");
+        let mut tokenizer = load_tiktoken(tiktoken_path, PretokenizerType::GPT2, &[])
+            .expect("Failed to load tokenizer");
         let pretokenize_iter = crate::pretokenize::pretokenize_as_iter(text.as_bytes());
         let mut output = vec![];
         tokenizer.memoized_encode(pretokenize_iter, |tokens| {

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -288,8 +288,10 @@ impl Tokenizer {
     /// Shared construction tail ([`Self::new`], [`Self::new_ranked`] and
     /// [`Self::from_ranks`]): derive `vocab_inv` and the pair-rank table
     /// from the finished merges/vocab, seed the pretoken cache, and
-    /// assemble the tokenizer with default pipeline settings (GPT-2
-    /// pretokenization, no added tokens, no NFC).
+    /// assemble the tokenizer with placeholder pipeline settings (GPT-2
+    /// pretokenization, no added tokens, no NFC) that every loader must
+    /// overwrite for its actual scheme — see issue #40 for what relying
+    /// on the placeholder pretokenizer silently does.
     fn from_tables(
         merges: HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
         ranked_merges: Option<RankedMerges>,
@@ -837,28 +839,43 @@ impl Tokenizer {
     ///
     /// [`WorkerPool`]: crate::batch::WorkerPool
     pub fn add_special_token(&mut self, content: Vec<u8>, id: TokenId) {
-        let idx = id.0 as usize;
-        // Loader-phase mutation of the shared model tables: `make_mut`
-        // copies only when a fork holds the tables too (never during
-        // loading, where this is called).
-        let vocab = Arc::make_mut(&mut self.vocab);
-        if idx >= vocab.len() {
-            vocab.resize(idx + 1, Arc::from(Vec::new().as_slice()));
-        }
-        if vocab[idx].is_empty() {
-            vocab[idx] = content.clone().into();
-            // If `content` duplicates an already-present vocab byte
-            // string, `vocab_inv` switches to the new ID (unconditional
-            // overwrite). The short-cache overwrite that keeps a matching
-            // pretoken resolving to `vocab_inv`'s answer happens in
-            // `set_added_tokens` below, which re-derives every added-token
-            // cache overwrite from the updated `vocab_inv` — the same
-            // computation a fork's reseed + re-apply performs (see
-            // [`Self::fork_sized`]), so parent and forked workers agree.
-            Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
-        }
+        self.add_special_tokens([(content, id)]);
+    }
+
+    /// Register a batch of special added tokens: all vocab entries are
+    /// written first, then `set_added_tokens` rebuilds the matcher and the
+    /// cache overwrites once — not once per token, which would rebuild the
+    /// Aho-Corasick automaton and re-derive every overwrite each time.
+    pub fn add_special_tokens(&mut self, tokens: impl IntoIterator<Item = (Vec<u8>, TokenId)>) {
         let mut added = self.added_tokens.clone();
-        added.push(AddedTokenDef { content: content.into(), id, lstrip: false, rstrip: false });
+        for (content, id) in tokens {
+            let idx = id.0 as usize;
+            // Loader-phase mutation of the shared model tables: `make_mut`
+            // copies only when a fork holds the tables too (never during
+            // loading, where this is called).
+            let vocab = Arc::make_mut(&mut self.vocab);
+            if idx >= vocab.len() {
+                vocab.resize(idx + 1, Arc::from(Vec::new().as_slice()));
+            }
+            if vocab[idx].is_empty() {
+                vocab[idx] = content.clone().into();
+                // If `content` duplicates an already-present vocab byte
+                // string, `vocab_inv` switches to the new ID (unconditional
+                // overwrite). The short-cache overwrite that keeps a matching
+                // pretoken resolving to `vocab_inv`'s answer happens in
+                // `set_added_tokens` below, which re-derives every added-token
+                // cache overwrite from the updated `vocab_inv` — the same
+                // computation a fork's reseed + re-apply performs (see
+                // [`Self::fork_sized`]), so parent and forked workers agree.
+                Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
+            }
+            added.push(AddedTokenDef {
+                content: content.into(),
+                id,
+                lstrip: false,
+                rstrip: false,
+            });
+        }
         self.set_added_tokens(added);
     }
 
@@ -1700,7 +1717,7 @@ mod tests {
         let text = "This is a test string. Please tokenize it!";
         let data_dir = std::env::home_dir().unwrap().join("data");
         let tiktoken_path = data_dir.join("tokenizers/r50k_base.tiktoken");
-        let mut tokenizer = load_tiktoken(tiktoken_path, PretokenizerType::GPT2, &[])
+        let mut tokenizer = load_tiktoken(tiktoken_path, PretokenizerType::GPT2, Vec::new())
             .expect("Failed to load tokenizer");
         let pretokenize_iter = crate::pretokenize::pretokenize_as_iter(text.as_bytes());
         let mut output = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,26 +80,9 @@ impl BPETokenizer {
         special_tokens: Option<HashMap<String, u32>>,
     ) -> PyResult<Self> {
         let scheme = pretokenizer_scheme(pretokenizer)?;
-        let mut special_tokens: Vec<(String, u32)> =
-            special_tokens.unwrap_or_default().into_iter().collect();
-        special_tokens.sort_by_key(|&(_, id)| id);
+        let special_tokens = special_tokens.unwrap_or_default().into_iter().collect();
         Ok(Self {
-            tokenizer: load_tokenizer::tiktoken::load_tiktoken(&path, scheme, &special_tokens)?,
-            workers: WorkerPool::new(),
-        })
-    }
-    /// Load from a tiktoken rank file plus a tokenizer_config.json carrying
-    /// the special tokens — the layout of repos that ship no tokenizer.json
-    /// (e.g. the moonshotai Kimi line) — with the named pretokenizer scheme.
-    #[staticmethod]
-    fn from_tiktoken_model(
-        model_path: PathBuf,
-        config_path: PathBuf,
-        pretokenizer: &str,
-    ) -> PyResult<Self> {
-        let scheme = pretokenizer_scheme(pretokenizer)?;
-        Ok(Self {
-            tokenizer: load_tokenizer::tiktoken::load_tiktoken_model(&model_path, &config_path, scheme)?,
+            tokenizer: load_tokenizer::tiktoken::load_tiktoken(&path, scheme, special_tokens)?,
             workers: WorkerPool::new(),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@ use crate::bindings::bridge::{
 };
 use crate::bindings::matcher::{SpecialTokenFound, SubstringMatcher};
 use crate::bindings::padding;
-use crate::bindings::pretokenize::{PretokenizerIter, pretokenized_counts, pretokenizer};
+use crate::bindings::pretokenize::{
+    PretokenizerIter, pretokenized_counts, pretokenizer, pretokenizer_scheme,
+};
 use crate::bindings::sources::{
     BytesSource, FileSource, JsonlFileSource, ParquetFileSource, TextFileSource,
     encode_files_ragged,
@@ -35,6 +37,7 @@ use numpy::{IntoPyArray, PyArray1};
 use pyo3::prelude::*;
 use pyo3::pybacked::{PyBackedBytes, PyBackedStr};
 use pyo3::types::{PyBytes, PyDict, PyList};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[pyclass]
@@ -64,10 +67,24 @@ impl BPETokenizer {
 
 #[pymethods]
 impl BPETokenizer {
+    /// Load from a .tiktoken rank file with the named pretokenizer scheme
+    /// and, optionally, a {content: id} mapping of special tokens. The file
+    /// carries neither, so both are the caller's to supply — see
+    /// `gigatoken.Tokenizer.from_tiktoken`, which knows them for the
+    /// encodings OpenAI publishes.
     #[staticmethod]
-    fn from_tiktoken(path: PathBuf) -> PyResult<Self> {
+    #[pyo3(signature = (path, pretokenizer, special_tokens = None))]
+    fn from_tiktoken(
+        path: PathBuf,
+        pretokenizer: &str,
+        special_tokens: Option<HashMap<String, u32>>,
+    ) -> PyResult<Self> {
+        let scheme = pretokenizer_scheme(pretokenizer)?;
+        let mut special_tokens: Vec<(String, u32)> =
+            special_tokens.unwrap_or_default().into_iter().collect();
+        special_tokens.sort_by_key(|&(_, id)| id);
         Ok(Self {
-            tokenizer: load_tokenizer::tiktoken::load_tiktoken(&path)?,
+            tokenizer: load_tokenizer::tiktoken::load_tiktoken(&path, scheme, &special_tokens)?,
             workers: WorkerPool::new(),
         })
     }
@@ -80,12 +97,7 @@ impl BPETokenizer {
         config_path: PathBuf,
         pretokenizer: &str,
     ) -> PyResult<Self> {
-        let scheme = pretokenize::PretokenizerType::from_name(pretokenizer).ok_or_else(|| {
-            pyo3::exceptions::PyValueError::new_err(format!(
-                "unknown pretokenizer scheme {pretokenizer:?}; expected one of \
-                 gpt2, gpt4, qwen2, qwen35, olmo3, deepseek_v3, o200k, nemotron, kimi"
-            ))
-        })?;
+        let scheme = pretokenizer_scheme(pretokenizer)?;
         Ok(Self {
             tokenizer: load_tokenizer::tiktoken::load_tiktoken_model(&model_path, &config_path, scheme)?,
             workers: WorkerPool::new(),

--- a/src/load_tokenizer/tiktoken.rs
+++ b/src/load_tokenizer/tiktoken.rs
@@ -26,15 +26,27 @@ fn load_tiktoken_ranks(file_path: impl AsRef<Path>) -> Result<Vec<Vec<u8>>> {
         .collect()
 }
 
-pub fn load_tiktoken(file_path: impl AsRef<Path>) -> Result<Tokenizer> {
+/// Load a tokenizer from a tiktoken rank file with the pretokenizer scheme
+/// and special tokens (`(content, id)`, in id order) supplied by the caller.
+/// A .tiktoken file carries neither — its split regex and specials live in
+/// the code that defines the encoding — and a wrong scheme silently changes
+/// every encode, so neither may be defaulted here.
+pub fn load_tiktoken(
+    file_path: impl AsRef<Path>,
+    pretokenizer: PretokenizerType,
+    special_tokens: &[(String, u32)],
+) -> Result<Tokenizer> {
     let rank_vocab = load_tiktoken_ranks(file_path)?;
     let n_ranks = rank_vocab.len() as u32;
     let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
-    // Tiktoken vocab files carry no special tokens; GPT-2-family vocabs
-    // (gpt2/r50k) place <|endoftext|> at the id right after the mergeable
-    // ranks. Register it so tiktoken- and tokenizer.json-loaded tokenizers
-    // encode and decode identically.
-    tokenizer.add_special_token(b"<|endoftext|>".to_vec(), n_ranks.into());
+    tokenizer.set_pretokenizer_type(pretokenizer);
+    for (content, id) in special_tokens {
+        ensure!(
+            *id >= n_ranks,
+            "special token {content:?} (id {id}) overlaps the {n_ranks} mergeable ranks"
+        );
+        tokenizer.add_special_token(content.clone().into_bytes(), (*id).into());
+    }
     Ok(tokenizer)
 }
 
@@ -62,26 +74,23 @@ pub fn load_tiktoken_model(
     config_path: impl AsRef<Path>,
     pretokenizer: PretokenizerType,
 ) -> Result<Tokenizer> {
-    let rank_vocab = load_tiktoken_ranks(model_path)?;
-    let n_ranks = rank_vocab.len() as u32;
-    let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
-    tokenizer.set_pretokenizer_type(pretokenizer);
     let config_path = config_path.as_ref();
     let config: TokenizerConfigJson = sonic_rs::from_slice(
         &std::fs::read(config_path)
             .with_context(|| format!("Failed to read {}", config_path.display()))?,
     )
     .map_err(|e| eyre::eyre!("Failed to parse {}: {e}", config_path.display()))?;
-    for (id, token) in &config.added_tokens_decoder {
-        let id = id.parse::<u32>().with_context(|| {
-            format!("added_tokens_decoder id {id:?} in {}", config_path.display())
-        })?;
-        ensure!(
-            id >= n_ranks,
-            "added token {:?} (id {id}) overlaps the {n_ranks} mergeable ranks",
-            token.content
-        );
-        tokenizer.add_special_token(token.content.clone().into_bytes(), id.into());
-    }
-    Ok(tokenizer)
+    let mut special_tokens = config
+        .added_tokens_decoder
+        .iter()
+        .map(|(id, token)| {
+            let path = config_path.display();
+            let id = id
+                .parse::<u32>()
+                .with_context(|| format!("added_tokens_decoder id {id:?} in {path}"))?;
+            Ok((token.content.clone(), id))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    special_tokens.sort_by_key(|&(_, id)| id);
+    load_tiktoken(model_path, pretokenizer, &special_tokens)
 }

--- a/src/load_tokenizer/tiktoken.rs
+++ b/src/load_tokenizer/tiktoken.rs
@@ -27,70 +27,29 @@ fn load_tiktoken_ranks(file_path: impl AsRef<Path>) -> Result<Vec<Vec<u8>>> {
 }
 
 /// Load a tokenizer from a tiktoken rank file with the pretokenizer scheme
-/// and special tokens (`(content, id)`, in id order) supplied by the caller.
-/// A .tiktoken file carries neither — its split regex and specials live in
-/// the code that defines the encoding — and a wrong scheme silently changes
-/// every encode, so neither may be defaulted here.
+/// and special tokens (`(content, id)`) supplied by the caller. A .tiktoken
+/// file carries neither — its split regex and specials live in the code
+/// that defines the encoding — and a wrong scheme silently changes every
+/// encode, so neither may be defaulted here.
 pub fn load_tiktoken(
     file_path: impl AsRef<Path>,
     pretokenizer: PretokenizerType,
-    special_tokens: &[(String, u32)],
+    special_tokens: Vec<(String, u32)>,
 ) -> Result<Tokenizer> {
     let rank_vocab = load_tiktoken_ranks(file_path)?;
     let n_ranks = rank_vocab.len() as u32;
     let mut tokenizer = Tokenizer::from_ranks(rank_vocab)?;
     tokenizer.set_pretokenizer_type(pretokenizer);
-    for (content, id) in special_tokens {
+    for (content, id) in &special_tokens {
         ensure!(
             *id >= n_ranks,
             "special token {content:?} (id {id}) overlaps the {n_ranks} mergeable ranks"
         );
-        tokenizer.add_special_token(content.clone().into_bytes(), (*id).into());
     }
+    tokenizer.add_special_tokens(
+        special_tokens
+            .into_iter()
+            .map(|(content, id)| (content.into_bytes(), id.into())),
+    );
     Ok(tokenizer)
-}
-
-/// The fields of a HuggingFace tokenizer_config.json a tiktoken-rank repo
-/// needs: the special tokens (there is no tokenizer.json to carry them).
-#[derive(serde::Deserialize)]
-struct TokenizerConfigJson {
-    #[serde(default)]
-    added_tokens_decoder: std::collections::BTreeMap<String, AddedTokenJson>,
-}
-
-#[derive(serde::Deserialize)]
-struct AddedTokenJson {
-    content: String,
-}
-
-/// Load a tokenizer from a tiktoken rank file plus a HuggingFace
-/// `tokenizer_config.json` whose `added_tokens_decoder` carries the special
-/// tokens — the layout of repos that ship no tokenizer.json (e.g. the
-/// moonshotai Kimi/Moonlight line's `tiktoken.model`). The pretokenizer
-/// scheme is passed by the caller: such repos define their split regex only
-/// in remote code, so no shipped file can name it.
-pub fn load_tiktoken_model(
-    model_path: impl AsRef<Path>,
-    config_path: impl AsRef<Path>,
-    pretokenizer: PretokenizerType,
-) -> Result<Tokenizer> {
-    let config_path = config_path.as_ref();
-    let config: TokenizerConfigJson = sonic_rs::from_slice(
-        &std::fs::read(config_path)
-            .with_context(|| format!("Failed to read {}", config_path.display()))?,
-    )
-    .map_err(|e| eyre::eyre!("Failed to parse {}: {e}", config_path.display()))?;
-    let mut special_tokens = config
-        .added_tokens_decoder
-        .iter()
-        .map(|(id, token)| {
-            let path = config_path.display();
-            let id = id
-                .parse::<u32>()
-                .with_context(|| format!("added_tokens_decoder id {id:?} in {path}"))?;
-            Ok((token.content.clone(), id))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    special_tokens.sort_by_key(|&(_, id)| id);
-    load_tiktoken(model_path, pretokenizer, &special_tokens)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,12 @@ pub fn main() {
             .unwrap()
             .join("data/tokenizers/r50k_base.tiktoken")
     });
-    let mut r50k =
-        load_tokenizer::tiktoken::load_tiktoken(&r50k_path).expect("Failed to load r50k tokenizer");
+    let mut r50k = load_tokenizer::tiktoken::load_tiktoken(
+        &r50k_path,
+        pretokenize::PretokenizerType::GPT2,
+        &[("<|endoftext|>".to_string(), 50256)],
+    )
+    .expect("Failed to load r50k tokenizer");
     eprintln!("Loaded r50k: {:?}", r50k);
 
     // Encode with r50k (GPT-2 style: pretokenize + memoized BPE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ pub fn main() {
     let mut r50k = load_tokenizer::tiktoken::load_tiktoken(
         &r50k_path,
         pretokenize::PretokenizerType::GPT2,
-        &[("<|endoftext|>".to_string(), 50256)],
+        vec![("<|endoftext|>".to_string(), 50256)],
     )
     .expect("Failed to load r50k tokenizer");
     eprintln!("Loaded r50k: {:?}", r50k);

--- a/src/pretokenize/options.rs
+++ b/src/pretokenize/options.rs
@@ -66,10 +66,25 @@ impl PretokenizerType {
         }
     }
 
+    /// The canonical name of each variant, in variant order — the
+    /// identifiers `from_name` accepts (plus the aliases listed there).
+    /// Error messages naming the valid schemes derive from this list.
+    pub const NAMES: [&'static str; 9] = [
+        "gpt2",
+        "gpt4",
+        "qwen2",
+        "qwen35",
+        "olmo3",
+        "deepseek_v3",
+        "o200k",
+        "nemotron",
+        "kimi",
+    ];
+
     /// The scheme named by a lowercase identifier, as used by loaders whose
     /// source format carries no split regex (e.g. tiktoken-rank repos, whose
     /// regex lives in remote code) and the Python bindings. Accepts each
-    /// variant's canonical name plus the common tiktoken aliases.
+    /// canonical name from [`Self::NAMES`] plus the common tiktoken aliases.
     pub fn from_name(name: &str) -> Option<Self> {
         Some(match name {
             "gpt2" | "r50k" => PretokenizerType::GPT2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,10 +189,16 @@ def dclm_sample_path(dclm_docs, tmp_path_factory) -> Path:
     return path
 
 
+def tiktoken_vocab_path(encoding: str) -> Path:
+    """Path to a published .tiktoken vocabulary (r50k_base, cl100k_base,
+    o200k_base, ...), downloaded from OpenAI if absent."""
+    return _download_url(
+        f"https://openaipublic.blob.core.windows.net/encodings/{encoding}.tiktoken",
+        f"{encoding}.tiktoken",
+    )
+
+
 @pytest.fixture(scope="session")
 def r50k_tiktoken_path() -> Path:
     """Path to r50k_base.tiktoken, downloaded from OpenAI if absent."""
-    return _download_url(
-        "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
-        "r50k_base.tiktoken",
-    )
+    return tiktoken_vocab_path("r50k_base")

--- a/tests/test_config_dispatch.py
+++ b/tests/test_config_dispatch.py
@@ -77,4 +77,4 @@ def test_unknown_scheme_rejected():
     from gigatoken.gigatoken_rs import BPETokenizer
 
     with pytest.raises(ValueError, match="unknown pretokenizer scheme"):
-        BPETokenizer.from_tiktoken_model("x", "y", "not-a-scheme")
+        BPETokenizer.from_tiktoken("x", "not-a-scheme")

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -13,7 +13,7 @@ def tiktoken_r50k():
 
 @fixture
 def gigatoken_r50k(r50k_tiktoken_path):
-    return BPETokenizer.from_tiktoken(r50k_tiktoken_path)
+    return BPETokenizer.from_tiktoken(r50k_tiktoken_path, "gpt2", {"<|endoftext|>": 50256})
 
 
 def test_use_gigatoken_model(gigatoken_r50k):

--- a/tests/test_from_tiktoken.py
+++ b/tests/test_from_tiktoken.py
@@ -1,6 +1,8 @@
 import pytest
 import tiktoken
+from conftest import tiktoken_vocab_path
 
+import gigatoken
 from gigatoken.gigatoken_rs import BPETokenizer
 
 
@@ -8,7 +10,7 @@ from gigatoken.gigatoken_rs import BPETokenizer
 def r50k(r50k_tiktoken_path) -> tuple[tiktoken.Encoding, BPETokenizer]:
     """Return (tiktoken_encoding, BPETokenizer) pair for r50k_base."""
     tt = tiktoken.get_encoding("r50k_base")
-    bpe = BPETokenizer.from_tiktoken(r50k_tiktoken_path)
+    bpe = BPETokenizer.from_tiktoken(r50k_tiktoken_path, "gpt2", {"<|endoftext|>": 50256})
     return tt, bpe
 
 
@@ -153,3 +155,57 @@ def test_multiline_code(r50k):
         return self.x * 2
 """
     _assert_same(tt, bpe, code)
+
+
+# ---------------------------------------------------------------------------
+# gigatoken.Tokenizer.from_tiktoken: which pretokenizer and special tokens a
+# rank file gets. The file itself carries neither, so nothing may be guessed
+# (issue #40: every vocabulary used to be pretokenized as r50k).
+# ---------------------------------------------------------------------------
+
+# Texts the schemes disagree on: r50k splits a leading punctuation character
+# off a word and takes digits in twos, cl100k/o200k keep the punctuation and
+# take digits in threes; o200k splits letter runs by case.
+SCHEME_SENSITIVE = [".data", "(self", "_name", "1234", "123456789", "CamelCaseWord", "xé́y", "  \n  end"]
+
+
+@pytest.mark.parametrize("encoding", ["r50k_base", "cl100k_base", "o200k_base"])
+def test_published_encoding_matches_tiktoken(encoding):
+    """Every .tiktoken vocabulary OpenAI publishes loads with its own
+    pretokenization scheme and special tokens, identified by file name."""
+    ref = tiktoken.get_encoding(encoding)
+    tok = gigatoken.Tokenizer.from_tiktoken(tiktoken_vocab_path(encoding))
+    for text in SCHEME_SENSITIVE + SIMPLE_STRINGS + UNICODE_STRINGS + CODE_STRINGS + PARAGRAPHS:
+        assert tok.encode(text.encode("utf-8")).tolist() == ref.encode_ordinary(text), f"{encoding} mismatch for {text!r}"
+    special = "Hello.<|endoftext|>Next."
+    assert tok.encode(special.encode("utf-8")).tolist() == ref.encode(special, allowed_special="all")
+
+
+def test_unnamed_vocab_needs_an_explicit_pretokenizer(tmp_path, r50k_tiktoken_path):
+    """A rank file whose name is not a published encoding cannot be resolved,
+    and says so instead of falling back to some default scheme."""
+    unnamed = tmp_path / "custom.tiktoken"
+    unnamed.symlink_to(r50k_tiktoken_path)
+    with pytest.raises(ValueError, match="pretokenizer"):
+        gigatoken.Tokenizer.from_tiktoken(unnamed)
+    with pytest.raises(ValueError, match="unknown pretokenizer scheme"):
+        gigatoken.Tokenizer.from_tiktoken(unnamed, "not-a-scheme")
+    tok = gigatoken.Tokenizer.from_tiktoken(unnamed, "gpt2")
+    ref = tiktoken.get_encoding("r50k_base")
+    assert tok.encode(b".data").tolist() == ref.encode_ordinary(".data")
+    # Specials are part of the encoding definition, not of the rank file:
+    # none are registered unless asked for.
+    assert tok._special_tokens() == {}
+    tok = gigatoken.Tokenizer.from_tiktoken(unnamed, "gpt2", {"<|endoftext|>": 50256})
+    assert tok._special_tokens() == {"<|endoftext|>": 50256}
+
+
+def test_explicit_pretokenizer_overrides_the_file_name(r50k_tiktoken_path):
+    """A named scheme takes precedence over the one the file name implies —
+    the same ranks then split differently (r50k takes digits in twos, the
+    cl100k scheme in threes)."""
+    as_r50k = gigatoken.Tokenizer.from_tiktoken(r50k_tiktoken_path)
+    as_cl100k = gigatoken.Tokenizer.from_tiktoken(r50k_tiktoken_path, "cl100k")
+    assert as_r50k.encode(b"1234").tolist() != as_cl100k.encode(b"1234").tolist()
+    assert as_r50k._special_tokens() == {"<|endoftext|>": 50256}
+    assert as_cl100k._special_tokens() == {}


### PR DESCRIPTION
Tiktoken files don't contain the full context needed for the tokenizer to be implemented correctly, and would silently default to using the GPT-2 tokenizer. See issue #40.

This PR removes this assumption, erroring if insufficient context is given for the rest of the tokenizer implementation when only the tiktoken spec to load is provided. To load, then, the user must specify additional configurations, which are now also plumbed through the loading function and CLI.