### PR TITLE
Bound the encode caches by default (512 MiB per worker)

### DIFF
--- a/gigatoken/__init__.py
+++ b/gigatoken/__init__.py
@@ -4,7 +4,9 @@ from gigatoken.gigatoken_rs import (
     JsonlFileSource,
     ParquetFileSource,
     TextFileSource,
+    get_max_cache_bytes,
     pretokenizer,
+    set_max_cache_bytes,
     train_bpe,
 )
 
@@ -21,6 +23,8 @@ __all__ = [
     "TextFileSource",
     "TiktokenCompat",
     "Tokenizer",
+    "get_max_cache_bytes",
     "pretokenizer",
+    "set_max_cache_bytes",
     "train_bpe",
 ]

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -218,6 +218,9 @@ class SentencePieceTokenizer:
     def decode(self, tokens: list[int] | npt.NDArray[np.integer] | ak.Array) -> bytes:
         """Integer numpy arrays are borrowed (uint32) or converted in one
         pass (other dtypes); sequences are extracted per element."""
+    def cache_entries(self) -> int:
+        """Cached unit entries on the single-document `encode` path's state
+        (batch encoders are per-call); see BPETokenizer.cache_entries."""
     @property
     def vocab_size(self) -> int:
         """Size of the vocabulary: one greater than the largest token ID,
@@ -261,13 +264,14 @@ def get_hf_token() -> str | None:
 def set_max_cache_bytes(max_bytes: int | None) -> None:
     """Set the process-global encode-cache budget in bytes per encode
     worker (a parallel batch encode may use up to workers x budget),
-    applied to BPE-backend tokenizers constructed AFTERWARD. When a
-    worker's caches fill the budget they are wiped back to their seed
-    state and re-filled; output is never affected — a wipe only costs
-    re-computing previously cached pretokens. Budgets too small for the
-    vocabulary seed are floored up to it; `None` removes the bound.
-    The default is 512 MiB, large enough that hit rates on diverse
-    corpora match an unbounded cache."""
+    applied to tokenizers of either backend constructed AFTERWARD. When
+    a worker's caches fill the budget they are wiped back to their
+    baseline (the vocab seed for BPE, empty for SentencePiece) and
+    re-filled; output is never affected — a wipe only costs re-computing
+    previously cached pretokens. Budgets too small for the baseline are
+    floored up to it; `None` removes the bound. The default is 512 MiB,
+    large enough that hit rates on diverse corpora match an unbounded
+    cache."""
 
 def get_max_cache_bytes() -> int | None:
     """The budget set_max_cache_bytes would apply to newly constructed

--- a/gigatoken/gigatoken_rs/__init__.pyi
+++ b/gigatoken/gigatoken_rs/__init__.pyi
@@ -161,6 +161,11 @@ class BPETokenizer:
         for the encodings OpenAI publishes."""
     @staticmethod
     def from_hf(path: str | Path) -> "BPETokenizer": ...
+    def cache_entries(self) -> int:
+        """Cached pretoken entries on the single-document `encode` path's
+        tokenizer (batch workers keep their own caches): grows as text is
+        encoded, drops back toward vocab-seed level when a budgeted cache
+        wipes (see set_max_cache_bytes)."""
     def __repr__(self) -> str: ...
 
 class SentencePieceTokenizer:
@@ -252,6 +257,21 @@ def get_hf_token() -> str | None:
     """The HuggingFace access token, discovered like huggingface_hub does it:
     HF_TOKEN (or legacy HUGGING_FACE_HUB_TOKEN), then the token file
     (HF_TOKEN_PATH, default $HF_HOME/token)."""
+
+def set_max_cache_bytes(max_bytes: int | None) -> None:
+    """Set the process-global encode-cache budget in bytes per encode
+    worker (a parallel batch encode may use up to workers x budget),
+    applied to BPE-backend tokenizers constructed AFTERWARD. When a
+    worker's caches fill the budget they are wiped back to their seed
+    state and re-filled; output is never affected — a wipe only costs
+    re-computing previously cached pretokens. Budgets too small for the
+    vocabulary seed are floored up to it; `None` removes the bound.
+    The default is 512 MiB, large enough that hit rates on diverse
+    corpora match an unbounded cache."""
+
+def get_max_cache_bytes() -> int | None:
+    """The budget set_max_cache_bytes would apply to newly constructed
+    tokenizers: bytes per encode worker, or None when unbounded."""
 
 class SpecialTokenFound(Exception):
     """Raised by _encode_batch_list_compat when a `forbid` pattern occurs in

--- a/src/bindings/cache.rs
+++ b/src/bindings/cache.rs
@@ -2,7 +2,7 @@
 //! construction. Semantics in the .pyi stubs, mechanism in
 //! `Tokenizer::set_max_cache_bytes`.
 
-use crate::bpe::Tokenizer;
+use crate::bpe::{SentencePieceBPE, Tokenizer};
 use pyo3::prelude::*;
 use std::sync::Mutex;
 
@@ -18,6 +18,12 @@ pub(crate) fn apply_max_cache_bytes(mut tokenizer: Tokenizer) -> Tokenizer {
         tokenizer.set_max_cache_bytes(configured);
     }
     tokenizer
+}
+
+/// SentencePiece analog of [`apply_max_cache_bytes`].
+pub(crate) fn apply_max_cache_bytes_sp(mut model: SentencePieceBPE) -> SentencePieceBPE {
+    model.set_max_cache_bytes(*MAX_CACHE_BYTES.lock().unwrap());
+    model
 }
 
 #[pyfunction]

--- a/src/bindings/cache.rs
+++ b/src/bindings/cache.rs
@@ -1,0 +1,32 @@
+//! The process-global cache-budget knob, read once per tokenizer
+//! construction. Semantics in the .pyi stubs, mechanism in
+//! `Tokenizer::set_max_cache_bytes`.
+
+use crate::bpe::Tokenizer;
+use pyo3::prelude::*;
+use std::sync::Mutex;
+
+/// The budget applied to tokenizers constructed after the last
+/// `set_max_cache_bytes` call; `None` = unbounded.
+static MAX_CACHE_BYTES: Mutex<Option<usize>> = Mutex::new(Some(Tokenizer::DEFAULT_MAX_CACHE_BYTES));
+
+/// Apply the global setting to a freshly constructed tokenizer (which
+/// already carries the built-in default, hence the `!=` skip).
+pub(crate) fn apply_max_cache_bytes(mut tokenizer: Tokenizer) -> Tokenizer {
+    let configured = *MAX_CACHE_BYTES.lock().unwrap();
+    if configured != tokenizer.max_cache_bytes() {
+        tokenizer.set_max_cache_bytes(configured);
+    }
+    tokenizer
+}
+
+#[pyfunction]
+#[pyo3(signature = (max_bytes))]
+pub(crate) fn set_max_cache_bytes(max_bytes: Option<usize>) {
+    *MAX_CACHE_BYTES.lock().unwrap() = max_bytes;
+}
+
+#[pyfunction]
+pub(crate) fn get_max_cache_bytes() -> Option<usize> {
+    *MAX_CACHE_BYTES.lock().unwrap()
+}

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -3,9 +3,11 @@
 //! submodule per feature: Python<->Rust bridging shared by the bindings
 //! (bridge), the FileSource/BytesSource classes (sources), BPE training (train), padded
 //! compat-API encoding (padding), the compat layers' special-token scanner
-//! (matcher), and the pretokenizer helpers (pretokenize).
+//! (matcher), the pretokenizer helpers (pretokenize), and the
+//! process-global cache-budget knob (cache).
 
 pub(crate) mod bridge;
+pub(crate) mod cache;
 pub(crate) mod hub;
 pub(crate) mod matcher;
 pub(crate) mod padding;

--- a/src/bpe/pretoken_cache.rs
+++ b/src/bpe/pretoken_cache.rs
@@ -178,11 +178,42 @@ impl ShortPretokenCache {
     /// 3/4 load. Either way the table is constructed exactly once, at the
     /// max of the two requirements.
     pub(crate) fn with_at_least(n: usize, min_slots: usize) -> Self {
+        Self::with_pow2_capacity(Self::required_capacity(n, min_slots))
+    }
+
+    /// The slot count [`Self::with_at_least`] would allocate for `n`
+    /// entries starting from `min_slots`, without allocating anything.
+    pub(crate) fn required_capacity(n: usize, min_slots: usize) -> usize {
         let mut cap = min_slots.max(1 << 16).next_power_of_two();
         while (n + 1) * 4 > cap * 3 {
             cap *= 2;
         }
-        Self::with_pow2_capacity(cap)
+        cap
+    }
+
+    /// Zero every slot in place (all-zero == all-empty), keeping the
+    /// allocation — the generational-wipe path. Like [`Self::insert`]'s
+    /// grow, this logically invalidates any outstanding [`ProbeView`].
+    pub(crate) fn clear(&mut self) {
+        // SAFETY: the allocation holds exactly `cap` entries.
+        unsafe { std::ptr::write_bytes(self.slots.ptr.as_ptr(), 0, self.slots.cap) };
+        self.len = 0;
+    }
+
+    /// Reset to an empty table of exactly `cap` slots (power of two,
+    /// >= 2), reusing the current allocation when the capacity matches.
+    pub(crate) fn reset_to_capacity(&mut self, cap: usize) {
+        debug_assert!(cap.is_power_of_two() && cap >= 2);
+        if cap == self.slots.cap {
+            self.clear();
+            return;
+        }
+        // Drop the old table (via a 2-slot placeholder) before building
+        // the new one, so two full-size tables never coexist.
+        self.slots = Slots::new_zeroed(2);
+        self.slots = Slots::new_zeroed(cap);
+        self.mask = cap - 1;
+        self.len = 0;
     }
 
     /// Address of `h`'s home pair; both slots share the addressed line.

--- a/src/bpe/sentencepiece.rs
+++ b/src/bpe/sentencepiece.rs
@@ -296,6 +296,8 @@ pub struct SentencePieceBPE {
     /// Bitset over the byte just before a candidate boundary (the last byte
     /// of some `cross_pieces` pre) for a one-load rejection in the scanner.
     pub(crate) cross_prev: [u64; 4],
+    /// Cache budget snapshot by each [`Self::encoder`]; `None` = unbounded.
+    pub(crate) max_cache_bytes: Option<usize>,
 }
 
 /// How many distinct punctuation bytes the unit splitter checks for.
@@ -764,8 +766,20 @@ impl SentencePieceBPE {
     pub fn encoder(&self) -> Encoder<'_> {
         Encoder {
             model: self,
-            state: EncodeState::new(),
+            state: EncodeState::with_budget(self.max_cache_bytes),
         }
+    }
+
+    /// SentencePiece analog of [`super::Tokenizer::set_max_cache_bytes`],
+    /// same default: bounds the caches of [`EncodeState`]s created
+    /// afterward, which wipe back to empty (there is no vocab seed here).
+    pub fn set_max_cache_bytes(&mut self, budget: Option<usize>) {
+        self.max_cache_bytes = budget;
+    }
+
+    /// The configured cache budget in bytes; `None` when unbounded.
+    pub fn max_cache_bytes(&self) -> Option<usize> {
+        self.max_cache_bytes
     }
 
     /// Size of the vocabulary: one greater than the largest token ID,
@@ -854,6 +868,14 @@ fn collapse_space_runs(input: &str, content: &str) -> String {
 /// Zipf-hot working set resident despite eviction churn from tail units.
 const FRONT_BITS: u32 = 20;
 
+/// Fixed footprint of the front cache (keys + vals), subtracted from the
+/// budget before bounding the growing caches.
+const FRONT_BYTES: usize = (1 << FRONT_BITS) * (16 + 8);
+/// Estimated bytes per map entry, payload + SwissTable slack (`long` adds
+/// its key bytes on top). Length-based, because the wipe keeps allocations.
+const SHORT_ENTRY_BYTES: usize = 48;
+const LONG_ENTRY_BYTES: usize = 48;
+
 /// Index of `key` in the front cache: multiplicative hash, top bits.
 #[inline(always)]
 fn front_index(key: u128) -> usize {
@@ -882,10 +904,26 @@ pub struct EncodeState {
     symbols: Vec<TokenId>,
     /// Scratch for composing keys with a virtual leading space.
     key_buf: Vec<u8>,
+    /// Byte budget for the growing caches ([`Self::with_budget`]);
+    /// `usize::MAX` = unbounded.
+    budget: usize,
+    /// Estimated `long` bytes: key bytes + [`LONG_ENTRY_BYTES`] per entry.
+    long_bytes_used: usize,
+    /// Largest single encoding, as wipe-trigger slack: one recurring giant
+    /// unit must not force a wipe per occurrence. Kept across wipes.
+    max_encoding: usize,
 }
 
 impl EncodeState {
     pub fn new() -> Self {
+        Self::with_budget(Some(super::Tokenizer::DEFAULT_MAX_CACHE_BYTES))
+    }
+
+    /// A state whose growing caches (short/long maps + arena; the front
+    /// cache is fixed-size) wipe back to empty when their estimated
+    /// footprint exceeds `max_bytes` minus the front cache, floored at
+    /// 1 MiB so tiny budgets stay functional.
+    pub fn with_budget(max_bytes: Option<usize>) -> Self {
         EncodeState {
             arena: Vec::new(),
             front_keys: vec![0u128; 1 << FRONT_BITS],
@@ -894,12 +932,34 @@ impl EncodeState {
             long: HashMap::with_hasher(FxBuildHasher),
             symbols: Vec::new(),
             key_buf: Vec::new(),
+            budget: max_bytes
+                .map_or(usize::MAX, |t| t.saturating_sub(FRONT_BYTES).max(1 << 20)),
+            long_bytes_used: 0,
+            max_encoding: 0,
         }
     }
 
     /// Number of cached units (for diagnostics).
     pub fn cache_size(&self) -> usize {
         self.short.len() + self.long.len()
+    }
+
+    #[inline]
+    fn over_budget(&self) -> bool {
+        self.short.len() * SHORT_ENTRY_BYTES + self.long_bytes_used + self.arena.len() * 4
+            > self.budget.saturating_add(self.max_encoding * 4)
+    }
+
+    /// Wipe every cache back to empty, keeping allocations. The front keys
+    /// must go too: their values are slices of the truncated arena.
+    #[cold]
+    #[inline(never)]
+    fn wipe(&mut self) {
+        self.arena.clear();
+        self.front_keys.fill(0);
+        self.short.clear();
+        self.long.clear();
+        self.long_bytes_used = 0;
     }
 }
 
@@ -1330,7 +1390,8 @@ impl SentencePieceBPE {
                 let (offset, len) = unsafe { *state.front_vals.get_unchecked(front_idx) };
                 let start = offset as usize;
                 // SAFETY: entries are recorded right after appending `len`
-                // tokens at `offset`; `arena` never shrinks.
+                // tokens at `offset`; the arena only clears in a budget
+                // wipe, which also zeroes every front key.
                 f(unsafe { state.arena.get_unchecked(start..start + len as usize) });
                 return;
             }
@@ -1347,13 +1408,18 @@ impl SentencePieceBPE {
             }
             let start = offset as usize;
             // SAFETY: every cached (offset, len) was recorded right after
-            // appending those `len` tokens at `offset`, and `arena` never
-            // shrinks, so the range is always in bounds.
+            // appending those `len` tokens at `offset`; the arena only
+            // clears in a budget wipe, which also clears both maps.
             f(unsafe { state.arena.get_unchecked(start..start + len as usize) });
             return;
         }
 
-        // Miss: character init → ranked merge, then record in the arena.
+        // Miss: budget check first (the lookups above already missed, and
+        // stay misses against the freshly wiped caches), then character
+        // init → ranked merge, then record in the arena.
+        if state.over_budget() {
+            state.wipe();
+        }
         state.symbols.clear();
         if virtual_prefix {
             state.symbols.extend_from_slice(&self.space_init);
@@ -1367,6 +1433,7 @@ impl SentencePieceBPE {
         let offset = state.arena.len() as u32;
         let len = state.symbols.len() as u32;
         state.arena.extend_from_slice(&state.symbols);
+        state.max_encoding = state.max_encoding.max(len as usize);
         match packed {
             Some(key) => {
                 state.short.insert(key, (offset, len));
@@ -1379,6 +1446,7 @@ impl SentencePieceBPE {
                 } else {
                     unit.into()
                 };
+                state.long_bytes_used += key.len() + LONG_ENTRY_BYTES;
                 state.long.insert(key, (offset, len));
             }
         }
@@ -1481,5 +1549,69 @@ mod tests {
         assert_eq!(collapse_space_runs("a \t  b", "▁"), "a \t▁b");
         assert_eq!(collapse_space_runs("  ", "▁"), "▁");
         assert_eq!(collapse_space_runs("no runs", "▁"), "no runs");
+    }
+
+    /// PARITY + BOUNDS: a budgeted EncodeState that wipes mid-corpus must
+    /// produce the exact token stream of an unbounded one, while the
+    /// estimated footprint of the growing caches stays within the budget
+    /// (plus the documented giant-encoding slack).
+    #[test]
+    fn budgeted_wipe_matches_unbounded() {
+        let Some(path) = crate::test_hub::hf_tokenizer_json("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+        else {
+            eprintln!("Skipping: TinyLlama tokenizer.json not in the HF cache");
+            return;
+        };
+        let model = crate::load_tokenizer::hf::load_hf_sentencepiece(&path).unwrap();
+        assert_eq!(
+            model.max_cache_bytes(),
+            Some(super::super::Tokenizer::DEFAULT_MAX_CACHE_BYTES)
+        );
+
+        // ~100k distinct short words plus interleaved > 15-byte words (the
+        // long-map path) and repeats of a common head.
+        let mut text = String::new();
+        let mut x = 0x1234_5678_9ABC_DEF0u64;
+        let mut rand = |m: u64| {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            x % m
+        };
+        for i in 0..100_000u32 {
+            let len = if i % 17 == 0 { 16 + rand(24) } else { 3 + rand(8) };
+            for _ in 0..len {
+                text.push((b'a' + rand(26) as u8) as char);
+            }
+            text.push(' ');
+            if i % 5 == 0 {
+                text.push_str("the quick brown fox ");
+            }
+        }
+
+        let mut unbounded = EncodeState::with_budget(None);
+        let mut expected = Vec::new();
+        model.encode_raw_with(&mut unbounded, &text, &mut expected);
+
+        // 25 MiB total = ~1 MiB effective past the 24 MiB front cache:
+        // several wipes over ~100k distinct units.
+        let mut budgeted = EncodeState::with_budget(Some(25 << 20));
+        let mut actual = Vec::new();
+        model.encode_raw_with(&mut budgeted, &text, &mut actual);
+        assert_eq!(actual, expected, "budgeted output diverged");
+        assert!(budgeted.long_bytes_used > 0, "corpus never hit the long map");
+        // Both saw ~100k distinct units, so a small survivor count proves
+        // wipes happened, and the estimate must end up within budget.
+        assert!(
+            budgeted.cache_size() < unbounded.cache_size() / 3,
+            "survivors {} vs unbounded {}",
+            budgeted.cache_size(),
+            unbounded.cache_size()
+        );
+        let used = budgeted.short.len() * SHORT_ENTRY_BYTES
+            + budgeted.long_bytes_used
+            + budgeted.arena.len() * 4;
+        let limit = budgeted.budget + budgeted.max_encoding * 4;
+        assert!(used <= limit + 4096, "estimate {used} exceeds budget {limit}");
     }
 }

--- a/src/bpe/tiktoken.rs
+++ b/src/bpe/tiktoken.rs
@@ -48,7 +48,9 @@ pub struct Tokenizer {
     /// Append-only arena of encoded token IDs. Cache entries for encodings
     /// of 5+ tokens store `(offset, len)` slices into this vector; shorter
     /// encodings (well over 99% of hit occurrences) live inline in the
-    /// cache entry and never touch it.
+    /// cache entry and never touch it. A generation wipe (see
+    /// [`Self::set_max_cache_bytes`]) truncates it together with every
+    /// cache entry referencing it.
     token_arena: Vec<TokenId>,
     /// Pretoken cache for the common case (≤ 15 bytes, ~99.9% of
     /// pretokens). The key packs the bytes into the low 15 bytes and the
@@ -88,6 +90,78 @@ pub struct Tokenizer {
     /// would decompose differently (GLM-5.2 has ~97k such words); a plain
     /// merge walk diverges from HF on those.
     ignore_merges: bool,
+    /// Cache memory budget; `None` = unbounded. See
+    /// [`Self::set_max_cache_bytes`].
+    cache_budget: Option<CacheBudget>,
+}
+
+/// Budget split of [`Tokenizer::set_max_cache_bytes`] plus the
+/// per-generation counters — a pure function of budget and seed, so
+/// forks just clone it with the counters reset.
+#[derive(Clone)]
+struct CacheBudget {
+    /// Configured total budget in bytes; forks inherit it verbatim.
+    total_bytes: usize,
+    /// Short-table slot CEILING (power of two): the table grows by
+    /// normal doubling below it; at the ceiling, reaching the 3/4
+    /// growth threshold triggers a generation wipe instead.
+    short_slots: usize,
+    /// Token-arena sub-budget in `TokenId` entries.
+    arena_entries: usize,
+    /// Long-map byte budget (key bytes + [`Self::LONG_ENTRY_BYTES`] each).
+    long_bytes: usize,
+    /// Long-map bytes this generation, maintained at the two long-map
+    /// insert sites; wipes reset it.
+    long_bytes_used: usize,
+    /// Largest single encoding (in tokens) appended to the arena. The
+    /// arena wipe trigger allows this much slack past `arena_entries`,
+    /// so one recurring giant pretoken whose encoding alone exceeds the
+    /// sub-budget cannot force a wipe per occurrence. Kept across wipes
+    /// (it describes the corpus, not the generation).
+    max_encoding: usize,
+    /// Wipes since the budget was set (or since this fork was created).
+    generations: u64,
+}
+
+impl CacheBudget {
+    /// Estimated non-key bytes per long-map entry (hashbrown bucket at
+    /// ~7/8 load + malloc overhead of the boxed key).
+    const LONG_ENTRY_BYTES: usize = 48;
+
+    /// Split `total_bytes` between the three caches given the seed
+    /// footprint (`n_seed` short entries, `seed_arena_len` arena
+    /// entries). Allocates nothing.
+    fn derive(total_bytes: usize, n_seed: usize, seed_arena_len: usize) -> Self {
+        // Ceiling: the largest power of two with slots * 32 <= 70% of
+        // the budget (floor 2^16 slots); the seed requirement can push
+        // it higher.
+        let target = ((total_bytes / 32).saturating_mul(7) / 10).max(1 << 16);
+        let target = if target.is_power_of_two() {
+            target
+        } else {
+            target.next_power_of_two() / 2
+        };
+        let mut short_slots = ShortPretokenCache::required_capacity(n_seed, target);
+        // Headroom floor: keep the seed at <= 5/8 of the ceiling so each
+        // generation admits at least capacity/8 entries before the 3/4
+        // wipe threshold — a seed landing just under the threshold would
+        // otherwise wipe every few misses.
+        while n_seed * 8 > short_slots * 5 {
+            short_slots *= 2;
+        }
+        let rem = total_bytes.saturating_sub(short_slots * 32);
+        // Even arena/long split, floored so degenerate budgets stay
+        // functional (the arena must hold the seed spills with headroom).
+        CacheBudget {
+            total_bytes,
+            short_slots,
+            arena_entries: ((rem / 2) / 4).max(seed_arena_len * 2 + 4096),
+            long_bytes: (rem / 2).max(64 << 10),
+            long_bytes_used: 0,
+            max_encoding: 0,
+            generations: 0,
+        }
+    }
 }
 
 /// NFC-normalize a segment if needed, using `buf` as scratch on the slow path.
@@ -263,6 +337,11 @@ fn apply_added_token_overwrites(
 }
 
 impl Tokenizer {
+    /// Default cache budget: 512 MiB per encode worker — large enough
+    /// that hit rates on diverse web-scale corpora match an unbounded
+    /// cache. `set_max_cache_bytes(None)` restores unbounded growth.
+    pub const DEFAULT_MAX_CACHE_BYTES: usize = 512 << 20;
+
     pub fn new(
         merges: HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
         vocab: Vec<Vec<u8>>,
@@ -321,6 +400,17 @@ impl Tokenizer {
             &mut token_arena,
             0,
         );
+        // The default budget's split is derived from the just-seeded
+        // state, so the seeded table above is the only build.
+        let n_seed = vocab
+            .iter()
+            .filter(|b| (1..=15).contains(&b.len()))
+            .count();
+        let cache_budget = Some(CacheBudget::derive(
+            Self::DEFAULT_MAX_CACHE_BYTES,
+            n_seed,
+            token_arena.len(),
+        ));
         Tokenizer {
             merges: Arc::new(merges),
             pair_ranks,
@@ -339,6 +429,7 @@ impl Tokenizer {
             normalize_nfc: false,
             add_prefix_space: false,
             ignore_merges: false,
+            cache_budget,
         }
     }
 
@@ -390,6 +481,35 @@ impl Tokenizer {
             .filter(|bytes| (1..=15).contains(&bytes.len()))
             .count();
         let mut cache = ShortPretokenCache::with_at_least(n_short, min_slots);
+        Self::seed_into(
+            &mut cache,
+            vocab,
+            byte_remapping,
+            pair_ranks,
+            merges,
+            ranked_merges,
+            ignore_merges,
+            vocab_inv,
+            token_arena,
+        );
+        cache
+    }
+
+    /// The seeding loop of [`Self::seeded_pretoken_cache`], populating
+    /// an existing (empty or seed-consistent) table in place, so the
+    /// generation wipe can re-seed without a fresh allocation.
+    #[allow(clippy::too_many_arguments)]
+    fn seed_into(
+        cache: &mut ShortPretokenCache,
+        vocab: &[Arc<[u8]>],
+        byte_remapping: Option<&ByteRemapping>,
+        pair_ranks: Option<&PairRankTable>,
+        merges: &HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
+        ranked_merges: Option<&RankedMerges>,
+        ignore_merges: bool,
+        vocab_inv: &HashMap<Arc<[u8]>, TokenId, rustc_hash::FxBuildHasher>,
+        token_arena: &mut Vec<TokenId>,
+    ) {
         let mut buf = [TokenId(0); SHORT_MERGE_MAX];
         for bytes in vocab {
             if !(1..=15).contains(&bytes.len()) {
@@ -415,7 +535,6 @@ impl Tokenizer {
                 cache.insert(key, h, val, ext);
             }
         }
-        cache
     }
 
     /// Seed-level encoding of one short vocab byte string under the
@@ -648,11 +767,19 @@ impl Tokenizer {
         // corpora more diverse than the OWT calibration. Clamped to 2^22
         // slots (128 MB) per worker.
         let distinct = 3.45 * (expected_bytes as f64).powf(0.62);
-        let cache_slots = ((distinct * (4.0 / 3.0) * 1.4) as usize)
+        let mut cache_slots = ((distinct * (4.0 / 3.0) * 1.4) as usize)
             .clamp(1 << 16, 1 << 22)
             .next_power_of_two();
-        let arena_cap = (expected_bytes / 256).min(1 << 24);
-        let long_cap = (expected_bytes / 8192).min(1 << 20);
+        let mut arena_cap = (expected_bytes / 256).min(1 << 24);
+        let mut long_cap = (expected_bytes / 8192).min(1 << 20);
+        if let Some(b) = &self.cache_budget {
+            // Each worker gets the FULL budget (a per-worker bound, not
+            // a pool to divide); the workload estimates keep their
+            // prealloc win but are clamped under the ceiling/sub-budgets.
+            cache_slots = cache_slots.min(b.short_slots);
+            arena_cap = arena_cap.min(b.arena_entries);
+            long_cap = long_cap.min(b.long_bytes / CacheBudget::LONG_ENTRY_BYTES);
+        }
         let mut token_arena = Vec::with_capacity(arena_cap);
         let mut pretoken_cache = Self::seeded_pretoken_cache(
             &self.vocab,
@@ -697,6 +824,12 @@ impl Tokenizer {
             normalize_nfc: self.normalize_nfc,
             add_prefix_space: self.add_prefix_space,
             ignore_merges: self.ignore_merges,
+            cache_budget: self.cache_budget.as_ref().map(|b| CacheBudget {
+                long_bytes_used: 0,
+                max_encoding: 0,
+                generations: 0,
+                ..b.clone()
+            }),
         }
     }
 
@@ -772,6 +905,147 @@ impl Tokenizer {
             &mut self.pretoken_cache,
             &mut self.token_arena,
         );
+        self.rederive_budget_if_set();
+    }
+
+    /// Bound the total memory of the encode caches (short pretoken table
+    /// + long-pretoken map + token arena), or remove the bound with
+    /// `None`. The default is `Some(`[`Self::DEFAULT_MAX_CACHE_BYTES`]`)`,
+    /// applied as part of construction.
+    ///
+    /// With a budget set, whenever the short table would grow past its
+    /// budgeted slot ceiling or the arena / long map crosses its
+    /// sub-budget, the miss path wipes all three back to seed-level
+    /// state (vocab seed + added-token overwrites) and encoding re-fills
+    /// them. Cache contents never affect encode output, so a wipe only
+    /// costs re-misses on previously cached pretokens.
+    ///
+    /// The short table takes the largest power-of-two slot count with
+    /// `slots * 32 <= 0.7 * budget` (raised as needed to keep headroom
+    /// over the vocab seed — budgets too small for the seed are floored,
+    /// not honored); the remainder splits evenly between arena and long
+    /// map. The slot count is a growth CEILING, not a preallocation, so
+    /// a tokenizer that never sees much data never pays the budget's
+    /// memory. Setting `Some` resets the caches to seed level (free at
+    /// the loader phase, where they are still seed-sized). Loader-phase
+    /// mutators re-derive the split from the mutated seed, so
+    /// budget/mutator call order does not matter, and forked workers
+    /// inherit the budget (each worker gets the FULL budget, not a
+    /// share).
+    pub fn set_max_cache_bytes(&mut self, budget: Option<usize>) {
+        let Some(total_bytes) = budget else {
+            self.cache_budget = None;
+            return;
+        };
+        let n_seed = self
+            .vocab
+            .iter()
+            .filter(|b| (1..=15).contains(&b.len()))
+            .count()
+            + self.added_tokens.len();
+        // Reset to seed level: the split is derived from the seed
+        // footprint, and starting from a known state needs no accounting
+        // for surviving contents.
+        self.pretoken_cache
+            .reset_to_capacity(ShortPretokenCache::required_capacity(n_seed, 0));
+        self.token_arena = Vec::new();
+        self.pretoken_cache_long = HashMap::with_hasher(rustc_hash::FxBuildHasher {});
+        self.reseed_cache();
+        self.cache_budget =
+            Some(CacheBudget::derive(total_bytes, n_seed, self.token_arena.len()));
+    }
+
+    /// The configured cache budget in bytes; `None` when unbounded.
+    pub fn max_cache_bytes(&self) -> Option<usize> {
+        self.cache_budget.as_ref().map(|b| b.total_bytes)
+    }
+
+    /// Current number of cached pretoken entries (short table + long
+    /// map). Grows as text is encoded and drops back toward vocab-seed
+    /// level when a budgeted cache wipes, so comparing it across encodes
+    /// tells you whether the bound engaged.
+    pub fn cache_entries(&self) -> usize {
+        self.pretoken_cache.len() + self.pretoken_cache_long.len()
+    }
+
+    /// Re-derive the budget split after a loader-phase mutation that
+    /// changes the seed footprint: a stale split could leave the grown
+    /// seed with no post-wipe headroom (worst case, a wipe per miss).
+    fn rederive_budget_if_set(&mut self) {
+        if let Some(total) = self.cache_budget.as_ref().map(|b| b.total_bytes) {
+            self.set_max_cache_bytes(Some(total));
+        }
+    }
+
+    /// Re-establish seed-level state in the existing short table and
+    /// arena: vocab seed, then added-token overwrites — value-identical
+    /// to a fresh fork's construction.
+    fn reseed_cache(&mut self) {
+        Self::seed_into(
+            &mut self.pretoken_cache,
+            &self.vocab,
+            self.byte_remapping.as_ref(),
+            self.pair_ranks.as_deref(),
+            &self.merges,
+            self.ranked_merges.as_deref(),
+            self.ignore_merges,
+            &self.vocab_inv,
+            &mut self.token_arena,
+        );
+        apply_added_token_overwrites(
+            &self.added_tokens,
+            &self.vocab_inv,
+            &mut self.pretoken_cache,
+            &mut self.token_arena,
+        );
+    }
+
+    /// Budget check at the top of the cache-miss path (before the miss's
+    /// own insert, so a wipe can never invalidate an arena offset the
+    /// insert just packed): wipes when the short table hits its growth
+    /// threshold AT its slot ceiling (below it, `grow()` proceeds as
+    /// always) or the arena / long map crosses its sub-budget. Returns
+    /// whether a wipe happened — the caller's probe-reported insert slot
+    /// is then stale.
+    #[inline]
+    fn wipe_if_over_budget(&mut self) -> bool {
+        let Some(b) = &self.cache_budget else {
+            return false;
+        };
+        let short_at_growth = self.pretoken_cache.capacity() >= b.short_slots
+            && (self.pretoken_cache.len() + 1) * 4 > self.pretoken_cache.capacity() * 3;
+        if !short_at_growth
+            && self.token_arena.len() <= b.arena_entries + b.max_encoding
+            && b.long_bytes_used <= b.long_bytes
+        {
+            return false;
+        }
+        self.wipe_generation();
+        true
+    }
+
+    /// The generation wipe: zero the short table in place (keeping its
+    /// budgeted allocation), drop accumulated arena tokens and long
+    /// entries, and re-seed. O(capacity + vocab), runs once per filled
+    /// budget; every discarded entry simply re-misses, so output is
+    /// unaffected.
+    #[cold]
+    #[inline(never)]
+    fn wipe_generation(&mut self) {
+        self.pretoken_cache.clear();
+        self.token_arena.clear();
+        self.pretoken_cache_long.clear();
+        self.reseed_cache();
+        let b = self
+            .cache_budget
+            .as_mut()
+            .expect("wipe_generation only runs with a budget set");
+        b.long_bytes_used = 0;
+        b.generations += 1;
+        // An oversized encoding can double the arena's allocation past
+        // its sub-budget mid-generation; give the excess back here so
+        // over-budget capacity is transient, not steady-state.
+        self.token_arena.shrink_to(b.arena_entries + 4096);
     }
 
     /// Set the added tokens matched atomically by
@@ -827,6 +1101,7 @@ impl Tokenizer {
             &mut self.pretoken_cache,
             &mut self.token_arena,
         );
+        self.rederive_budget_if_set();
     }
 
     /// Register one additional added token, extending the decode vocab when
@@ -1211,7 +1486,9 @@ impl Tokenizer {
                     } else {
                         let start = (val >> 32) as usize;
                         // SAFETY: recorded right after appending `len`
-                        // tokens at `start`; the arena never shrinks.
+                        // tokens at `start`; the arena only shrinks in a
+                        // generation wipe, which also clears every cache
+                        // entry referencing it.
                         let toks =
                             unsafe { self.token_arena.get_unchecked(start..start + len) };
                         out.extend_from_slice(token_ids_as_u32s(toks));
@@ -1287,6 +1564,11 @@ impl Tokenizer {
             let len = symbols.len() as u32;
             let offset = self.token_arena.len() as u32;
             self.token_arena.extend_from_slice(symbols);
+            // Accounted here, enforced by the next miss's budget check.
+            if let Some(b) = &mut self.cache_budget {
+                b.long_bytes_used += bytes.len() + CacheBudget::LONG_ENTRY_BYTES;
+                b.max_encoding = b.max_encoding.max(len as usize);
+            }
             self.pretoken_cache_long.insert(bytes.into(), (offset, len));
             out.extend_from_slice(token_ids_as_u32s(symbols));
         }
@@ -1307,6 +1589,30 @@ impl Tokenizer {
         slot: usize,
         out: &mut Vec<u32>,
     ) {
+        // Budget check FIRST: a wipe must precede this miss's `pack_val`
+        // (whose arena offsets it would otherwise truncate away) and
+        // invalidates the probe-reported `slot`, recomputed here.
+        let mut slot = slot;
+        if self.wipe_if_over_budget() && key != 0 {
+            match self.pretoken_cache.get_or_slot(key, h) {
+                Err(s) => slot = s,
+                Ok((val, ext)) => {
+                    // Unreachable (the reseeded table is a subset of the
+                    // pre-wipe table this key just missed in), but
+                    // serving the value is correct however we got here.
+                    debug_assert!(false, "post-wipe re-probe hit a key that missed pre-wipe");
+                    let len = (val & 0x7F) as usize;
+                    if val & VAL_SPILL == 0 {
+                        out.extend_from_slice(&unpack_val_lanes(val, ext)[..len]);
+                    } else {
+                        let start = (val >> 32) as usize;
+                        let toks = &self.token_arena[start..start + len];
+                        out.extend_from_slice(token_ids_as_u32s(toks));
+                    }
+                    return;
+                }
+            }
+        }
         // Rank-mapped vocabularies take the outlined
         // ranked miss path; the branch is one perfectly-predicted test for
         // everything else, keeping this function's codegen identical to a
@@ -1378,6 +1684,11 @@ impl Tokenizer {
             let len = symbols.len() as u32;
             let offset = self.token_arena.len() as u32;
             self.token_arena.extend_from_slice(symbols);
+            // Accounted here, enforced by the next miss's budget check.
+            if let Some(b) = &mut self.cache_budget {
+                b.long_bytes_used += bytes.len() + CacheBudget::LONG_ENTRY_BYTES;
+                b.max_encoding = b.max_encoding.max(len as usize);
+            }
             self.pretoken_cache_long.insert(bytes.into(), (offset, len));
             out.extend_from_slice(token_ids_as_u32s(symbols));
         }
@@ -1389,7 +1700,7 @@ impl Tokenizer {
             .copied()
     }
 
-    /// Detailed cache stats for memory accounting (see examples/cache_memory.rs):
+    /// Detailed cache stats for memory accounting:
     /// (short_len, short_cap, long_len, long_cap, long_key_bytes, arena_len, arena_cap).
     pub fn cache_mem_stats(&self) -> (usize, usize, usize, usize, usize, usize, usize) {
         let long_key_bytes: usize = self.pretoken_cache_long.keys().map(|k| k.len()).sum();
@@ -1728,6 +2039,430 @@ mod tests {
         println!("Encoded: {:?}", output);
         let decoded = tokenizer.decode(&output).collect::<Vec<u8>>();
         println!("Decoded: {:?}", String::from_utf8_lossy(&decoded));
+    }
+
+    /// Byte-level tokenizer plus `extra_vocab` entries, `pairs` merge
+    /// rules (`(left, right, merged-id)`, rank = position) and `added`
+    /// special tokens, with GPT-2 pretokenization. `ranked` builds the
+    /// same model through the explicit-rank merge table, covering the
+    /// ranked miss path's wipe handling.
+    fn synth_tokenizer(
+        extra_vocab: Vec<Vec<u8>>,
+        pairs: &[(TokenId, TokenId, u32)],
+        added: &[(&[u8], u32)],
+        ranked: bool,
+    ) -> Tokenizer {
+        let mut vocab: Vec<Vec<u8>> = (0..=255u32).map(|b| vec![b as u8]).collect();
+        vocab.extend(extra_vocab);
+        let mut tok = if ranked {
+            let mut rm = RankedMerges::default();
+            for (rank, &(a, b, id)) in pairs.iter().enumerate() {
+                rm.insert(crate::bpe::ranked_merge_key(a, b), (TokenId(id), rank as u32));
+            }
+            Tokenizer::new_ranked(rm, vocab, None)
+        } else {
+            let mut merges: HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher> =
+                HashMap::with_hasher(rustc_hash::FxBuildHasher {});
+            for &(a, b, id) in pairs {
+                merges.insert((a, b), TokenId(id));
+            }
+            Tokenizer::new(merges, vocab, None)
+        };
+        tok.set_pretokenizer_type(PretokenizerType::GPT2);
+        tok.add_special_tokens(added.iter().map(|&(c, id)| (c.to_vec(), TokenId(id))));
+        tok
+    }
+
+    /// Standard budget fixture: word merges (th/the/an/and/in/ing/er), a
+    /// pure special token, and an added token duplicating a vocab byte
+    /// string ("the" -> 301 overrides the merge result 257), so a
+    /// generation wipe must restore the added-token OVERWRITE, not just
+    /// the vocab seed.
+    fn budget_test_tokenizer(ranked: bool) -> Tokenizer {
+        let t = |b: u8| TokenId(b as u32);
+        let pairs = [
+            (t(b't'), t(b'h'), 256),
+            (TokenId(256), t(b'e'), 257),
+            (t(b'a'), t(b'n'), 258),
+            (TokenId(258), t(b'd'), 259),
+            (t(b'i'), t(b'n'), 260),
+            (TokenId(260), t(b'g'), 261),
+            (t(b'e'), t(b'r'), 262),
+        ];
+        let extra = [
+            b"th".as_slice(), b"the", b"an", b"and", b"in", b"ing", b"er",
+        ]
+        .map(<[u8]>::to_vec)
+        .to_vec();
+        let added: &[(&[u8], u32)] = &[(b"<|doc|>", 300), (b"the", 301)];
+        synth_tokenizer(extra, &pairs, added, ranked)
+    }
+
+    const LOWER: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
+    const MIXED: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    /// `n` space-prefixed random words, `len` letters each, drawn
+    /// uniformly from `alphabet`.
+    fn random_words(
+        rng: &mut test_util::XorShift64,
+        n: usize,
+        len: usize,
+        alphabet: &[u8],
+    ) -> Vec<u8> {
+        let mut out = Vec::new();
+        for _ in 0..n {
+            out.push(b' ');
+            for _ in 0..len {
+                out.push(alphabet[(rng.next_u64() % alphabet.len() as u64) as usize]);
+            }
+        }
+        out
+    }
+
+    /// Generation wipes performed since the budget was set (0 when
+    /// unbounded) — the internal counter the wipe-count regressions
+    /// assert on; deliberately not public API.
+    fn wipe_gens(tok: &Tokenizer) -> u64 {
+        tok.cache_budget.as_ref().map_or(0, |b| b.generations)
+    }
+
+    /// Corpus for the cache-budget tests: Zipf-ish common words, rare
+    /// random words (the distinct material that fills the caches and
+    /// spills 5+-token encodings into the arena), > 15-byte words (the
+    /// long-map path), digit runs, unicode, punctuation, and added-token
+    /// occurrences — all interleaved throughout, so every path runs both
+    /// before and after each wipe.
+    fn budget_test_corpus(n_words: usize, seed: u64) -> Vec<u8> {
+        let mut rng = test_util::XorShift64(seed);
+        let common: [&str; 20] = [
+            "the", "and", "ing", "her", "that", "with", "for", "was", "his", "not", "this",
+            "but", "from", "they", "she", "which", "were", "been", "have", "their",
+        ];
+        let unicode: [&str; 7] = [
+            "世界", "café", "naïve", "🦀🔥", "héllo", "Übung", "переменная",
+        ];
+        let mut out: Vec<u8> = Vec::new();
+        for i in 0..n_words {
+            match rng.next_u64() % 100 {
+                0..=39 => {
+                    // Zipf-ish head: min of two draws skews low indices.
+                    let idx = (rng.next_u64() % 20).min(rng.next_u64() % 20) as usize;
+                    out.extend_from_slice(common[idx].as_bytes());
+                }
+                40..=79 => {
+                    // Rare short words (<= 15 bytes with the leading
+                    // space): mostly-distinct cache pressure; 4+ letters
+                    // encode to 5+ tokens with the space, spilling to
+                    // the arena.
+                    let len = 3 + (rng.next_u64() % 8) as usize;
+                    for _ in 0..len {
+                        out.push(b'a' + (rng.next_u64() % 26) as u8);
+                    }
+                }
+                80..=86 => {
+                    // > 15 bytes: the long-map path.
+                    let len = 16 + (rng.next_u64() % 40) as usize;
+                    for _ in 0..len {
+                        out.push(b'a' + (rng.next_u64() % 26) as u8);
+                    }
+                }
+                87..=90 => {
+                    let len = 1 + (rng.next_u64() % 12) as usize;
+                    for _ in 0..len {
+                        out.push(b'0' + (rng.next_u64() % 10) as u8);
+                    }
+                }
+                91..=94 => {
+                    out.extend_from_slice(unicode[(rng.next_u64() % 7) as usize].as_bytes());
+                }
+                95..=96 => out.extend_from_slice(b"!?.,;:()[]{}--"),
+                97..=98 => out.extend_from_slice(b"<|doc|>"),
+                _ => out.extend_from_slice(b"the weather"),
+            }
+            out.push(if i % 17 == 0 { b'\n' } else { b' ' });
+        }
+        out
+    }
+
+    /// PARITY + BOUNDS: a budgeted tokenizer that wipes several times
+    /// mid-corpus must produce the exact token stream of a fresh
+    /// unbounded one — for both the id-as-rank and explicit-rank miss
+    /// paths — while every cache stays within its budgeted share
+    /// (modulo the documented one-miss overshoot window). Also pins
+    /// that a wipe restores the added-token overwrite ("the" -> 301),
+    /// observed through the raw memoized path where the cache entry is
+    /// what answers (the added-token matcher is not in front of it).
+    #[test]
+    fn budgeted_wipe_parity_and_bounds() {
+        for ranked in [false, true] {
+            let corpus = budget_test_corpus(300_000, 0x1234_5678_9ABC_DEF0);
+
+            let mut unbounded = budget_test_tokenizer(ranked);
+            unbounded.set_max_cache_bytes(None);
+            let mut expected: Vec<u32> = Vec::new();
+            unbounded.encode_with_added_tokens_flat(&corpus, &mut expected);
+            assert_eq!(wipe_gens(&unbounded), 0);
+
+            let mut budgeted = budget_test_tokenizer(ranked);
+            budgeted.set_max_cache_bytes(Some(4 << 20));
+            let (short_slots, arena_entries, long_bytes) = {
+                let b = budgeted.cache_budget.as_ref().unwrap();
+                (b.short_slots, b.arena_entries, b.long_bytes)
+            };
+            assert!(
+                budgeted.pretoken_cache.capacity() <= short_slots,
+                "short table starts above its ceiling"
+            );
+
+            // A budgeted fork inherits the full budget with fresh counters.
+            let fork = budgeted.fork();
+            assert!(fork.pretoken_cache.capacity() <= short_slots);
+            let fb = fork.cache_budget.as_ref().unwrap();
+            assert_eq!(fb.total_bytes, 4 << 20);
+            assert_eq!((fb.generations, fb.long_bytes_used), (0, 0));
+
+            let mut actual: Vec<u32> = Vec::new();
+            budgeted.encode_with_added_tokens_flat(&corpus, &mut actual);
+
+            let gens = wipe_gens(&budgeted);
+            assert!(
+                gens >= 3,
+                "expected several wipes at a 4 MB budget, got {gens} (ranked={ranked})"
+            );
+            assert_eq!(
+                actual.len(),
+                expected.len(),
+                "token count diverged (ranked={ranked})"
+            );
+            if let Some(i) = (0..actual.len()).find(|&i| actual[i] != expected[i]) {
+                panic!(
+                    "first divergence at token {i}: {} vs {} (ranked={ranked})",
+                    actual[i], expected[i]
+                );
+            }
+
+            let (short_len, short_cap, _, _, long_key_bytes, arena_len, _) =
+                budgeted.cache_mem_stats();
+            let b = budgeted.cache_budget.as_ref().unwrap();
+            assert!(short_cap <= short_slots, "short table grew past its ceiling");
+            assert!(short_len * 4 <= short_cap * 3, "short table past 3/4 load");
+            assert!(
+                arena_len <= arena_entries + b.max_encoding + 256,
+                "arena_len {arena_len} exceeds its budget {arena_entries}"
+            );
+            assert!(
+                b.long_bytes_used <= long_bytes + 4096,
+                "long map {} exceeds its budget {long_bytes}",
+                b.long_bytes_used
+            );
+            assert!(long_key_bytes <= b.long_bytes_used);
+
+            let encode_raw = |t: &mut Tokenizer, input: &[u8]| -> Vec<TokenId> {
+                let mut out = Vec::new();
+                t.memoized_encode(crate::pretokenize::pretokenize_as_iter(input), |toks| {
+                    out.extend_from_slice(toks)
+                });
+                out
+            };
+            assert_eq!(
+                encode_raw(&mut budgeted, b"the"),
+                vec![TokenId(301)],
+                "wipe lost the added-token overwrite (ranked={ranked})"
+            );
+            assert_eq!(encode_raw(&mut unbounded, b"the"), vec![TokenId(301)]);
+
+            // Dropping the budget restores unbounded semantics without
+            // touching cache contents.
+            budgeted.set_max_cache_bytes(None);
+            assert_eq!(wipe_gens(&budgeted), 0);
+            assert!(budgeted.cache_budget.is_none());
+        }
+    }
+
+    /// HEADROOM: pins the near-seed-boundary thrash pathology (measured:
+    /// hundreds of wipes before the 5/8 floor) — a vocab whose
+    /// short-entry count lands just under `required_capacity`'s 3/4
+    /// bound (~48.8k vs 49152 for 2^16 slots) must get its ceiling
+    /// doubled so wipes scale with distinct-pretokens / headroom.
+    #[test]
+    fn budgeted_wipe_headroom_near_seed_boundary() {
+        let extra = (0..48_500u32).map(|i| format!("v{i:05}").into_bytes()).collect();
+        let mut tok = synth_tokenizer(extra, &[], &[], false);
+        tok.set_max_cache_bytes(Some(4 << 20));
+        let short_slots = tok.cache_budget.as_ref().unwrap().short_slots;
+        assert!(
+            tok.pretoken_cache.len() * 8 <= short_slots * 5,
+            "seed {} over 5/8 of {short_slots} slots",
+            tok.pretoken_cache.len()
+        );
+
+        // ~124k distinct 3-letter words: 4-token inline values, so the
+        // short table is the only wipe trigger.
+        let mut rng = test_util::XorShift64(0x0DDB_1A5E_5BAD_5EED);
+        let corpus = random_words(&mut rng, 300_000, 3, MIXED);
+        let mut out: Vec<u32> = Vec::new();
+        tok.encode_with_added_tokens_flat(&corpus, &mut out);
+        assert!(!out.is_empty());
+
+        let gens = wipe_gens(&tok);
+        assert!(gens >= 1, "corpus no longer fills the table");
+        assert!(gens <= 10, "wipe-thrash: {gens} wipes for ~124k distinct pretokens");
+        let (_, short_cap, ..) = tok.cache_mem_stats();
+        assert_eq!(short_cap, short_slots, "a wiping table sits exactly at its ceiling");
+    }
+
+    /// GIANT PRETOKEN: a recurring pretoken whose encoding alone exceeds
+    /// the arena sub-budget must not force a wipe per occurrence — the
+    /// arena trigger carries slack for the largest single encoding seen,
+    /// so the giant re-overflowing a freshly wiped arena cannot itself
+    /// re-trigger the wipe.
+    #[test]
+    fn budgeted_wipe_giant_pretoken_no_thrash() {
+        let mut rng = test_util::XorShift64(0x61A7_0000_C0FF_EE00);
+        // One 300k-letter pretoken; 'h' excluded so the added token
+        // "the" cannot split it into many medium segments (a different
+        // overflow shape than the single-encoding one pinned here).
+        let giant = random_words(&mut rng, 1, 300_000, b"abcdefgijklmnopqrstuvwxyz");
+        let occurrences = 30usize;
+        let mut corpus = Vec::new();
+        for i in 0..occurrences {
+            corpus.extend_from_slice(&giant);
+            corpus.extend_from_slice(format!(" filler{i} words here\n").as_bytes());
+        }
+
+        let mut unbounded = budget_test_tokenizer(false);
+        unbounded.set_max_cache_bytes(None);
+        let mut expected: Vec<u32> = Vec::new();
+        unbounded.encode_with_added_tokens_flat(&corpus, &mut expected);
+
+        let mut tok = budget_test_tokenizer(false);
+        tok.set_max_cache_bytes(Some(4 << 20));
+        // Test premise: the giant's ~297k-token encoding exceeds the
+        // arena sub-budget outright.
+        let arena_entries = tok.cache_budget.as_ref().unwrap().arena_entries;
+        assert!(
+            arena_entries < 290_000,
+            "premise broken: arena sub-budget {arena_entries} no longer \
+             below the giant's encoding"
+        );
+        let mut out: Vec<u32> = Vec::new();
+        tok.encode_with_added_tokens_flat(&corpus, &mut out);
+        assert_eq!(out, expected, "budgeted output diverged");
+
+        let gens = wipe_gens(&tok);
+        assert!(
+            (gens as usize) <= 2,
+            "wipe per giant occurrence: {gens} wipes for {occurrences} occurrences"
+        );
+    }
+
+    /// REDERIVE: loader-phase mutations after a budget is set must
+    /// recompute the split. Regression: a tight budget's arena floor is
+    /// derived from the seed's spill footprint; growing the seed
+    /// afterwards (added tokens whose contents seed as arena spills)
+    /// under a stale floor would leave the post-wipe seed alone over
+    /// budget — a wipe on every miss, forever.
+    #[test]
+    fn budgeted_rederive_after_loader_mutation() {
+        let mut unbounded = budget_test_tokenizer(false);
+        unbounded.set_max_cache_bytes(None);
+        let mut tok = budget_test_tokenizer(false);
+        // Tight budget: the short table swallows all of it, so the arena
+        // sub-budget sits at its seed-derived floor.
+        tok.set_max_cache_bytes(Some(2 << 20));
+        let stale_arena = tok.cache_budget.as_ref().unwrap().arena_entries;
+        assert!(stale_arena < 8192, "premise: floor-bound arena sub-budget, got {stale_arena}");
+
+        // 2000 added tokens whose 11-byte contents seed as 11-token
+        // arena spills: 22k entries, far past the stale 4096 floor.
+        let added: Vec<(Vec<u8>, TokenId)> = (0..2000u32)
+            .map(|i| (format!("«tok{i:04}»").into_bytes(), TokenId(1000 + i)))
+            .collect();
+        tok.add_special_tokens(added.clone());
+        unbounded.add_special_tokens(added);
+
+        let b = tok.cache_budget.as_ref().unwrap();
+        assert_eq!(b.total_bytes, 2 << 20, "budget lost across loader mutation");
+        assert_eq!(b.generations, 0);
+        let arena_entries = b.arena_entries;
+        assert!(
+            tok.token_arena.len() <= arena_entries,
+            "re-derived arena floor {arena_entries} below the new seed {}",
+            tok.token_arena.len()
+        );
+        assert!(arena_entries > stale_arena);
+
+        let corpus = budget_test_corpus(50_000, 0xFEED_FACE_CAFE_F00D);
+        let mut expected: Vec<u32> = Vec::new();
+        unbounded.encode_with_added_tokens_flat(&corpus, &mut expected);
+        let mut out: Vec<u32> = Vec::new();
+        tok.encode_with_added_tokens_flat(&corpus, &mut out);
+        assert_eq!(out, expected, "budgeted output diverged");
+
+        let gens = wipe_gens(&tok);
+        assert!(gens >= 1);
+        assert!(
+            gens <= 40,
+            "wipe-thrash after loader mutation: {gens} wipes for 50k words"
+        );
+        let b = tok.cache_budget.as_ref().unwrap();
+        let (_, _, _, _, _, arena_len, _) = tok.cache_mem_stats();
+        assert!(arena_len <= b.arena_entries + b.max_encoding + 256);
+    }
+
+    /// DEFAULT LIFECYCLE: a fresh tokenizer reports the default budget
+    /// and builds its table ONCE at seed size — no ceiling presize, no
+    /// eager arena prealloc (measured: the naive default-on cost every
+    /// construction ~2x 256 MiB memsets + reseeds) — then grows by
+    /// normal doubling below the budgeted ceiling with zero wipes, and
+    /// wipes only once load hits 3/4 AT the ceiling. `None` is the
+    /// unbounded escape hatch.
+    #[test]
+    fn default_budget_lifecycle() {
+        // The fixture runs a loader-shaped sequence: constructor,
+        // set_pretokenizer_type, add_special_tokens.
+        let mut tok = budget_test_tokenizer(false);
+        assert_eq!(tok.max_cache_bytes(), Some(Tokenizer::DEFAULT_MAX_CACHE_BYTES));
+        assert_eq!(tok.fork().max_cache_bytes(), tok.max_cache_bytes());
+        assert_eq!(
+            tok.pretoken_cache.capacity(),
+            1 << 16,
+            "default budget must not presize the table"
+        );
+        assert!(tok.token_arena.capacity() < 1 << 20, "eager arena preallocation");
+        // Loader-phase mutation re-derives the split.
+        tok.add_special_tokens([(b"<|extra|>".to_vec(), TokenId(400))]);
+        assert_eq!(tok.pretoken_cache.capacity(), 1 << 16);
+        assert_eq!(tok.max_cache_bytes(), Some(Tokenizer::DEFAULT_MAX_CACHE_BYTES));
+
+        // 16 MiB gives a 2^18-slot ceiling to observe growth against;
+        // the ceiling-growth mechanics are budget-independent.
+        tok.set_max_cache_bytes(Some(16 << 20));
+        let ceiling = tok.cache_budget.as_ref().unwrap().short_slots;
+        assert_eq!(ceiling, 1 << 18);
+        assert_eq!(tok.pretoken_cache.capacity(), 1 << 16, "budget must not presize either");
+
+        let mut rng = test_util::XorShift64(0xCE11_1216_5107_C047);
+        let mut out: Vec<u32> = Vec::new();
+        // ~35k distinct 3-letter words: under the seed table's 3/4
+        // threshold (inline 4-token values — no arena traffic).
+        tok.encode_with_added_tokens_flat(&random_words(&mut rng, 40_000, 3, MIXED), &mut out);
+        assert_eq!(wipe_gens(&tok), 0);
+        assert_eq!(tok.pretoken_cache.capacity(), 1 << 16, "grew too early");
+        // ~140k distinct: grows 2^16 -> 2^17 -> 2^18 with zero wipes
+        // (the ceiling's 196k threshold is unreachable with 3 letters).
+        tok.encode_with_added_tokens_flat(&random_words(&mut rng, 600_000, 3, MIXED), &mut out);
+        assert_eq!(wipe_gens(&tok), 0, "wiped below the ceiling");
+        assert_eq!(tok.pretoken_cache.capacity(), ceiling, "must reach the ceiling");
+        // ~120k more distinct 4-letter words push load past 3/4 AT the
+        // ceiling (spills stay well under the arena sub-budget).
+        tok.encode_with_added_tokens_flat(&random_words(&mut rng, 150_000, 4, LOWER), &mut out);
+        assert!(wipe_gens(&tok) >= 1, "no wipe at the ceiling");
+        assert_eq!(tok.pretoken_cache.capacity(), ceiling, "wipe must keep the ceiling");
+
+        tok.set_max_cache_bytes(None);
+        assert_eq!(tok.max_cache_bytes(), None);
+        assert_eq!(tok.fork().max_cache_bytes(), None);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,9 @@ impl BPETokenizer {
         let scheme = pretokenizer_scheme(pretokenizer)?;
         let special_tokens = special_tokens.unwrap_or_default().into_iter().collect();
         Ok(Self {
-            tokenizer: load_tokenizer::tiktoken::load_tiktoken(&path, scheme, special_tokens)?,
+            tokenizer: bindings::cache::apply_max_cache_bytes(
+                load_tokenizer::tiktoken::load_tiktoken(&path, scheme, special_tokens)?,
+            ),
             workers: WorkerPool::new(),
         })
     }
@@ -90,7 +92,9 @@ impl BPETokenizer {
     #[staticmethod]
     fn from_hf(path: PathBuf) -> PyResult<Self> {
         Ok(Self {
-            tokenizer: load_tokenizer::hf::load_hf_bpe(&path)?,
+            tokenizer: bindings::cache::apply_max_cache_bytes(load_tokenizer::hf::load_hf_bpe(
+                &path,
+            )?),
             workers: WorkerPool::new(),
         })
     }
@@ -250,6 +254,14 @@ impl BPETokenizer {
     fn decode(&self, tokens: Bound<'_, PyAny>) -> PyResult<Vec<u8>> {
         let ids = extract_token_ids(&tokens)?;
         Ok(self.tokenizer.decode(ids.as_slice()?).collect())
+    }
+
+    /// Cached pretoken entries on the single-document `encode` path's
+    /// tokenizer (batch workers keep their own caches): grows as text is
+    /// encoded, drops back toward vocab-seed level when a budgeted cache
+    /// wipes (see gigatoken.set_max_cache_bytes).
+    fn cache_entries(&self) -> usize {
+        self.tokenizer.cache_entries()
     }
 
     fn __repr__(&self) -> PyResult<String> {
@@ -504,7 +516,7 @@ fn load_hf_json(py: Python<'_>, data: Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         load_tokenizer::hf::HfTokenizer::Bpe(tokenizer) => Ok(Py::new(
             py,
             BPETokenizer {
-                tokenizer,
+                tokenizer: bindings::cache::apply_max_cache_bytes(tokenizer),
                 workers: WorkerPool::new(),
             },
         )?
@@ -545,5 +557,7 @@ fn gigatoken_rs<'py>(py: Python, m: &Bound<'py, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(bindings::hub::hub_file, m)?)?;
     m.add_function(wrap_pyfunction!(bindings::hub::looks_like_repo_id, m)?)?;
     m.add_function(wrap_pyfunction!(bindings::hub::get_hf_token, m)?)?;
+    m.add_function(wrap_pyfunction!(bindings::cache::set_max_cache_bytes, m)?)?;
+    m.add_function(wrap_pyfunction!(bindings::cache::get_max_cache_bytes, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,16 +330,22 @@ impl SentencePieceTokenizer {
             }
         })
     }
+
+    /// Wrap a loaded model, applying the global cache budget to it and to
+    /// the single-document encode state.
+    fn with_model(model: bpe::SentencePieceBPE) -> Self {
+        let tokenizer = bindings::cache::apply_max_cache_bytes_sp(model);
+        let state =
+            bpe::sentencepiece::EncodeState::with_budget(tokenizer.max_cache_bytes());
+        Self { tokenizer, state }
+    }
 }
 
 #[pymethods]
 impl SentencePieceTokenizer {
     #[staticmethod]
     fn from_hf(path: PathBuf) -> PyResult<Self> {
-        Ok(Self {
-            tokenizer: load_tokenizer::hf::load_hf_sentencepiece(&path)?,
-            state: bpe::sentencepiece::EncodeState::new(),
-        })
+        Ok(Self::with_model(load_tokenizer::hf::load_hf_sentencepiece(&path)?))
     }
 
     /// Encode a batch of documents in parallel, releasing the GIL. Accepts
@@ -487,6 +493,12 @@ impl SentencePieceTokenizer {
         Ok(self.tokenizer.decode(ids.as_slice()?))
     }
 
+    /// Cached unit entries on the single-document `encode` path's state
+    /// (batch encoders are per-call); see `BPETokenizer.cache_entries`.
+    fn cache_entries(&self) -> usize {
+        self.state.cache_size()
+    }
+
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{:?}", self.tokenizer))
     }
@@ -521,14 +533,9 @@ fn load_hf_json(py: Python<'_>, data: Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
             },
         )?
         .into_any()),
-        load_tokenizer::hf::HfTokenizer::SentencePiece(tokenizer) => Ok(Py::new(
-            py,
-            SentencePieceTokenizer {
-                tokenizer,
-                state: bpe::sentencepiece::EncodeState::new(),
-            },
-        )?
-        .into_any()),
+        load_tokenizer::hf::HfTokenizer::SentencePiece(tokenizer) => {
+            Ok(Py::new(py, SentencePieceTokenizer::with_model(tokenizer))?.into_any())
+        }
     }
 }
 

--- a/src/load_tokenizer/hf.rs
+++ b/src/load_tokenizer/hf.rs
@@ -413,6 +413,7 @@ fn build_sentencepiece(tj: &TokenizerJson) -> Result<SentencePieceBPE> {
         split_safe: Vec::new(),
         cross_pieces: Vec::new(),
         cross_prev: [0; 4],
+        max_cache_bytes: Some(crate::bpe::Tokenizer::DEFAULT_MAX_CACHE_BYTES),
     };
     model.norm_added_tokens = norm_added_tokens
         .into_iter()

--- a/tests/test_cache_budget.py
+++ b/tests/test_cache_budget.py
@@ -3,7 +3,7 @@
 import random
 
 import gigatoken
-from gigatoken.gigatoken_rs import BPETokenizer
+from gigatoken.gigatoken_rs import BPETokenizer, SentencePieceTokenizer
 
 DEFAULT = 512 * 1024 * 1024
 
@@ -37,4 +37,29 @@ def test_max_cache_bytes_knob(gpt2_tokenizer_path):
     grown = default.cache_entries()
     assert grown > seed + 60_000
     assert small.cache_entries() < seed + 60_000
+    assert small.cache_entries() < grown
+
+
+def test_max_cache_bytes_sentencepiece(tinyllama_tokenizer_path):
+    # SentencePiece caches start empty (no vocab seed); the budget covers
+    # the growing maps past the fixed 24 MiB front cache, so 25 MiB leaves
+    # ~1 MiB for ~80k distinct units.
+    rng = random.Random(4321)
+    text = " ".join(
+        "".join(rng.choice("abcdefghijklmnopqrstuvwxyz") for _ in range(rng.randint(6, 10)))
+        for _ in range(80_000)
+    )
+    try:
+        gigatoken.set_max_cache_bytes(25 * 1024 * 1024)
+        small = SentencePieceTokenizer.from_hf(tinyllama_tokenizer_path)
+    finally:
+        gigatoken.set_max_cache_bytes(DEFAULT)
+    default = SentencePieceTokenizer.from_hf(tinyllama_tokenizer_path)
+    assert small.cache_entries() == default.cache_entries() == 0
+
+    small_ids = small.encode(text)
+    assert (small_ids == default.encode(text)).all()
+    grown = default.cache_entries()
+    assert grown > 60_000
+    assert small.cache_entries() < 60_000
     assert small.cache_entries() < grown

--- a/tests/test_cache_budget.py
+++ b/tests/test_cache_budget.py
@@ -1,0 +1,40 @@
+"""The process-global cache-budget knob, end to end."""
+
+import random
+
+import gigatoken
+from gigatoken.gigatoken_rs import BPETokenizer
+
+DEFAULT = 512 * 1024 * 1024
+
+
+def test_max_cache_bytes_knob(gpt2_tokenizer_path):
+    assert gigatoken.get_max_cache_bytes() == DEFAULT
+    # Enough distinct gibberish to overflow a 5 MiB budget
+    # (gpt2's ~50k-entry seed plus ~80k new pretokens).
+    rng = random.Random(1234)
+    text = " ".join(
+        "".join(rng.choice("abcdefghijklmnopqrstuvwxyz") for _ in range(rng.randint(6, 10)))
+        for _ in range(80_000)
+    )
+    try:
+        gigatoken.set_max_cache_bytes(None)
+        assert gigatoken.get_max_cache_bytes() is None
+        gigatoken.set_max_cache_bytes(5 * 1024 * 1024)
+        assert gigatoken.get_max_cache_bytes() == 5 * 1024 * 1024
+        small = BPETokenizer.from_hf(gpt2_tokenizer_path)
+    finally:
+        gigatoken.set_max_cache_bytes(DEFAULT)
+    default = BPETokenizer.from_hf(gpt2_tokenizer_path)
+    seed = small.cache_entries()
+    assert seed == default.cache_entries()  # both start at vocab-seed level
+
+    # The budget changes memory behavior only, never output: the default
+    # cache keeps most distinct words, while the 5 MiB one wiped back
+    # toward seed level along the way and stays well below.
+    small_ids = small.encode(text)
+    assert (small_ids == default.encode(text)).all()
+    grown = default.cache_entries()
+    assert grown > seed + 60_000
+    assert small.cache_entries() < seed + 60_000
+    assert small.cache_entries() < grown


### PR DESCRIPTION
Closes #36.

The per-worker pretoken caches (short table, long-pretoken map, token arena) previously grew without bound, eventually exhausting memory when encoding TB-scale corpora. This makes every tokenizer (both backends) bounded by default at 512 MiB per encode worker, with the bound configurable or removable.

## Mechanism

- At construction the budget is split: the short table gets a power-of-two slot **ceiling** (~70% of the budget, floored so the vocab seed keeps headroom), and the remainder is split between the token arena and the long map.
- The ceiling is not a preallocation — the table starts seed-sized and grows by its normal doubling below the ceiling, so small jobs never pay the budget's memory.
- When a worker's caches fill the budget, the next cache miss wipes all three back to the vocab-seed state and encoding re-fills them. Cache contents never affect output, so a wipe only costs re-misses on previously seen pretokens.
- The hit path is instruction-identical to main (asm-verified); the budget check runs only on the miss path.

## API

```python
gigatoken.set_max_cache_bytes(n)      # bytes per worker, applies to tokenizers constructed afterward
gigatoken.set_max_cache_bytes(None)   # unbounded (previous behavior)
gigatoken.get_max_cache_bytes()
tokenizer.cache_entries()             # current entry count; drops toward seed level when a wipe fires
```

## Measured (full OWT, 11.9 GB, GPT-2, single thread, interleaved min-of-3)

| budget | time | wipes |
|---|---|---|
| unbounded (main) | 12.8 s | — |
| 512 MiB (default) | 12.7 s | 0 |
| 256 MiB | 13.2 s | 2 (+3.5%) |
| 128 MiB | 14.0 s | 8 (+9.5%) |
| 64 MiB | 15.3 s | 27 (+19.6%) |

The second commit applies the same budget to the SentencePiece backend: each `EncodeState` estimates the footprint of its growing caches (short/long maps + token arena) past the fixed-size front cache and wipes them back to empty on the miss path when it exceeds the budget (SP has no vocab seed to restore). Same miss-path-only check; hit paths are unchanged. Measured (TinyLlama, `encode_st_sp`, interleaved min-of-N on an idle machine): at 2 GB of OWT the budget doesn't bind and throughput is identical to unbounded (cold 6.73 s vs 6.81 s, warm 4.84 s vs 5.04 s); full OWT's 22.8M distinct units do overflow the default (5.9M survivors at the end) at a cost of ~2–3% (39.3 s vs 38.3 s; the gap holds with the run order reversed), with identical token output.

Multithreaded (`cargo bench --bench encode`, full OWT, interleaved min-of-3 vs main): identical for both backends — GPT-2 8.60 vs 8.55 GB/s, TinyLlama 6.65 s vs 6.68 s — since each worker/chunk sees only its slice of the input and stays under budget, so no wipes fire.

The default limit may be too low for a large server or for instance for CJK documents, so I'm considering having it depend be proportional to (available system RAM)/(the default number of threads) in the future.

Notes for review:
- The budget is per worker: a parallel batch encode may use up to workers × budget.
- Unknown performance overhead on CJK documents.
